### PR TITLE
add `MeasurementUnitAbbreviation`

### DIFF
--- a/app/formatters/duty_expression_formatter.rb
+++ b/app/formatters/duty_expression_formatter.rb
@@ -16,13 +16,14 @@ class DutyExpressionFormatter
       duty_amount = opts[:duty_amount]
       monetary_unit = opts[:monetary_unit_abbreviation].presence || opts[:monetary_unit]
       measurement_unit = opts[:measurement_unit]
-      measurement_unit_qualifier = opts[:formatted_measurement_unit_qualifier]
+      measurement_unit_qualifier = opts[:measurement_unit_qualifier]
+      measurement_unit_abbreviation = measurement_unit.try :abbreviation,
+                                                           measurement_unit_qualifier: measurement_unit_qualifier
 
       output = []
-
       case duty_expression_id
       when "99"
-        output << measurement_unit
+        output << measurement_unit_abbreviation
       when "12", "14", "37", "40", "41", "42", "43", "44", "21", "25", "27", "29"
         if duty_expression_abbreviation.present?
           output << duty_expression_abbreviation
@@ -43,10 +44,12 @@ class DutyExpressionFormatter
         else
           output << "%"
         end
-        if measurement_unit.present? && measurement_unit_qualifier.present?
-          output << "/ (#{measurement_unit}/#{measurement_unit_qualifier})"
-        elsif measurement_unit.present?
-          output << "/ #{measurement_unit}"
+        if measurement_unit_abbreviation.present?
+          if opts[:formatted]
+            output << "/ <abbr title='#{measurement_unit.description}'>#{measurement_unit_abbreviation}</abbr>"
+          else
+            output << "/ #{measurement_unit_abbreviation}"
+          end
         end
       else
         if duty_amount.present?
@@ -62,10 +65,12 @@ class DutyExpressionFormatter
         if monetary_unit.present?
           output << monetary_unit
         end
-        if measurement_unit.present? && measurement_unit_qualifier.present?
-          output << "/ (#{measurement_unit}/#{measurement_unit_qualifier})"
-        elsif measurement_unit.present?
-          output << "/ #{measurement_unit}"
+        if measurement_unit_abbreviation.present?
+          if opts[:formatted]
+            output << "/ <abbr title='#{measurement_unit.description}'>#{measurement_unit_abbreviation}</abbr>"
+          else
+            output << "/ #{measurement_unit_abbreviation}"
+          end
         end
       end
       output.join(" ").html_safe

--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -311,6 +311,10 @@ class Measure < Sequel::Model
   end
 
   def duty_expression
+    measure_components.map(&:duty_expression_str).join(" ")
+  end
+
+  def formatted_duty_expression
     measure_components.map(&:formatted_duty_expression).join(" ")
   end
 

--- a/app/models/measure_component.rb
+++ b/app/models/measure_component.rb
@@ -34,24 +34,30 @@ class MeasureComponent < Sequel::Model
 
   delegate :description, :abbreviation, to: :duty_expression, prefix: true
   delegate :abbreviation, to: :monetary_unit, prefix: true, allow_nil: true
-  delegate :formatted_measurement_unit_qualifier, to: :measurement_unit_qualifier, prefix: false, allow_nil: true
-  delegate :description, to: :measurement_unit, prefix: true, allow_nil: true
   delegate :description, to: :monetary_unit, prefix: true, allow_nil: true
 
   def formatted_duty_expression
-    DutyExpressionFormatter.format({
-      duty_expression_id: duty_expression_id,
+    DutyExpressionFormatter.format(duty_expression_formatter_options.merge(formatted: true))
+  end
+
+  def duty_expression_str
+    DutyExpressionFormatter.format(duty_expression_formatter_options)
+  end
+
+  def meursing?
+    duty_expression_id.in?(DutyExpression::MEURSING_DUTY_EXPRESSION_IDS)
+  end
+
+  private
+
+  def duty_expression_formatter_options
+    { duty_expression_id: duty_expression_id,
       duty_expression_description: duty_expression_description,
       duty_expression_abbreviation: duty_expression_abbreviation,
       duty_amount: duty_amount,
       monetary_unit: monetary_unit_code,
       monetary_unit_abbreviation: monetary_unit_abbreviation,
-      measurement_unit: measurement_unit_description,
-      formatted_measurement_unit_qualifier: formatted_measurement_unit_qualifier
-    })
-  end
-
-  def meursing?
-    duty_expression_id.in?(DutyExpression::MEURSING_DUTY_EXPRESSION_IDS)
+      measurement_unit: measurement_unit,
+      measurement_unit_qualifier: measurement_unit_qualifier }
   end
 end

--- a/app/models/measure_condition_component.rb
+++ b/app/models/measure_condition_component.rb
@@ -33,8 +33,6 @@ class MeasureConditionComponent < Sequel::Model
 
   delegate :description, :abbreviation, to: :duty_expression, prefix: true
   delegate :abbreviation, to: :monetary_unit, prefix: true, allow_nil: true
-  delegate :formatted_measurement_unit_qualifier, to: :measurement_unit_qualifier, allow_nil: true
-  delegate :description, to: :measurement_unit, prefix: true, allow_nil: true
   delegate :description, to: :monetary_unit, prefix: true, allow_nil: true
 
   def formatted_duty_expression
@@ -45,8 +43,8 @@ class MeasureConditionComponent < Sequel::Model
       duty_amount: duty_amount,
       monetary_unit: monetary_unit_code,
       monetary_unit_abbreviation: monetary_unit_abbreviation,
-      measurement_unit: measurement_unit_description,
-      formatted_measurement_unit_qualifier: formatted_measurement_unit_qualifier
+      measurement_unit: measurement_unit,
+      measurement_unit_qualifier: measurement_unit_qualifier
     })
   end
 end

--- a/app/models/measurement_unit.rb
+++ b/app/models/measurement_unit.rb
@@ -13,4 +13,18 @@ class MeasurementUnit < Sequel::Model
   def to_s
     description
   end
+
+  def abbreviation(options={})
+    measurement_unit_abbreviation(options).abbreviation
+  rescue Sequel::RecordNotFound
+    description
+  end
+
+  def measurement_unit_abbreviation(options={})
+    measurement_unit_qualifier = options[:measurement_unit_qualifier]
+    MeasurementUnitAbbreviation.where(
+      measurement_unit_code: measurement_unit_code,
+      measurement_unit_qualifier: measurement_unit_qualifier.try(:measurement_unit_qualifier_code)
+    ).take
+  end
 end

--- a/app/models/measurement_unit_abbreviation.rb
+++ b/app/models/measurement_unit_abbreviation.rb
@@ -1,0 +1,4 @@
+class MeasurementUnitAbbreviation < Sequel::Model
+  one_to_one :measurement_unit, primary_key: :measurement_unit_code,
+                                key: :measurement_unit_code
+end

--- a/app/views/api/v1/measures/_measure.json.rabl
+++ b/app/views/api/v1/measures/_measure.json.rabl
@@ -16,6 +16,7 @@ node(:measure_type) { |measure|
 node(:duty_expression) { |measure|
   {
     base: measure.duty_expression,
+    formatted_base: measure.formatted_duty_expression,
     national_measurement_units: measure.national_measurement_units_for(locals[:declarable])
   }
 }

--- a/db/data_migrations/20140715230838_add_default_measurement_unit_abbreviations.rb
+++ b/db/data_migrations/20140715230838_add_default_measurement_unit_abbreviations.rb
@@ -1,0 +1,93 @@
+# encoding: utf-8
+TradeTariffBackend::DataMigrator.migration do
+  name "Add default measurement unit abbreviations"
+
+  up do
+    applicable {
+      MeasurementUnitAbbreviation.empty?
+    }
+
+    apply {
+      [ {abbr: "% vol",                code: "ASV"},
+        {abbr: "% vol/hl",             code: "ASV", qualifier: "X"},
+        {abbr: "ct/l",                 code: "CCT"},
+        {abbr: "100 p/st",             code: "CEN"},
+        {abbr: "c/k",                  code: "CTM"},
+        {abbr: "10 000 kg/polar",      code: "DAP"},
+        {abbr: "kg DHS",               code: "DHS"},
+        {abbr: "100 kg",               code: "DTN"},
+        {abbr: "100 kg/net eda",       code: "DTN", qualifier: "E"},
+        {abbr: "100 kg common wheat",  code: "DTN", qualifier: "F"},
+        {abbr: "100 kg/br",            code: "DTN", qualifier: "G"},
+        {abbr: "100 kg live weight",   code: "DTN", qualifier: "L"},
+        {abbr: "100 kg/net mas",       code: "DTN", qualifier: "M"},
+        {abbr: "100 kg std qual",      code: "DTN", qualifier: "R"},
+        {abbr: "100 kg raw sugar",     code: "DTN", qualifier: "S"},
+        {abbr: "100 kg/net/%sacchar.", code: "DTN", qualifier: "Z"},
+        {abbr: "EUR",                  code: "EUR"},
+        {abbr: "gi F/S",               code: "GFI"},
+        {abbr: "g",                    code: "GRM"},
+        {abbr: "GT",                   code: "GRT"},
+        {abbr: "hl",                   code: "HLT"},
+        {abbr: "100 m",                code: "HMT"},
+        {abbr: "kg C₅H₁₄ClNO",         code: "KCC"},
+        {abbr: "tonne KCl",            code: "KCL"},
+        {abbr: "kg",                   code: "KGM"},
+        {abbr: "kg/tot/alc",           code: "KGM", qualifier: "A"},
+        {abbr: "kg/net eda",           code: "KGM", qualifier: "E"},
+        {abbr: "GKG",                  code: "KGM", qualifier: "G"},
+        {abbr: "kg/lactic matter",     code: "KGM", qualifier: "P"},
+        {abbr: "kg/raw sugar",         code: "KGM", qualifier: "S"},
+        {abbr: "kg/dry lactic matter", code: "KGM", qualifier: "T"},
+        {abbr: "1000 l",               code: "KLT"},
+        {abbr: "kg methylamines",      code: "KMA"},
+        {abbr: "KM",                   code: "KMT"},
+        {abbr: "kg N",                 code: "KNI"},
+        {abbr: "kg H₂O₂",              code: "KNS"},
+        {abbr: "kg KOH",               code: "KPH"},
+        {abbr: "kg K₂O",               code: "KPO"},
+        {abbr: "kg P₂O₅",              code: "KPP"},
+        {abbr: "kg 90% sdt",           code: "KSD"},
+        {abbr: "kg NaOH",              code: "KSH"},
+        {abbr: "kg U",                 code: "KUR"},
+        {abbr: "l alc. 100%",          code: "LPA"},
+        {abbr: "l",                    code: "LTR"},
+        {abbr: "L total alc.",         code: "LTR", qualifier: "A"},
+        {abbr: "1000 p/st",            code: "MIL"},
+        {abbr: "1000 pa",              code: "MPR"},
+        {abbr: "m²",                   code: "MTK"},
+        {abbr: "m³",                   code: "MTQ"},
+        {abbr: "1000 m³",              code: "MTQ", qualifier: "C"},
+        {abbr: "m",                    code: "MTR"},
+        {abbr: "1000 kWh",             code: "MWH"},
+        {abbr: "p/st",                 code: "NAR"},
+        {abbr: "b/f",                  code: "NAR", qualifier: "B"},
+        {abbr: "ce/el",                code: "NCL"},
+        {abbr: "pa",                   code: "NPR"},
+        {abbr: "TJ",                   code: "TJO"},
+        {abbr: "1000 kg",              code: "TNE"},
+        {abbr: "1000 kg/net eda",      code: "TNE", qualifier: "E"},
+        {abbr: "1000 kg/biodiesel",    code: "TNE", qualifier: "I"},
+        {abbr: "1000 kg/fuel content", code: "TNE", qualifier: "J"},
+        {abbr: "1000 kg/bioethanol",   code: "TNE", qualifier: "K"},
+        {abbr: "1000 kg/net mas",      code: "TNE", qualifier: "M"},
+        {abbr: "1000 kg std qual",     code: "TNE", qualifier: "R"},
+        {abbr: "1000 kg/net/%saccha.", code: "TNE", qualifier: "Z"},
+        {abbr: "Watt",                 code: "WAT"} ].each do |m|
+        MeasurementUnitAbbreviation.create(abbreviation: m[:abbr],
+                                  measurement_unit_code: m[:code],
+                             measurement_unit_qualifier: m[:qualifier])
+      end
+    }
+  end
+
+  down do
+    applicable {
+      MeasurementUnitAbbreviation.any?
+    }
+
+    apply {
+      MeasurementUnitAbbreviation.filter.delete
+    }
+  end
+end

--- a/db/migrate/20140715224356_create_measurement_unit_abbreviations.rb
+++ b/db/migrate/20140715224356_create_measurement_unit_abbreviations.rb
@@ -1,0 +1,13 @@
+Sequel.migration do
+  change do
+    create_table :measurement_unit_abbreviations do
+      primary_key :id
+      String :abbreviation
+      String :measurement_unit_code
+      String :measurement_unit_qualifier
+
+      index [:measurement_unit_code, :measurement_unit_qualifier],
+        name: :measurement_unit_code_qualifier
+    end
+  end
+end

--- a/spec/factories/measurement_unit_abbreviation_factory.rb
+++ b/spec/factories/measurement_unit_abbreviation_factory.rb
@@ -1,0 +1,16 @@
+FactoryGirl.define do
+  factory :measurement_unit_abbreviation do
+    abbreviation { Forgery(:basic).text }
+    measurement_unit_code { Forgery(:basic).text(exactly: 3) }
+
+    trait :with_measurement_unit do
+      after(:create) do |measurement_unit_abbreviation|
+        FactoryGirl.create(:measurement_unit, measurement_unit_code: measurement_unit_abbreviation.measurement_unit_code)
+      end
+    end
+
+    trait :include_qualifier do
+      measurement_unit_qualifier { Forgery(:basic).text(exactly: 1) }
+    end
+  end
+end

--- a/spec/formatters/duty_expression_formatter_spec.rb
+++ b/spec/formatters/duty_expression_formatter_spec.rb
@@ -3,10 +3,38 @@ require 'duty_expression_formatter'
 
 describe DutyExpressionFormatter do
   describe '.format' do
+    let(:measurement_unit) {
+      measurement_unit_abbreviation.measurement_unit
+    }
+    let(:unit) {
+      measurement_unit.abbreviation(measurement_unit_qualifier: measurement_unit_qualifier)
+    }
+    let!(:measurement_unit_abbreviation) {
+      create(:measurement_unit_abbreviation, :with_measurement_unit, :include_qualifier)
+    }
+    let!(:measurement_unit_qualifier) {
+      create(:measurement_unit_qualifier, measurement_unit_qualifier_code: measurement_unit_abbreviation.measurement_unit_qualifier)
+    }
+
     context 'for duty expression 99' do
-      it 'return the measurement unit' do
-        DutyExpressionFormatter.format(duty_expression_id: '99',
-                                       measurement_unit: 'abc').should eq 'abc'
+      describe "with qualifier" do
+        it 'return the measurement unit' do
+          DutyExpressionFormatter.format(duty_expression_id: '99',
+                                         measurement_unit: measurement_unit,
+                                         measurement_unit_qualifier: measurement_unit_qualifier).should eq unit
+        end
+      end
+
+      describe "without qualifier" do
+        let!(:measurement_unit_abbreviation) {
+          create(:measurement_unit_abbreviation, :with_measurement_unit)
+        }
+        let(:measurement_unit_qualifier) { nil }
+
+        it "returns unit" do
+          DutyExpressionFormatter.format(duty_expression_id: "99",
+                                         measurement_unit: measurement_unit).should eq unit
+        end
       end
     end
 
@@ -60,17 +88,22 @@ describe DutyExpressionFormatter do
       context 'measurement unit and measurement unit qualifier present' do
         it 'result includes measurement unit and measurement unit qualifier' do
           DutyExpressionFormatter.format(duty_expression_id: '15',
-                                         measurement_unit: 'KG',
-                                         formatted_measurement_unit_qualifier: 'L',
-                                         duty_expression_description: 'abc').should =~ /\/ \(KG\/L\)/
+                                         measurement_unit: measurement_unit,
+                                         measurement_unit_qualifier: measurement_unit_qualifier,
+                                         duty_expression_description: 'abc').should =~ Regexp.new(unit)
         end
       end
 
       context 'just measurement unit present' do
+        let!(:measurement_unit_abbreviation) {
+          create(:measurement_unit_abbreviation, :with_measurement_unit)
+        }
+        let(:measurement_unit_qualifier) { nil }
+
         it 'result includes measurement unit' do
           DutyExpressionFormatter.format(duty_expression_id: '15',
-                                         measurement_unit: 'KG',
-                                         duty_expression_description: 'abc').should =~ /\/ KG/
+                                         measurement_unit: measurement_unit,
+                                         duty_expression_description: 'abc').should =~ Regexp.new(unit)
         end
       end
     end
@@ -118,17 +151,22 @@ describe DutyExpressionFormatter do
       context 'measurement unit and measurement unit qualifier present' do
         it 'result includes measurement unit and measurement unit qualifier' do
           DutyExpressionFormatter.format(duty_expression_id: '66',
-                                         measurement_unit: 'KG',
-                                         formatted_measurement_unit_qualifier: 'L',
-                                         duty_expression_description: 'abc').should =~ /\/ \(KG\/L\)/
+                                         measurement_unit: measurement_unit,
+                                         measurement_unit_qualifier: measurement_unit_qualifier,
+                                         duty_expression_description: 'abc').should =~ Regexp.new(unit)
         end
       end
 
       context 'measurement unit present' do
+        let!(:measurement_unit_abbreviation) {
+          create(:measurement_unit_abbreviation, :with_measurement_unit)
+        }
+        let(:measurement_unit_qualifier) { nil }
+
         it 'result includes measurement unit' do
           DutyExpressionFormatter.format(duty_expression_id: '66',
-                                         measurement_unit: 'KG',
-                                         duty_expression_description: 'abc').should =~ /\/ KG/
+                                         measurement_unit: measurement_unit,
+                                         duty_expression_description: 'abc').should =~ Regexp.new(unit)
         end
       end
     end

--- a/spec/models/measurement_unit_spec.rb
+++ b/spec/models/measurement_unit_spec.rb
@@ -15,4 +15,32 @@ describe MeasurementUnit do
     # MU2 The start date must be less than or equal to the end date.
     it { should validate_validity_dates }
   end
+
+  describe "#abbreviation" do
+    before {
+      measurement_unit.stub(:measurement_unit_abbreviation) { raise Sequel::RecordNotFound }
+    }
+    it {
+      expect(measurement_unit.abbreviation).to eq(measurement_unit.description)
+    }
+  end
+
+  describe "#measurement_unit_abbreviation" do
+    context "without measurement_unit_abbreviation" do
+      it {
+        expect {
+          measurement_unit.measurement_unit_abbreviation
+        }.to raise_error(Sequel::RecordNotFound)
+      }
+    end
+
+    context "with measurement_unit_abbreviation" do
+      let!(:measurement_unit_abbreviation) {
+        create(:measurement_unit_abbreviation, measurement_unit_code: measurement_unit.measurement_unit_code)
+      }
+      it {
+        expect(measurement_unit.measurement_unit_abbreviation).to eq(measurement_unit_abbreviation)
+      }
+    end
+  end
 end


### PR DESCRIPTION
The UK Trade tariff currently displays the measurement units "as is" from the TARIC database, some of which are quite old or long. There is a document published by the EU on how these units can be reimported in an abbreviated (and more common form). This PR implements the unit abbreviations and will change how the measures are displayed.

[pivotal story](https://www.pivotaltracker.com/story/show/75057154)
