### PR TITLE
Timezones consistency

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -36,7 +36,7 @@ module TradeTariffBackend
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    # config.time_zone = 'Central Time (US & Canada)'
+    config.time_zone = 'UTC'
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]

--- a/config/initializers/sequel.rb
+++ b/config/initializers/sequel.rb
@@ -7,3 +7,5 @@ Sequel::Model.plugin :validation_class_methods
 
 Sequel::Model.db.extension :pagination
 Sequel::Model.db.extension :server_block
+
+Sequel.default_timezone = :utc

--- a/lib/tariff_synchronizer.rb
+++ b/lib/tariff_synchronizer.rb
@@ -167,7 +167,7 @@ module TariffSynchronizer
     TradeTariffBackend.with_redis_lock do
       date = Date.parse(rollback_date.to_s)
 
-      (date..Date.today).to_a.reverse.each do |date_for_rollback|
+      (date..Date.current).to_a.reverse.each do |date_for_rollback|
         Sequel::Model.db.transaction do
           oplog_based_models.each do |model|
             model.operation_klass.where { operation_date > date_for_rollback }.delete
@@ -239,7 +239,7 @@ module TariffSynchronizer
 
   def update_range_in_days
     last_pending_update = BaseUpdate.last_pending.first
-    update_to = ENV['DATE'] ? Date.parse(ENV['DATE']) : Date.today
+    update_to = ENV['DATE'] ? Date.parse(ENV['DATE']) : Date.current
 
     if last_pending_update
       (last_pending_update.issue_date..update_to)

--- a/lib/tariff_synchronizer/base_update.rb
+++ b/lib/tariff_synchronizer/base_update.rb
@@ -175,7 +175,7 @@ module TariffSynchronizer
         Sequel::Model.db.transaction(reraise: true) do
           # If a error is raised during import, the transaction is roll-backed
           # we then run this block afterwards to mark the update as failed
-          Sequel::Model.db.after_rollback { mark_as_failed } 
+          Sequel::Model.db.after_rollback { mark_as_failed }
 
           import!
         end
@@ -200,7 +200,7 @@ module TariffSynchronizer
       delegate :instrument, to: ActiveSupport::Notifications
 
       def sync
-        (pending_from..Date.today).each { |date| download(date) }
+        (pending_from..Date.current).each { |date| download(date) }
 
         notify_about_missing_updates if self.order(Sequel.desc(:issue_date)).last(TariffSynchronizer.warning_day_count).all?(&:missing?)
       end
@@ -264,7 +264,7 @@ module TariffSynchronizer
           create_update_entry(date, FAILED_STATE, file_name)
           instrument("retry_exceeded.tariff_synchronizer", date: date, url: response.url)
         elsif response.not_found?
-          if date < Date.today
+          if date < Date.current
             create_update_entry(date, MISSING_STATE, missing_update_name_for(date))
             instrument("not_found.tariff_synchronizer", date: date, url: response.url)
           end

--- a/lib/tariff_synchronizer/taric_update.rb
+++ b/lib/tariff_synchronizer/taric_update.rb
@@ -35,7 +35,7 @@ module TariffSynchronizer
           elsif response.not_found?
             # We will be retrying a few more times today, so do not create
             # missing record until we are sure
-            if date < Date.today
+            if date < Date.current
               create_update_entry(date, BaseUpdate::MISSING_STATE, missing_update_name_for(date))
               instrument("not_found.tariff_synchronizer",
                        date: date,

--- a/spec/controllers/api/v1/chapters_controller_spec.rb
+++ b/spec/controllers/api/v1/chapters_controller_spec.rb
@@ -118,7 +118,7 @@ describe Api::V1::ChaptersController, "GET #changes" do
 
   context 'changes happened before requested date' do
     let(:chapter) { create :chapter, :with_section, :with_note,
-                                     operation_date: Date.today }
+                                     operation_date: Date.current }
     let(:heading) { create :heading, goods_nomenclature_item_id: "#{chapter.goods_nomenclature_item_id.first(2)}20000000" }
     let!(:measure) {
       create :measure,
@@ -126,7 +126,7 @@ describe Api::V1::ChaptersController, "GET #changes" do
         goods_nomenclature: heading,
         goods_nomenclature_sid: heading.goods_nomenclature_sid,
         goods_nomenclature_item_id: heading.goods_nomenclature_item_id,
-        operation_date: Date.today
+        operation_date: Date.current
     }
 
     it 'does not include change records' do

--- a/spec/controllers/api/v1/commodities_controller_spec.rb
+++ b/spec/controllers/api/v1/commodities_controller_spec.rb
@@ -111,7 +111,7 @@ describe Api::V1::CommoditiesController, "GET #changes" do
                                           :with_heading,
                                           :with_description,
                                           :declarable,
-                                          operation_date: Date.today }
+                                          operation_date: Date.current }
 
     it 'does not include change records' do
       get :changes, id: commodity, as_of: Date.yesterday, format: :json

--- a/spec/controllers/api/v1/headings_controller_spec.rb
+++ b/spec/controllers/api/v1/headings_controller_spec.rb
@@ -143,7 +143,7 @@ describe Api::V1::HeadingsController, "GET #changes" do
                                      :non_declarable,
                                      :with_description,
                                      :with_chapter,
-                                     operation_date: Date.today }
+                                     operation_date: Date.current }
 
     it 'does not include change records' do
       get :changes, id: heading, as_of: Date.yesterday, format: :json

--- a/spec/integration/chief_transformer/vat_excises_spec.rb
+++ b/spec/integration/chief_transformer/vat_excises_spec.rb
@@ -120,7 +120,7 @@ describe "CHIEF: VAT and Excises" do
     it "should create measures for 0303030300" do
       m = Measure.where(goods_nomenclature_item_id: "0303030300", validity_start_date: DateTime.parse("2007-11-15 11:00:00")).first
       expect(m.goods_nomenclature_item_id).to eq "0303030300"
-      expect(m.validity_end_date).to eq Time.parse("2007-12-01 00:00:00")
+      expect(m.validity_end_date).to eq DateTime.parse("2007-12-01 00:00:00")
       expect(m.measure_components.first.duty_amount).to eq 0.6007
       expect(m.measure_components.first.monetary_unit_code).to eq 'GBP'
     end
@@ -128,7 +128,7 @@ describe "CHIEF: VAT and Excises" do
     it "should create measures for 0404040400" do
       m = Measure.where(goods_nomenclature_item_id: "0404040400", validity_start_date: DateTime.parse("2007-10-01 00:00:00")).first
       expect(m.goods_nomenclature_item_id).to eq "0404040400"
-      expect(m.validity_end_date).to eq Time.parse("2007-12-31 23:50:00")
+      expect(m.validity_end_date).to eq DateTime.parse("2007-12-31 23:50:00")
       expect(m.measure_components.first.duty_amount).to eq 0.6007
       expect(m.measure_components.first.monetary_unit_code).to eq 'GBP'
     end

--- a/spec/integration/tariff_synchronizer_spec.rb
+++ b/spec/integration/tariff_synchronizer_spec.rb
@@ -3,7 +3,7 @@ require 'tariff_synchronizer'
 
 describe TariffSynchronizer do
   describe '#apply', truncation: true do
-    let(:example_date)  { Date.today }
+    let(:example_date)  { Date.current }
     let!(:taric_update) { create :taric_update, example_date: example_date }
     let!(:chief_update) { create :chief_update, example_date: example_date }
 
@@ -93,8 +93,8 @@ describe TariffSynchronizer do
   end
 
   describe '.rollback' do
-    let!(:measure) { create :measure, operation_date: Date.today }
-    let!(:update)  { create :chief_update, :applied, issue_date: Date.today }
+    let!(:measure) { create :measure, operation_date: Date.current }
+    let!(:update)  { create :chief_update, :applied, issue_date: Date.current }
     let!(:mfcm)    { create :mfcm, origin: update.filename }
 
     context 'successful run' do

--- a/spec/models/geographical_area_spec.rb
+++ b/spec/models/geographical_area_spec.rb
@@ -81,7 +81,7 @@ describe GeographicalArea do
                                                                            validity_end_date: Date.today.ago(2.years) }
       let!(:contained_area_past)              { create :geographical_area, geographical_area_id: 'de',
                                                                            validity_start_date: Date.today.ago(5.years),
-                                                                           validity_end_date: Date.today.ago(3.years) }
+                                                                           validity_end_date: 3.years.ago }
       let!(:geographical_area_membership1)    { create :geographical_area_membership, geographical_area_sid: contained_area_present.geographical_area_sid,
                                                                                       geographical_area_group_sid: geographical_area.geographical_area_sid,
                                                                                       validity_start_date: Date.today.ago(2.years),
@@ -89,7 +89,7 @@ describe GeographicalArea do
       let!(:geographical_area_membership2)    { create :geographical_area_membership, geographical_area_sid: contained_area_past.geographical_area_sid,
                                                                                       geographical_area_group_sid: geographical_area.geographical_area_sid,
                                                                                       validity_start_date: Date.today.ago(5.years),
-                                                                                      validity_end_date: Date.today.ago(3.years) }
+                                                                                      validity_end_date: 3.years.ago }
 
       context 'direct loading' do
         it 'loads correct description respecting given actual time' do
@@ -201,8 +201,8 @@ describe GeographicalArea do
     describe "GA5" do
       let(:geographical_area) {
         create(:geographical_area,
-              validity_end_date: Date.today,
-              validity_start_date: Date.today.ago(3.years),
+              validity_end_date: Date.current,
+              validity_start_date: 3.years.ago,
               parent_geographical_area: parent)
       }
 
@@ -223,7 +223,7 @@ describe GeographicalArea do
           let(:parent) {
             create(:geographical_area,
                    validity_end_date: Date.yesterday,
-                   validity_start_date: Date.today.ago(3.years))
+                   validity_start_date: 3.years.ago)
           }
 
           it {
@@ -233,8 +233,8 @@ describe GeographicalArea do
 
         context "without end date" do
           let(:parent) { create(:geographical_area,
-                                validity_end_date: Date.today,
-                                validity_start_date: Date.today.ago(3.years))
+                                validity_end_date: Date.current,
+                                validity_start_date: 3.years.ago)
           }
 
           before {
@@ -249,8 +249,8 @@ describe GeographicalArea do
 
         context "with start_date after parent and no end date" do
           let(:parent) { create(:geographical_area,
-                                validity_end_date: Date.today,
-                                validity_start_date: Date.today.ago(3.years))
+                                validity_end_date: Date.current,
+                                validity_start_date: 3.years.ago)
           }
 
           before {
@@ -269,8 +269,8 @@ describe GeographicalArea do
         context "with end date" do
           let(:parent) {
             create(:geographical_area,
-                   validity_end_date: Date.today,
-                   validity_start_date: Date.today.ago(3.years))
+                   validity_end_date: Date.current,
+                   validity_start_date: 3.years.ago)
           }
 
           it {
@@ -282,7 +282,7 @@ describe GeographicalArea do
           let(:parent) {
             create(:geographical_area,
                    validity_end_date: nil,
-                   validity_start_date: Date.today.ago(3.years))
+                   validity_start_date: 3.years.ago)
           }
 
           it {
@@ -294,7 +294,7 @@ describe GeographicalArea do
           let(:parent) {
             create(:geographical_area,
                    validity_end_date: nil,
-                   validity_start_date: Date.today.ago(3.years))
+                   validity_start_date: 3.years.ago)
           }
 
           before {

--- a/spec/unit/tariff_synchronizer/chief_update_spec.rb
+++ b/spec/unit/tariff_synchronizer/chief_update_spec.rb
@@ -142,21 +142,21 @@ describe TariffSynchronizer::ChiefUpdate do
         end
 
         it 'does not create not found entry if update is still for today' do
-          TariffSynchronizer::ChiefUpdate.download(Date.today)
+          TariffSynchronizer::ChiefUpdate.download(Date.current)
 
           expect(
             TariffSynchronizer::ChiefUpdate.missing
-                                           .with_issue_date(Date.today)
+                                           .with_issue_date(Date.current)
                                            .present?
           ).to be_falsy
         end
 
         it 'creates not found entry if date has passed' do
-          TariffSynchronizer::ChiefUpdate.download(Date.today)
+          TariffSynchronizer::ChiefUpdate.download(Date.current)
 
           expect(
             TariffSynchronizer::ChiefUpdate.missing
-                                           .with_issue_date(Date.today)
+                                           .with_issue_date(Date.current)
                                            .present?
           ).to be_falsy
         end

--- a/spec/unit/tariff_synchronizer/taric_update_spec.rb
+++ b/spec/unit/tariff_synchronizer/taric_update_spec.rb
@@ -223,11 +223,11 @@ describe TariffSynchronizer::TaricUpdate do
       end
 
       it 'does not create not found entry if update is still for today' do
-        TariffSynchronizer::TaricUpdate.download(Date.today)
+        TariffSynchronizer::TaricUpdate.download(Date.current)
 
         expect(
           TariffSynchronizer::TaricUpdate.missing
-                                       .with_issue_date(Date.today)
+                                       .with_issue_date(Date.current)
                                        .present?
         ).to be_falsy
       end

--- a/spec/unit/trade_tariff_backend/validations/validity_date_span_validation_spec.rb
+++ b/spec/unit/trade_tariff_backend/validations/validity_date_span_validation_spec.rb
@@ -13,7 +13,7 @@ describe TradeTariffBackend::Validations::ValidityDateSpanValidation do
     context 'of option not provided' do
       context 'associated records validity start date is less than models' do
         let(:model) { double(validity_start_date: Date.yesterday,
-                           associated_record: double(validity_start_date: Date.today, new?: false))}
+                           associated_record: double(validity_start_date: Date.current, new?: false))}
         let(:validation) { described_class.new(:vld1, 'validity_date') }
 
         it 'should return false' do
@@ -30,7 +30,7 @@ describe TradeTariffBackend::Validations::ValidityDateSpanValidation do
       context 'associated record has validity end date and model does not' do
         let(:model) { double(validity_start_date: Date.yesterday,
                            validity_end_date: nil,
-                           associated_record: double(validity_start_date: Date.today, new?: false,
+                           associated_record: double(validity_start_date: Date.current, new?: false,
                                                    validity_end_date: Date.yesterday))}
         let(:validation) { described_class.new(:vld1, 'validity_date') }
 
@@ -48,8 +48,8 @@ describe TradeTariffBackend::Validations::ValidityDateSpanValidation do
       context 'both have end dates but associated records validity end date is greater than models' do
         let(:model) { double(validity_start_date: Date.yesterday,
                            validity_end_date: Date.yesterday,
-                           associated_record: double(validity_start_date: Date.today,
-                                                   validity_end_date: Date.today,
+                           associated_record: double(validity_start_date: Date.current,
+                                                   validity_end_date: Date.current,
                                                    new?: false))}
         let(:validation) { described_class.new(:vld1, 'validity_date') }
 

--- a/spec/unit/trade_tariff_backend/validations/validity_dates_validation_spec.rb
+++ b/spec/unit/trade_tariff_backend/validations/validity_dates_validation_spec.rb
@@ -14,7 +14,7 @@ describe TradeTariffBackend::Validations::ValidityDatesValidation do
     end
 
     context 'only validity start date present' do
-      let(:record) { double(validity_start_date: Date.today,
+      let(:record) { double(validity_start_date: Date.current,
                           validity_end_date: nil) }
 
       it 'returns true' do
@@ -24,7 +24,7 @@ describe TradeTariffBackend::Validations::ValidityDatesValidation do
 
     context 'validity end date is greater than validity start date' do
       let(:record) { double(validity_start_date: Date.yesterday,
-                          validity_end_date: Date.today) }
+                          validity_end_date: Date.current) }
 
       it 'returns true' do
         expect(validation.valid?(record)).to be_truthy
@@ -32,7 +32,7 @@ describe TradeTariffBackend::Validations::ValidityDatesValidation do
     end
 
     context 'validity start date is greater than validity end date' do
-      let(:record) { double(validity_start_date: Date.today,
+      let(:record) { double(validity_start_date: Date.current,
                           validity_end_date: Date.yesterday) }
 
       it 'returns false' do


### PR DESCRIPTION
#### What this PR does:

This PR configures `Sequel` Timezone and set explicitly the Rails timezone.

#### Notes

When I ran the tests I had many failures and after some debugging I found that is related on how Sequel treats the DB time... by default Rails with AR stores the datetimes in the DB in utc not matter what we sent, in Sequel this datetime is not treated, so it stores it without changing this.

Since I'm in a different timezone I found many tests failing because of that, so I fixed them.

We can expect other false positives in the tests too because of this reason.


We should never use `Time.now` or `Date.today` in tests because they do not respect timezones, they will return the system time ( in my case -5 )

for more information:
https://robots.thoughtbot.com/its-about-time-zones
http://danilenko.org/2012/7/6/rails_timezones/
------