### PR TITLE
Sync process updates

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -32,12 +32,4 @@ Rails.application.configure do
 
   # Expands the lines which load the assets
   config.assets.debug = true
-
-  file_logger = Logger.new(Rails.root.join("log", "development.log"))
-  console_logger = Logger.new(STDOUT)
-
-  config.logger = console_logger.extend(ActiveSupport::Logger.broadcast(file_logger))
-
-  config.log_level = :info
-  config.synchronizer_console_logs = true
 end

--- a/db/data_migrations/20130130132054_add_hydrocarbon_oils_footnote.rb
+++ b/db/data_migrations/20130130132054_add_hydrocarbon_oils_footnote.rb
@@ -1,9 +1,6 @@
 TradeTariffBackend::DataMigrator.migration do
   name "Add hydrocarbon oils footnote 05976"
 
-  FOOTNOTE_TYPE_ID = '05'
-  FOOTNOTE_ID = '976'
-
   ASSOCIATED_GOODS_CODES = %w[
     3826001010
     3826001090

--- a/db/data_migrations/20130808081012_add_national_footnote_to_cd622.rb
+++ b/db/data_migrations/20130808081012_add_national_footnote_to_cd622.rb
@@ -10,7 +10,7 @@ TradeTariffBackend::DataMigrator.migration do
 
   VALIDITY_START_DATE = Date.new(2013,8,6)
 
-  ASSOCIATED_GOODS_CODES = %w[
+  GOODS_NOMENCLATURE_ITEM_IDS = %w[
     3818001011
     3818001019
     8541409021
@@ -82,7 +82,7 @@ TradeTariffBackend::DataMigrator.migration do
         :measures,
         { footnote_association_measures__measure_sid: :measures__measure_sid }
       ).where(
-        measures__goods_nomenclature_item_id: ASSOCIATED_GOODS_CODES
+        measures__goods_nomenclature_item_id: GOODS_NOMENCLATURE_ITEM_IDS
       ).each { |measure_association|
         FootnoteAssociationMeasure.new { |fa_meas|
           fa_meas.measure_sid = measure_association.measure_sid

--- a/db/data_migrations/20130910112803_fix_national_certificate_type_validity_period.rb
+++ b/db/data_migrations/20130910112803_fix_national_certificate_type_validity_period.rb
@@ -1,13 +1,11 @@
 TradeTariffBackend::DataMigrator.migration do
   name "Fix National Certificate Type validity period"
 
-  VALIDITY_START_DATE = Date.new(1971,12,13)
-
   up do
     applicable {
       CertificateType::Operation.where(
         certificate_type_code: '9',
-        validity_start_date: VALIDITY_START_DATE
+        validity_start_date: Date.new(1971,12,13)
       ).none?
     }
 
@@ -15,7 +13,7 @@ TradeTariffBackend::DataMigrator.migration do
       CertificateType::Operation.where(
         certificate_type_code: '9',
       ).update(
-        validity_start_date: VALIDITY_START_DATE
+        validity_start_date: Date.new(1971,12,13)
       )
     }
   end

--- a/lib/taric_importer.rb
+++ b/lib/taric_importer.rb
@@ -36,7 +36,7 @@ class TaricImporter < TariffImporter
         transaction.persist
         transaction.validate if @validate
       rescue StandardError => exception
-        ActiveSupport::Notifications.instrument("taric_failed.tariff_importer", exception: exception)
+        ActiveSupport::Notifications.instrument("taric_failed.tariff_importer", exception: exception, hash: hash_from_node)
         raise ImportException.new
       end
     end

--- a/lib/tariff_importer/logger.rb
+++ b/lib/tariff_importer/logger.rb
@@ -14,8 +14,8 @@ class TariffImporter
 
     def taric_failed(event)
       "Taric import failed: #{event.payload[:exception]}".tap {|message|
-        message << "\n Failed transaction: #{event.payload[:xml]}" if event.payload.has_key?(:xml)
-        message << "Backtrace:\n #{event.payload[:exception].backtrace.join("\n")}"
+        message << "\n Failed transaction:\n #{event.payload[:hash]}"
+        message << "\n Backtrace:\n #{event.payload[:exception].backtrace.join("\n")}"
         error message
       }
     end

--- a/lib/tariff_synchronizer.rb
+++ b/lib/tariff_synchronizer.rb
@@ -79,33 +79,27 @@ module TariffSynchronizer
   # Gets latest downloaded file present in (inbox/failbox/processed) and tries
   # to download any further updates to current day.
   def download
-    TradeTariffBackend.with_redis_lock do
-      if sync_variables_set?
-        instrument("download.tariff_synchronizer") do
-          begin
-            [TaricUpdate, ChiefUpdate].map(&:sync)
-          rescue FileService::DownloadException => exception
-            instrument("failed_download.tariff_synchronizer",
-              exception: exception.original,
-              url: exception.url
-            )
+    return instrument("config_error.tariff_synchronizer") unless sync_variables_set?
 
-            raise exception.original
-          end
+    TradeTariffBackend.with_redis_lock do
+      instrument("download.tariff_synchronizer") do
+        begin
+          [TaricUpdate, ChiefUpdate].map(&:sync)
+        rescue FileService::DownloadException => exception
+          instrument("failed_download.tariff_synchronizer",
+            exception: exception.original,
+            url: exception.url)
+          raise exception.original
         end
-      else
-        instrument("config_error.tariff_synchronizer")
       end
     end
   end
 
   def download_archive
-    if sync_variables_set?
-      instrument("download.tariff_synchronizer") do
-        [TaricArchive, ChiefArchive].map(&:sync)
-      end
-    else
-      instrument("config_error.tariff_synchronizer")
+    return instrument("config_error.tariff_synchronizer") unless sync_variables_set?
+    
+    instrument("download.tariff_synchronizer") do
+      [TaricArchive, ChiefArchive].map(&:sync)
     end
   end
 

--- a/lib/tariff_synchronizer.rb
+++ b/lib/tariff_synchronizer.rb
@@ -42,12 +42,12 @@ module TariffSynchronizer
   self.request_throttle = 60
 
   # Initial dump date + 1 day
-  mattr_accessor :taric_initial_update
-  self.taric_initial_update = Date.new(2012,6,6)
+  mattr_accessor :taric_initial_update_date
+  self.taric_initial_update_date = Date.new(2012,6,6)
 
   # Initial dump date + 1 day
-  mattr_accessor :chief_initial_update
-  self.chief_initial_update = Date.new(2012,6,30)
+  mattr_accessor :chief_initial_update_date
+  self.chief_initial_update_date = Date.new(2012,6,30)
 
   # Times to retry downloading update before giving up
   mattr_accessor :retry_count
@@ -224,9 +224,8 @@ module TariffSynchronizer
     end
   end
 
-  # Initial update day for specific update type
-  def initial_update_for(update_type)
-    send("#{update_type}_initial_update".to_sym)
+  def initial_update_date_for(update_type)
+    send("#{update_type}_initial_update_date")
   end
 
   private

--- a/lib/tariff_synchronizer.rb
+++ b/lib/tariff_synchronizer.rb
@@ -26,13 +26,13 @@ module TariffSynchronizer
   extend self
 
   mattr_accessor :username
-  self.username = TradeTariffBackend.secrets.sync_username
+  self.username = ENV["TARIFF_SYNC_USERNAME"]
 
   mattr_accessor :password
-  self.password = TradeTariffBackend.secrets.sync_password
+  self.password = ENV["TARIFF_SYNC_PASSWORD"]
 
   mattr_accessor :host
-  self.host = TradeTariffBackend.secrets.sync_host
+  self.host = ENV["TARIFF_SYNC_HOST"]
 
   mattr_accessor :root_path
   self.root_path = Rails.env.test? ? "tmp/data" : "data"
@@ -97,7 +97,6 @@ module TariffSynchronizer
 
   def download_archive
     return instrument("config_error.tariff_synchronizer") unless sync_variables_set?
-    
     instrument("download.tariff_synchronizer") do
       [TaricArchive, ChiefArchive].map(&:sync)
     end

--- a/lib/tariff_synchronizer.rb
+++ b/lib/tariff_synchronizer.rb
@@ -248,10 +248,7 @@ module TariffSynchronizer
   end
 
   def sync_variables_set?
-    username.present? &&
-    password.present? &&
-    host.present? &&
-    TradeTariffBackend.admin_email.present?
+    username.present? && password.present? && host.present?
   end
 
   def oplog_based_models

--- a/lib/tariff_synchronizer/base_update.rb
+++ b/lib/tariff_synchronizer/base_update.rb
@@ -319,7 +319,7 @@ module TariffSynchronizer
         if last_download = last_pending.first || descending.first
           last_download.issue_date
         else
-         TariffSynchronizer.initial_update_for(update_type)
+         TariffSynchronizer.initial_update_date_for(update_type)
         end
       end
 

--- a/lib/tariff_synchronizer/base_update.rb
+++ b/lib/tariff_synchronizer/base_update.rb
@@ -201,8 +201,7 @@ module TariffSynchronizer
 
       def sync
         (pending_from..Date.current).each { |date| download(date) }
-
-        notify_about_missing_updates if self.order(Sequel.desc(:issue_date)).last(TariffSynchronizer.warning_day_count).all?(&:missing?)
+        notify_about_missing_updates if last_updates_are_missing?
       end
 
       def find_update(local_file_name, date)
@@ -326,6 +325,10 @@ module TariffSynchronizer
       def parse_file_path(file_path)
         filename = Pathname.new(file_path).basename.to_s
         filename.match(/^(\d{4}-\d{2}-\d{2})_(.*)$/)[1,2]
+      end
+
+      def last_updates_are_missing?
+        order(Sequel.desc(:issue_date)).last(TariffSynchronizer.warning_day_count).all?(&:missing?)
       end
 
       def notify_about_missing_updates

--- a/lib/tariff_synchronizer/chief_archive.rb
+++ b/lib/tariff_synchronizer/chief_archive.rb
@@ -23,7 +23,7 @@ module TariffSynchronizer
         if ENV["CHIEF_START_DATE"].present?
           Date.strptime(ENV["CHIEF_START_DATE"], "%Y-%m-%d")
         else
-          TariffSynchronizer.initial_update_for(update_type)
+          TariffSynchronizer.initial_update_date_for(update_type)
         end
       end
 

--- a/lib/tariff_synchronizer/logger.rb
+++ b/lib/tariff_synchronizer/logger.rb
@@ -2,18 +2,12 @@ module TariffSynchronizer
   class Logger < ActiveSupport::LogSubscriber
 
     def logger
-      @logger ||= if
-        formatter = Proc.new {|severity, time, progname, msg| "#{time.strftime('%Y-%m-%dT%H:%M:%S.%L %z')} #{sprintf('%5s', severity)} #{msg}\n" }
-
+      @logger ||= begin
         file_logger = ::Logger.new('log/tariff_synchronizer.log')
-        file_logger.formatter = formatter
-
-        if defined?(Rails) &&
-              Rails.respond_to?(:configuration) &&
-              Rails.configuration.respond_to?(:synchronizer_console_logs) &&
-              Rails.configuration.synchronizer_console_logs
+        file_logger.formatter = TradeTariffBackend.log_formatter
+        if defined?(Rails) && Rails.env.development?
           console_logger = ActiveSupport::Logger.new(STDOUT)
-          console_logger.formatter = formatter
+          console_logger.formatter = TradeTariffBackend.log_formatter
           console_logger.extend(ActiveSupport::Logger.broadcast(file_logger))
         else
           file_logger

--- a/lib/tariff_synchronizer/logger.rb
+++ b/lib/tariff_synchronizer/logger.rb
@@ -28,7 +28,7 @@ module TariffSynchronizer
 
     # Sync variables were not set correctly
     def config_error(event)
-      error "Missing: config/trade_tariff_backend_secrets.yml. Variables: username, password, host and email."
+      error "Missing: Tariff sync enviroment variables: TARIFF_SYNC_USERNAME, TARIFF_SYNC_PASSWORD, TARIFF_SYNC_HOST and TARIFF_SYNC_EMAIL."
     end
 
     # There are failed updates (can't proceed)

--- a/lib/tariff_synchronizer/taric_archive.rb
+++ b/lib/tariff_synchronizer/taric_archive.rb
@@ -24,7 +24,7 @@ module TariffSynchronizer
         if ENV["TARIC_START_DATE"].present?
           Date.strptime(ENV["TARIC_START_DATE"], "%Y-%m-%d")
         else
-          TariffSynchronizer.initial_update_for(update_type)
+          TariffSynchronizer.initial_update_date_for(update_type)
         end
       end
 

--- a/lib/tariff_synchronizer/taric_update.rb
+++ b/lib/tariff_synchronizer/taric_update.rb
@@ -88,9 +88,7 @@ module TariffSynchronizer
     def self.taric_update_name_for(date)
       taric_query_url = taric_query_url_for(date)
 
-      instrument(
-        "get_taric_update_name.tariff_synchronizer", date: date, url: taric_query_url
-      ) do
+      instrument("get_taric_update_name.tariff_synchronizer", date: date, url: taric_query_url) do
         download_content(taric_query_url)
       end
     end

--- a/lib/trade_tariff_backend.rb
+++ b/lib/trade_tariff_backend.rb
@@ -27,7 +27,7 @@ module TradeTariffBackend
 
     # Email of the user who receives all info/error notifications
     def admin_email
-      secrets.sync_email || 'trade-tariff-alerts@digital.cabinet-office.gov.uk'
+      ENV.fetch("TARIFF_SYNC_EMAIL", "trade-tariff-alerts@digital.cabinet-office.gov.uk")
     end
 
     def platform
@@ -59,10 +59,6 @@ module TradeTariffBackend
           Mailer.reindex_exception(e).deliver_now
         end
       end
-    end
-
-    def secrets
-      @secrets ||= OpenStruct.new(load_secrets)
     end
 
     # Number of changes to fetch for Commodity/Heading/Chapter
@@ -132,17 +128,6 @@ module TradeTariffBackend
 
     def model_serializer_for(model)
       "#{model}Serializer".constantize
-    end
-
-    private
-
-    def load_secrets
-      {
-        sync_username: ENV["TARIFF_SYNC_USERNAME"],
-        sync_password: ENV["TARIFF_SYNC_PASSWORD"],
-        sync_email: ENV["TARIFF_SYNC_EMAIL"],
-        sync_host: ENV["TARIFF_SYNC_HOST"]
-      }
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -42,6 +42,7 @@ RSpec.configure do |config|
   config.include SynchronizerHelper
   config.include RescueHelper
   config.include ChiefDataHelper
+  config.include ActiveSupport::Testing::TimeHelpers
 
   config.include FactoryGirl::Syntax::Methods
 

--- a/spec/unit/tariff_synchronizer/taric_update_spec.rb
+++ b/spec/unit/tariff_synchronizer/taric_update_spec.rb
@@ -309,19 +309,20 @@ describe TariffSynchronizer::TaricUpdate do
     end
   end
 
-  describe '.sync' do
+  describe ".sync" do
     let(:not_found_response) { build :response, :not_found }
 
-    context 'file not found for nth time in a row' do
-      before {
-        allow(TariffSynchronizer::TaricUpdate).to receive(:download_content)
-                                              .and_return(not_found_response)
-      }
+    it "notifies about several missing updates in a row" do
+      allow(TariffSynchronizer::TaricUpdate).to receive(:download_content).and_return(not_found_response)
+      expect(TariffSynchronizer::TaricUpdate).to receive(:notify_about_missing_updates)
+      create :taric_update, :missing, issue_date: Date.today.ago(2.days)
+      create :taric_update, :missing, issue_date: Date.today.ago(3.days)
+      TariffSynchronizer::TaricUpdate.sync
+    end
 
-      it 'notifies about several missing updates in a row' do
-        create :taric_update, :missing, issue_date: Date.today.ago(2.days)
-        create :taric_update, :missing, issue_date: Date.today.ago(3.days)
-        expect(TariffSynchronizer::TaricUpdate).to receive(:notify_about_missing_updates).and_return(true)
+    it "Calls the difference from the intial update to the current time, the donwload method" do
+      expect(TariffSynchronizer::TaricUpdate).to receive(:download_content).and_return(not_found_response).exactly(3).times
+      travel_to TariffSynchronizer.taric_initial_update_date + 2 do
         TariffSynchronizer::TaricUpdate.sync
       end
     end

--- a/spec/unit/tariff_synchronizer/taric_update_spec.rb
+++ b/spec/unit/tariff_synchronizer/taric_update_spec.rb
@@ -313,15 +313,14 @@ describe TariffSynchronizer::TaricUpdate do
     let(:not_found_response) { build :response, :not_found }
 
     context 'file not found for nth time in a row' do
-      let!(:taric_update1) { create :taric_update, :missing, issue_date: Date.today.ago(2.days) }
-      let!(:taric_update2) { create :taric_update, :missing, issue_date: Date.today.ago(3.days) }
-
       before {
         allow(TariffSynchronizer::TaricUpdate).to receive(:download_content)
                                               .and_return(not_found_response)
       }
 
       it 'notifies about several missing updates in a row' do
+        create :taric_update, :missing, issue_date: Date.today.ago(2.days)
+        create :taric_update, :missing, issue_date: Date.today.ago(3.days)
         expect(TariffSynchronizer::TaricUpdate).to receive(:notify_about_missing_updates).and_return(true)
         TariffSynchronizer::TaricUpdate.sync
       end

--- a/spec/unit/tariff_synchronizer_spec.rb
+++ b/spec/unit/tariff_synchronizer_spec.rb
@@ -2,12 +2,12 @@ require 'rails_helper'
 require 'tariff_synchronizer'
 
 describe TariffSynchronizer, truncation: true do
-  describe '.initial_update_for' do
+  describe '.initial_update_date_for' do
     # helper method where update type is a param
-    it 'returns initial update day for specific update type' do
-      expect(TariffSynchronizer.initial_update_for(:taric)).to eq(TariffSynchronizer.taric_initial_update)
-      expect(TariffSynchronizer.initial_update_for(:chief)).to eq(TariffSynchronizer.chief_initial_update)
-      expect { TariffSynchronizer.initial_update_for(:non_existent) }.to raise_error(NoMethodError)
+    it 'returns initial update date for specific update type taric or chief ' do
+      expect(TariffSynchronizer.initial_update_date_for(:taric)).to eq(TariffSynchronizer.taric_initial_update_date)
+      expect(TariffSynchronizer.initial_update_date_for(:chief)).to eq(TariffSynchronizer.chief_initial_update_date)
+      expect { TariffSynchronizer.initial_update_date_for(:non_existent) }.to raise_error(NoMethodError)
     end
   end
 


### PR DESCRIPTION
#### What this PR does:

This PR fixes small issues found during the sync process.

- Add the .cfignore which is a symlink of the .gitignore file (Cloud Foundry isn’t version-control-aware)
- Remove redundant instructions in the the `development.rb` rails env file. (Since we have updated rails this is part of rails defaults to send logs to the development.log file and the stdout in development mode)
- Remove warnings of constants been redefined.
- Fix importer logger message to include record which failed and a better format to improve readability.
- Remove unnecessary code.
- Rename variables to more revealing intention names.
- Simplify synchronizer logger.
- Add the `ActiveSupport::Testing::TimeHelpers` module for have access to the `travel_to` helper
- Add more tests.

#### Notes

There is more space for improvements, but I don't want to create big PRs with a lot of changes to give chance to review every line deleted or introduced, so this is the first one of many PRs :+1: 
