### PR TITLE
Importer refactor

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -32,4 +32,9 @@ Rails.application.configure do
 
   # Expands the lines which load the assets
   config.assets.debug = true
+
+  # Configure Rails.logger to log to both STDOUT and development.log file.
+  config.log_level = :info
+  file_logger = Logger.new(Rails.root.join("log", "development.log"))
+  config.logger = file_logger.extend(ActiveSupport::Logger.broadcast(Logger.new(STDOUT)))
 end

--- a/lib/chief_importer.rb
+++ b/lib/chief_importer.rb
@@ -52,11 +52,7 @@ class ChiefImporter < TariffImporter
         entry.process!
       end
     end
-
-    ActiveSupport::Notifications.instrument("chief_imported.tariff_importer",
-                                             path: path,
-                                             date: extraction_date,
-                                             count: record_count)
+    importer_logger("chief_imported",path: path, date: extraction_date, count: record_count)
   rescue => exception
     ActiveSupport::Notifications.instrument("chief_failed.tariff_importer",
                                               path: path,

--- a/lib/chief_importer.rb
+++ b/lib/chief_importer.rb
@@ -26,15 +26,13 @@ class ChiefImporter < TariffImporter
   cattr_accessor :end_mark
   self.end_mark = "ZZZZZZZZZZZ"
 
-  attr_reader :processor, :start_entry,
-              :end_entry, :file_name
+  attr_reader :processor, :start_entry, :end_entry, :file_name
 
   delegate :extraction_date, to: :start_entry, allow_nil: true
   delegate :record_count, to: :end_entry, allow_nil: true
 
   def initialize(path, issue_date = nil)
     super(path, issue_date)
-
     @file_name = Pathname.new(path).basename.to_s
   end
 
@@ -54,10 +52,7 @@ class ChiefImporter < TariffImporter
     end
     importer_logger("chief_imported",path: path, date: extraction_date, count: record_count)
   rescue => exception
-    ActiveSupport::Notifications.instrument("chief_failed.tariff_importer",
-                                              path: path,
-                                              exception: exception)
-
+    importer_logger("chief_failed",path: path, exception: exception)
     raise ImportException.new(exception.message, exception)
   end
 end

--- a/lib/chief_importer.rb
+++ b/lib/chief_importer.rb
@@ -1,19 +1,17 @@
-require 'csv'
-
-require 'tariff_importer'
-require 'chief_importer/entry'
-require 'chief_importer/start_entry'
-require 'chief_importer/end_entry'
-require 'chief_importer/change_entry'
-
-require 'chief_importer/strategies/base_strategy'
-require 'chief_importer/strategies/strategies'
+require "csv"
+require "tariff_importer"
+require "chief_importer/entry"
+require "chief_importer/start_entry"
+require "chief_importer/end_entry"
+require "chief_importer/change_entry"
+require "chief_importer/strategies/base_strategy"
+require "chief_importer/strategies/strategies"
 
 class ChiefImporter < TariffImporter
   class ImportException < StandardError
     attr_reader :original
 
-    def initialize(msg = "ChiefImporter::ImportException", original=$!)
+    def initialize(msg = "ChiefImporter::ImportException", original = $!)
       super(msg)
       @original = original
     end
@@ -41,14 +39,14 @@ class ChiefImporter < TariffImporter
   end
 
   def import
-    CSV.foreach(path, encoding: 'ISO-8859-1') do |line|
+    CSV.foreach(path, encoding: "ISO-8859-1") do |line|
       entry = Entry.build(line)
 
       if entry.is_a?(StartEntry)
         @start_entry = entry
       elsif entry.is_a?(EndEntry)
         @end_entry = entry
-      else # means it's ChangeEntry
+      else # means it"s ChangeEntry
         next unless entry.relevant?
         entry.origin = file_name
         entry.process!
@@ -56,16 +54,13 @@ class ChiefImporter < TariffImporter
     end
 
     ActiveSupport::Notifications.instrument("chief_imported.tariff_importer",
-      path: path,
-      date: extraction_date,
-      count: record_count
-    )
-
+                                             path: path,
+                                             date: extraction_date,
+                                             count: record_count)
   rescue => exception
     ActiveSupport::Notifications.instrument("chief_failed.tariff_importer",
-      path: path,
-      exception: exception
-    )
+                                              path: path,
+                                              exception: exception)
 
     raise ImportException.new(exception.message, exception)
   end

--- a/lib/chief_importer.rb
+++ b/lib/chief_importer.rb
@@ -44,7 +44,7 @@ class ChiefImporter < TariffImporter
         @start_entry = entry
       elsif entry.is_a?(EndEntry)
         @end_entry = entry
-      else # means it"s ChangeEntry
+      else # means it's ChangeEntry
         next unless entry.relevant?
         entry.origin = file_name
         entry.process!

--- a/lib/chief_transformer/logger.rb
+++ b/lib/chief_transformer/logger.rb
@@ -1,9 +1,6 @@
 class ChiefTransformer
   class Logger < ActiveSupport::LogSubscriber
-    cattr_accessor :logger
-    self.logger = ::Logger.new('log/chief_transformer.log')
-    self.logger.formatter = TradeTariffBackend.log_formatter
-
+    
     def start_transform(event)
       info "CHIEF Transformer started in #{event.payload[:mode]} mode"
     end

--- a/lib/tariff_importer.rb
+++ b/lib/tariff_importer.rb
@@ -1,24 +1,22 @@
-require 'delegate'
-require 'date'
-require 'active_support/notifications'
-require 'active_support/log_subscriber'
-
-require 'tariff_importer/logger'
+require "delegate"
+require "date"
+require "active_support/notifications"
+require "active_support/log_subscriber"
+require "tariff_importer/logger"
 
 class TariffImporter
-  NotFound = Class.new(StandardError)
-
   attr_reader :path, :issue_date
 
   def initialize(path, issue_date = nil)
-    if file_exists?(path)
-      @path = path
-      @issue_date = issue_date
-    end
+    raise FileNotFoundError, "#{path} was not found." unless File.exist?(path)
+    @path = path
+    @issue_date = issue_date
   end
 
-  def file_exists?(path)
-    raise NotFound.new("#{path} was not found.") unless File.exists?(path)
-    true
+  # def importer_logger(key, payload)
+  #   ActiveSupport::Notifications.instrument("#{key}.tariff_importer", payload)
+  # end
+
+  class FileNotFoundError < StandardError
   end
 end

--- a/lib/tariff_importer.rb
+++ b/lib/tariff_importer.rb
@@ -13,7 +13,7 @@ class TariffImporter
     @issue_date = issue_date
   end
 
-  def importer_logger(key, payload)
+  def importer_logger(key, payload = {})
     ActiveSupport::Notifications.instrument("#{key}.tariff_importer", payload)
   end
 

--- a/lib/tariff_importer.rb
+++ b/lib/tariff_importer.rb
@@ -13,9 +13,9 @@ class TariffImporter
     @issue_date = issue_date
   end
 
-  # def importer_logger(key, payload)
-  #   ActiveSupport::Notifications.instrument("#{key}.tariff_importer", payload)
-  # end
+  def importer_logger(key, payload)
+    ActiveSupport::Notifications.instrument("#{key}.tariff_importer", payload)
+  end
 
   class FileNotFoundError < StandardError
   end

--- a/lib/tariff_importer/logger.rb
+++ b/lib/tariff_importer/logger.rb
@@ -1,9 +1,6 @@
 class TariffImporter
   class Logger < ActiveSupport::LogSubscriber
-    cattr_accessor :logger
-    self.logger = ::Logger.new('log/tariff_importer.log')
-    self.logger.formatter = TradeTariffBackend.log_formatter
-
+    
     def chief_imported(event)
       info "Parsed #{event.payload[:count]} CHIEF records for #{event.payload[:date]} at #{event.payload[:path]}"
     end

--- a/lib/tariff_synchronizer/base_update.rb
+++ b/lib/tariff_synchronizer/base_update.rb
@@ -125,7 +125,7 @@ module TariffSynchronizer
       # Check if file exists and if it doesn't try redownloading it.
       # This may be necessary when tariff runs in multiserver environment
       # where one server downloads updates and another server tries to apply it
-      File.exists?(file_path) || (
+      File.exist?(file_path) || (
         instrument("not_found_on_file_system.tariff_synchronizer", path: file_path)
         self.class.download(issue_date) || file_exists?
       )

--- a/lib/tariff_synchronizer/logger.rb
+++ b/lib/tariff_synchronizer/logger.rb
@@ -1,20 +1,6 @@
 module TariffSynchronizer
   class Logger < ActiveSupport::LogSubscriber
 
-    def logger
-      @logger ||= begin
-        file_logger = ::Logger.new('log/tariff_synchronizer.log')
-        file_logger.formatter = TradeTariffBackend.log_formatter
-        if defined?(Rails) && Rails.env.development?
-          console_logger = ActiveSupport::Logger.new(STDOUT)
-          console_logger.formatter = TradeTariffBackend.log_formatter
-          console_logger.extend(ActiveSupport::Logger.broadcast(file_logger))
-        else
-          file_logger
-        end
-      end
-    end
-
     # Download all pending Taric and Chief updates
     def download(event)
       info "Finished downloading updates"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -19,7 +19,6 @@ require 'json_expressions/rspec'
 require 'fakefs/spec_helpers'
 require 'sidekiq/testing'
 require 'elasticsearch/extensions/test/cluster'
-require 'active_support/log_subscriber/test_helper'
 
 require Rails.root.join("spec/support/tariff_validation_matcher.rb")
 Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}
@@ -41,6 +40,7 @@ RSpec.configure do |config|
   config.include RSpec::Rails::RequestExampleGroup, type: :request, file_path: /spec\/api/
   config.include ControllerSpecHelper, type: :controller
   config.include SynchronizerHelper
+  config.include LoggerHelper
   config.include RescueHelper
   config.include ChiefDataHelper
   config.include ActiveSupport::Testing::TimeHelpers

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -28,6 +28,7 @@ Dir[Rails.root.join("app/models/*.rb")].each {|f| require f}
 Dir[Rails.root.join("app/serializers/*.rb")].each {|f| require f}
 
 RSpec.configure do |config|
+  config.use_transactional_fixtures = false
   config.raise_errors_for_deprecations!
   config.mock_with :rspec
   config.order = "random"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -19,6 +19,7 @@ require 'json_expressions/rspec'
 require 'fakefs/spec_helpers'
 require 'sidekiq/testing'
 require 'elasticsearch/extensions/test/cluster'
+require 'active_support/log_subscriber/test_helper'
 
 require Rails.root.join("spec/support/tariff_validation_matcher.rb")
 Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}

--- a/spec/support/logger_helper.rb
+++ b/spec/support/logger_helper.rb
@@ -1,0 +1,17 @@
+require 'active_support/log_subscriber/test_helper'
+
+module LoggerHelper
+  include ActiveSupport::LogSubscriber::TestHelper
+
+  def tariff_importer_logger_listener
+    setup # Setup LogSubscriber::TestHelper
+    TariffImporter::Logger.attach_to :tariff_importer
+    TariffImporter::Logger.logger = @logger
+  end
+
+  def chief_transformer_logger_listener
+    setup # Setup LogSubscriber::TestHelper
+    ChiefTransformer::Logger.attach_to :chief_transformer
+    ChiefTransformer::Logger.logger = @logger
+  end
+end

--- a/spec/support/logger_helper.rb
+++ b/spec/support/logger_helper.rb
@@ -9,6 +9,12 @@ module LoggerHelper
     TariffImporter::Logger.logger = @logger
   end
 
+  def tariff_synchronizer_logger_listener
+    setup # Setup LogSubscriber::TestHelper
+    allow_any_instance_of(TariffSynchronizer::Logger).to receive(:logger).and_return(@logger)
+    TariffSynchronizer::Logger.attach_to :tariff_synchronizer
+  end
+
   def chief_transformer_logger_listener
     setup # Setup LogSubscriber::TestHelper
     ChiefTransformer::Logger.attach_to :chief_transformer

--- a/spec/unit/chief_importer_spec.rb
+++ b/spec/unit/chief_importer_spec.rb
@@ -56,9 +56,12 @@ describe ChiefImporter do
     context "when provided with malformed sample" do
       let(:invalid_file) { "spec/fixtures/chief_samples/malformed_sample.txt" }
 
-      it "raises ChiefImportException" do
+      it "raises ChiefImportException and sends a log" do
+        tariff_importer_logger_listener
         @importer = ChiefImporter.new(invalid_file)
         expect { @importer.import }.to raise_error ChiefImporter::ImportException
+        expect(@logger.logged(:error).size).to eq 1
+        expect(@logger.logged(:error).last).to match /CHIEF import of (.*) failed/
       end
     end
   end

--- a/spec/unit/chief_importer_spec.rb
+++ b/spec/unit/chief_importer_spec.rb
@@ -1,10 +1,10 @@
-require 'rails_helper'
-
-require 'chief_importer'
+require "rails_helper"
+require "tariff_importer"
+require "chief_importer"
 
 describe ChiefImporter do
-  describe 'initialization' do
-    it 'assigns path' do
+  describe "initialization" do
+    it "assigns path" do
       importer = ChiefImporter.new("spec/fixtures/chief_samples/KBT009\(12044\).txt")
       expect(importer.path.to_s).to eq "spec/fixtures/chief_samples/KBT009\(12044\).txt"
     end
@@ -13,19 +13,26 @@ describe ChiefImporter do
   describe "#import" do
 
     context "when provided with valid chief file" do
-      before(:all) do
-        valid_file = "spec/fixtures/chief_samples/KBT009\(12044\).txt"
+      let(:valid_file) { "spec/fixtures/chief_samples/KBT009\(12044\).txt" }
 
-        @importer = ChiefImporter.new(valid_file)
-        @importer.import
+      it "assigns start entry" do
+        importer = ChiefImporter.new(valid_file)
+        importer.import
+        expect(importer.start_entry).to be_kind_of ChiefImporter::StartEntry
       end
 
-      it 'assigns start entry' do
-        expect(@importer.start_entry).to be_kind_of ChiefImporter::StartEntry
+      it "assigns end entry" do
+        importer = ChiefImporter.new(valid_file)
+        importer.import
+        expect(importer.end_entry).to be_kind_of ChiefImporter::EndEntry
       end
 
-      it 'assigns end entry' do
-        expect(@importer.end_entry).to be_kind_of ChiefImporter::EndEntry
+      it "logs an info event" do
+        tariff_importer_logger_listener
+        importer = ChiefImporter.new(valid_file)
+        importer.import
+        expect(@logger.logged(:info).size).to eq 1
+        expect(@logger.logged(:info).last).to match /Parsed (.*) CHIEF records/
       end
     end
 
@@ -37,11 +44,11 @@ describe ChiefImporter do
         rescuing { @importer.import }
       end
 
-      it 'does not assign start entry' do
+      it "does not assign start entry" do
         expect(@importer.start_entry).to be_blank
       end
 
-      it 'does not assign end entry' do
+      it "does not assign end entry" do
         expect(@importer.end_entry).to be_blank
       end
     end
@@ -49,7 +56,7 @@ describe ChiefImporter do
     context "when provided with malformed sample" do
       let(:invalid_file) { "spec/fixtures/chief_samples/malformed_sample.txt" }
 
-      it 'raises ChiefImportException' do
+      it "raises ChiefImportException" do
         @importer = ChiefImporter.new(invalid_file)
         expect { @importer.import }.to raise_error ChiefImporter::ImportException
       end

--- a/spec/unit/chief_importer_spec.rb
+++ b/spec/unit/chief_importer_spec.rb
@@ -3,13 +3,6 @@ require "tariff_importer"
 require "chief_importer"
 
 describe ChiefImporter do
-  describe "initialization" do
-    it "assigns path" do
-      importer = ChiefImporter.new("spec/fixtures/chief_samples/KBT009\(12044\).txt")
-      expect(importer.path.to_s).to eq "spec/fixtures/chief_samples/KBT009\(12044\).txt"
-    end
-  end
-
   describe "#import" do
 
     context "when provided with valid chief file" do

--- a/spec/unit/chief_transformer/logger_spec.rb
+++ b/spec/unit/chief_transformer/logger_spec.rb
@@ -2,14 +2,7 @@ require 'rails_helper'
 require 'chief_transformer'
 
 describe ChiefTransformer::Logger do
-  include ActiveSupport::LogSubscriber::TestHelper
-
-  before {
-    setup # ActiveSupport::LogSubscriber::TestHelper.setup
-
-    ChiefTransformer::Logger.attach_to :chief_transformer
-    ChiefTransformer::Logger.logger = @logger
-  }
+  before { chief_transformer_logger_listener }
 
   describe '#start_transform logging' do
     before { ChiefTransformer.instance.invoke }

--- a/spec/unit/chief_transformer/logger_spec.rb
+++ b/spec/unit/chief_transformer/logger_spec.rb
@@ -1,6 +1,5 @@
 require 'rails_helper'
 require 'chief_transformer'
-require 'active_support/log_subscriber/test_helper'
 
 describe ChiefTransformer::Logger do
   include ActiveSupport::LogSubscriber::TestHelper

--- a/spec/unit/tariff_importer/logger_spec.rb
+++ b/spec/unit/tariff_importer/logger_spec.rb
@@ -2,14 +2,7 @@ require 'rails_helper'
 require 'tariff_importer'
 
 describe TariffImporter::Logger do
-  include ActiveSupport::LogSubscriber::TestHelper
-
-  before {
-    setup # ActiveSupport::LogSubscriber::TestHelper.setup
-
-    TariffImporter::Logger.attach_to :tariff_importer
-    TariffImporter::Logger.logger = @logger
-  }
+  before { tariff_importer_logger_listener }
 
   describe '#chief_imported logging' do
     let(:valid_file) { "spec/fixtures/chief_samples/KBT009\(12044\).txt" }

--- a/spec/unit/tariff_importer/logger_spec.rb
+++ b/spec/unit/tariff_importer/logger_spec.rb
@@ -4,14 +4,10 @@ require 'tariff_importer'
 describe TariffImporter::Logger do
   before { tariff_importer_logger_listener }
 
-  describe '#chief_imported logging' do
-    let(:valid_file) { "spec/fixtures/chief_samples/KBT009\(12044\).txt" }
-
-    before { ChiefImporter.new(valid_file).import }
-
-    it 'logs an info event' do
-      expect(@logger.logged(:info).size).to eq 1
-      expect(@logger.logged(:info).last).to match /Parsed (.*) CHIEF records/
+  describe '#chief_imported' do
+    it 'logs an info event with count date and path' do
+      log = TariffImporter::Logger.new.chief_imported(chief_imported_event)
+      expect(log[0]).to eq "Parsed 5 CHIEF records for 2012-12-21 at file.xml"
     end
   end
 
@@ -68,5 +64,9 @@ describe TariffImporter::Logger do
     it 'raises ImportException' do
       expect { TaricImporter.new(unknown_file).import }.to raise_error TaricImporter::ImportException
     end
+  end
+
+  def chief_imported_event
+    double("event", payload: {count: '5', date: '2012-12-21', path: 'file.xml'})
   end
 end

--- a/spec/unit/tariff_importer/logger_spec.rb
+++ b/spec/unit/tariff_importer/logger_spec.rb
@@ -1,6 +1,5 @@
 require 'rails_helper'
 require 'tariff_importer'
-require 'active_support/log_subscriber/test_helper'
 
 describe TariffImporter::Logger do
   include ActiveSupport::LogSubscriber::TestHelper

--- a/spec/unit/tariff_importer/logger_spec.rb
+++ b/spec/unit/tariff_importer/logger_spec.rb
@@ -6,21 +6,17 @@ describe TariffImporter::Logger do
 
   describe '#chief_imported' do
     it 'logs an info event with count date and path' do
-      log = TariffImporter::Logger.new.chief_imported(chief_imported_event)
+      imported_event = double("event", payload: {count: '5', date: '2012-12-21', path: 'file.xml'})
+      log = TariffImporter::Logger.new.chief_imported(imported_event)
       expect(log[0]).to eq "Parsed 5 CHIEF records for 2012-12-21 at file.xml"
     end
   end
 
-  describe '#chief_failed logging' do
-    let(:invalid_file) { "spec/fixtures/chief_samples/malformed_sample.txt" }
-
-    before {
-      rescuing { ChiefImporter.new(invalid_file).import }
-    }
-
-    it 'logs an info event' do
-      expect(@logger.logged(:error).size).to eq 1
-      expect(@logger.logged(:error).last).to match /CHIEF import (.*) failed/
+  describe '#chief_failed' do
+    it 'logs an error event with path and exception' do
+      failed_event = double("event", payload: {path: 'file.txt', exception: 'fail'})
+      log = TariffImporter::Logger.new.chief_failed(failed_event)
+      expect(log[0]).to eq "CHIEF import of #{Rails.root}/file.txt failed: Reason: fail"
     end
   end
 
@@ -64,9 +60,5 @@ describe TariffImporter::Logger do
     it 'raises ImportException' do
       expect { TaricImporter.new(unknown_file).import }.to raise_error TaricImporter::ImportException
     end
-  end
-
-  def chief_imported_event
-    double("event", payload: {count: '5', date: '2012-12-21', path: 'file.xml'})
   end
 end

--- a/spec/unit/tariff_importer_spec.rb
+++ b/spec/unit/tariff_importer_spec.rb
@@ -1,24 +1,26 @@
-require 'rails_helper'
-
-require 'tariff_importer'
+require "rails_helper"
+require "tariff_importer"
 
 describe TariffImporter do
-  let(:valid_file)       { "spec/fixtures/chief_samples/KBT009\(12044\).txt" }
-  let(:invalid_file)     { "err" }
-  let(:valid_importer)   { "ChiefImporter" }
-  let(:invalid_importer) { "Err" }
+  let(:valid_path)       { "spec/fixtures/chief_samples/KBT009\(12044\).txt" }
+  let(:date)             { Date.new(2013, 8, 2) }
 
-  describe "initialization" do
-    it 'sets path on initialization' do
-      expect(
-        -> { TariffImporter.new(valid_file, ChiefImporter) }
-      ).to_not raise_error
+  describe "#initialize" do
+    it "set path and issue_date attributes" do
+      importer = TariffImporter.new(valid_path, date)
+      expect(importer.path).to eq(valid_path)
+      expect(importer.issue_date).to eq(date)
     end
 
-    it 'throws an error if path is non existent' do
-      expect(
-        -> { TariffImporter.new(invalid_file) }
-      ).to raise_error(TariffImporter::NotFound)
+    it "set issue_date as nil if not defined" do
+      importer = TariffImporter.new(valid_path)
+      expect(importer.issue_date).to be_nil
+    end
+
+    it "throws an error if path is non existent" do
+      expect {
+        TariffImporter.new("x")
+      }.to raise_error(TariffImporter::FileNotFoundError)
     end
   end
 end

--- a/spec/unit/tariff_importer_spec.rb
+++ b/spec/unit/tariff_importer_spec.rb
@@ -23,4 +23,12 @@ describe TariffImporter do
       }.to raise_error(TariffImporter::FileNotFoundError)
     end
   end
+
+  describe "#importer_logger" do
+    it "triggers a call to the tariff importer logger" do
+      expect(ActiveSupport::Notifications).to receive(:instrument)
+                                              .with("chief_imported.tariff_importer", {:x=>"y"})
+      TariffImporter.new(valid_path).importer_logger("chief_imported", x: "y")
+    end
+  end
 end

--- a/spec/unit/tariff_synchronizer/logger_spec.rb
+++ b/spec/unit/tariff_synchronizer/logger_spec.rb
@@ -2,19 +2,10 @@ require 'rails_helper'
 require 'tariff_synchronizer'
 
 describe TariffSynchronizer::Logger, truncation: true do
-  include ActiveSupport::LogSubscriber::TestHelper
-
   before(:all) { WebMock.disable_net_connect! }
   after(:all)  { WebMock.allow_net_connect! }
 
-  before {
-    setup # ActiveSupport::LogSubscriber::TestHelper.setup
-
-    allow_any_instance_of(
-      TariffSynchronizer::Logger
-    ).to receive(:logger).and_return(@logger)
-    TariffSynchronizer::Logger.attach_to :tariff_synchronizer
-  }
+  before { tariff_synchronizer_logger_listener }
 
   describe '#download logging' do
     before {

--- a/spec/unit/tariff_synchronizer/logger_spec.rb
+++ b/spec/unit/tariff_synchronizer/logger_spec.rb
@@ -1,6 +1,5 @@
 require 'rails_helper'
 require 'tariff_synchronizer'
-require 'active_support/log_subscriber/test_helper'
 
 describe TariffSynchronizer::Logger, truncation: true do
   include ActiveSupport::LogSubscriber::TestHelper

--- a/spec/unit/tariff_synchronizer/logger_spec.rb
+++ b/spec/unit/tariff_synchronizer/logger_spec.rb
@@ -175,7 +175,7 @@ describe TariffSynchronizer::Logger, truncation: true do
     }
 
     before {
-      allow_any_instance_of(TariffImporter).to receive(:file_exists?).and_return true
+      allow(File).to receive(:exist?).and_return true
       allow_any_instance_of(TariffSynchronizer::BaseUpdate).to receive(:file_exists?).and_return true
       allow_any_instance_of(TaricImporter).to receive(:import) {
         Measure.first
@@ -348,7 +348,7 @@ describe TariffSynchronizer::Logger, truncation: true do
     before {
       # Test in isolation, file is not actually in the file system
       # so bypass the check
-      expect(File).to receive(:exists?)
+      expect(File).to receive(:exist?)
                   .with(chief_update.file_path)
                   .twice
                   .and_return(true)
@@ -391,7 +391,7 @@ describe TariffSynchronizer::Logger, truncation: true do
     before {
       # Test in isolation, file is not actually in the file system
       # so bypass the check
-      expect(File).to receive(:exists?)
+      expect(File).to receive(:exist?)
                   .with(taric_update.file_path)
                   .twice
                   .and_return(true)


### PR DESCRIPTION
#### What this PR does:

- Refactors `tariff_importer.rb` and add more tests
- Remove deprecated methods.
- Configure `use_transactional_fixtures` value to false, since we are using DatabaseCleaner.
- Creates a `LoggerHelper` module with helper methods for LogSubscriber testing.
- Add more tests.

#### Notes

 I've noticed that we are not testing the logging calls in the unit test, for example in the `chief_importer_spec.rb` file we don't check for the `import` method the possible logger calls..  but  we are testing here things like the initialization process that should be tested in the `tariff_importer` test.

The `unit/tariff_importer/logger_spec.rb` is the file that holds the testing of the `import` method for the `ChiefImporter` class which is weird since this is an unit test, it should test only the expected result.

So I've decided to add the missing tests to the `chief_importer_spec.rb`, move one test from  `unit/tariff_importer/logger_spec.rb` and create a new one checking the logging message in case of failure, and in the `unit/tariff_importer/logger_spec.rb` I changed this from being an integration test, to only check the expected message in isolation.

What do you think about this change @matthewford ?  Having the logging checks in another file leads to issues like, for example the one we had about not testing the log message in case of a failure and of course we split the unit tests in different files with different responsibilities.

#### Updates

After the feedback that we don't want to have multiple log files for each process, I've removed this config, so Rails will send this logs to each enviroment file. In production since we are using the `rails_stdout_logging` gem this logs will be send to the STDOUT by default.

In development we want to show this logs in the STDOUT too but this will produce an empty `development.log` and we might want to persist these logs (?) .. so, in the `development.rb` environment file, we set a custom logger to the `development.log` file and we broadcast to another logger (STDOUT).

As a note, I found that is no longer possible to extend the logger, from this file, so you have to create a new one a set it to the `config.logger`. Another option could be, created an initializer and extend the `Rails.logger` that is no longer empty to the new desired one, but I didn't want to add conditionals in a initializer file.