### PR TITLE
Fix latest_applied_of_both_kinds method and add missing tests

### DIFF
--- a/lib/tariff_synchronizer/base_update.rb
+++ b/lib/tariff_synchronizer/base_update.rb
@@ -73,11 +73,7 @@ module TariffSynchronizer
       end
 
       def latest_applied_of_both_kinds
-        select(:state, :update_type)
-          .applied
-          .select_group(:update_type, :state)
-          .select_append { max(:applied_at).as(:applied_at) }
-          .select_append { max(:filename).as(:filename) }.all
+        distinct(:update_type).select(Sequel.expr(:tariff_updates).*).descending.applied.order_prepend(:update_type)
       end
     end
 

--- a/spec/controllers/api/v1/updates_controller_spec.rb
+++ b/spec/controllers/api/v1/updates_controller_spec.rb
@@ -42,11 +42,11 @@ end
 describe Api::V1::UpdatesController, "GET #latest" do
   render_views
 
-  let(:pattern) {
+  let(:pattern) do
     [{ update_type: String,
       state: String,
       filename: String}.ignore_extra_keys!].ignore_extra_values!
-  }
+  end
 
   context 'when records are present' do
     it 'returns rendered records' do

--- a/spec/unit/tariff_synchronizer/base_update_spec.rb
+++ b/spec/unit/tariff_synchronizer/base_update_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+require 'tariff_synchronizer'
+
+describe TariffSynchronizer::BaseUpdate do
+
+  describe '.latest_applied_of_both_kinds' do
+    it "Makes the right sql query" do
+      expected_sql = %{SELECT DISTINCT ON ("update_type") "tariff_updates".* FROM "tariff_updates" WHERE ("state" = 'A') ORDER BY "update_type", "issue_date" DESC}
+      result = TariffSynchronizer::BaseUpdate.latest_applied_of_both_kinds.sql
+      expect(result).to eq(expected_sql)
+    end
+
+    it "returns only one record for each update_type" do
+      create_list :chief_update, 2, :applied
+      create_list :taric_update, 2, :applied
+      result = TariffSynchronizer::BaseUpdate.latest_applied_of_both_kinds.all
+      expect(result.size).to eq(2)
+    end
+
+    it "return only the most recen one of each update_type" do
+      date = Date.new(2016, 2, 6)
+      create :chief_update, :applied, issue_date: date
+      create :chief_update, :applied, issue_date: date - 1
+      result = TariffSynchronizer::BaseUpdate.latest_applied_of_both_kinds.all
+      expect(result.size).to eq(1)
+      expect(result.first.issue_date).to eq(date)
+    end
+  end
+end


### PR DESCRIPTION
While testing the FrontEnd app for the CloudFoundry deploy I found an error with the returned values from this method invoked by the api endpoint.

The `latest_applied_of_both_kinds` method didn’t have any test and when we fixed the query for postgresql we introduced a regression, about a required field in the response.

`base_update_spec` added in order to add unit tests for this methods in the Base class.