### PR TITLE
Switch from Unicorn to Puma

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem "builder", "~> 3.2"
 gem "plek", "~> 1.11"
 gem "gds-sso", "~> 11.0"
 gem "ox", '~> 2.3'
-gem "unicorn", "~> 4.9"
+gem "puma"
 gem "curb", "~> 0.8"
 
 gem "nokogiri", "~> 1.6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,7 +135,6 @@ GEM
     json (1.8.3)
     json_expressions (0.8.3)
     jwt (1.4.1)
-    kgio (2.9.3)
     libv8 (3.16.14.13)
     listen (3.0.3)
       rb-fsevent (>= 0.9.3)
@@ -192,6 +191,7 @@ GEM
       pry (>= 0.9.10, < 0.11.0)
     pry-rails (0.3.4)
       pry (>= 0.9.10)
+    puma (2.13.4)
     rabl (0.11.6)
       activesupport (>= 2.3.14)
     rack (1.6.4)
@@ -228,7 +228,6 @@ GEM
       activesupport (= 4.2.5.1)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    raindrops (0.15.0)
     rake (10.5.0)
     rb-fsevent (0.9.5)
     rb-inotify (0.9.5)
@@ -325,10 +324,6 @@ GEM
     uglifier (2.7.2)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
-    unicorn (4.9.0)
-      kgio (~> 2.6)
-      rack
-      raindrops (~> 0.7)
     warden (1.2.3)
       rack (>= 1.0)
     warden-oauth2 (0.0.1)
@@ -373,6 +368,7 @@ DEPENDENCIES
   plek (~> 1.11)
   pry-nav
   pry-rails (~> 0.3)
+  puma
   rabl (~> 0.11)
   rails (= 4.2.5.1)
   rails_12factor
@@ -388,7 +384,6 @@ DEPENDENCIES
   simplecov-rcov
   therubyracer (~> 0.12)
   uglifier (~> 2.7)
-  unicorn (~> 4.9)
   webmock
   whenever (~> 0.9)
   yajl-ruby (~> 1.2)

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+web: bundle exec puma -C config/puma.rb
 worker: bundle exec sidekiq -C ./config/sidekiq.yml

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,0 +1,9 @@
+workers Integer(ENV['WEB_CONCURRENCY'] || 2)
+threads_count = Integer(ENV['MAX_THREADS'] || 5)
+threads threads_count, threads_count
+
+preload_app!
+
+rackup      DefaultRackup
+port        ENV['PORT']     || 3000
+environment ENV['RACK_ENV'] || 'development'

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,4 +1,0 @@
-govuk_defaults = '/etc/govuk/unicorn.rb'
-instance_eval(File.read(govuk_defaults), govuk_defaults) if File.exist?(govuk_defaults)
-
-worker_processes 4


### PR DESCRIPTION
This PR Switch Unicorn to Puma as heroku recommends.

https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server


#### Notes
You may also find interesting that the CloudFoundry buildpack for ruby is a fork of the heroku's buildpack
https://github.com/cloudfoundry/ruby-buildpack