### PR TITLE
Taric update refactor

### DIFF
--- a/lib/tariff_synchronizer.rb
+++ b/lib/tariff_synchronizer.rb
@@ -65,7 +65,7 @@ module TariffSynchronizer
 
   # TARIC update url template
   mattr_accessor :taric_update_url_template
-  self.taric_update_url_template = "%{host}/taric/%{file_name}"
+  self.taric_update_url_template = "%{host}/taric/%{filename}"
 
   # Number of days to warn about missing updates after
   mattr_accessor :warning_day_count

--- a/lib/tariff_synchronizer/base_update.rb
+++ b/lib/tariff_synchronizer/base_update.rb
@@ -205,9 +205,9 @@ module TariffSynchronizer
           if update = find(filename: local_file_name, update_type: self.name, issue_date: date)
             update.update(filesize: File.read(local_file_path).size)
           else
-            create_update_entry(
+            create_or_update(
               date,
-              BaseUpdate::PENDING_STATE,
+              PENDING_STATE,
               local_file_name,
               File.read(local_file_path).size
             )
@@ -236,7 +236,7 @@ module TariffSynchronizer
             validate_file!(File.read(file_path))
             filename = Pathname.new(file_path).basename.to_s
             file_date = Date.parse(filename.match(/^(\d{4}-\d{2}-\d{2})_.*$/)[1])
-            create_update_entry(file_date, BaseUpdate::PENDING_STATE, filename)
+            create_or_update(file_date, PENDING_STATE, filename)
           rescue InvalidContents
             next
           end
@@ -253,14 +253,14 @@ module TariffSynchronizer
         if response.success? && response.content_present?
           validate_and_create_update(date, response, file_name)
         elsif response.success? && !response.content_present?
-          create_update_entry(date, FAILED_STATE, file_name)
+          create_or_update(date, FAILED_STATE, file_name)
           instrument("blank_update.tariff_synchronizer", date: date, url: response.url)
         elsif response.retry_count_exceeded?
-          create_update_entry(date, FAILED_STATE, file_name)
+          create_or_update(date, FAILED_STATE, file_name)
           instrument("retry_exceeded.tariff_synchronizer", date: date, url: response.url)
         elsif response.not_found?
           if date < Date.current
-            create_update_entry(date, MISSING_STATE, missing_update_name_for(date))
+            create_or_update(date, MISSING_STATE, missing_update_name_for(date))
             instrument("not_found.tariff_synchronizer", date: date, url: response.url)
           end
         end
@@ -272,7 +272,7 @@ module TariffSynchronizer
         rescue InvalidContents => e
           instrument("invalid_contents.tariff_synchronizer", date: date, url: response.url)
           exception = e.original
-          create_update_entry(date, FAILED_STATE, file_name).tap do |entry|
+          create_or_update(date, FAILED_STATE, file_name).tap do |entry|
             entry.update(
               exception_class: "#{exception.class}: #{exception.message}",
               exception_backtrace: exception.backtrace.try(:join, "\n")
@@ -280,7 +280,7 @@ module TariffSynchronizer
           end
         else
           # file is valid
-          create_update_entry(date, PENDING_STATE, file_name, response.content.size)
+          create_or_update(date, PENDING_STATE, file_name, response.content.size)
           write_update_file(date, response, file_name)
         end
       end
@@ -297,7 +297,7 @@ module TariffSynchronizer
         "#{date}_#{update_type}"
       end
 
-      def create_update_entry(date, state, file_name, filesize = nil)
+      def create_or_update(date, state, file_name, filesize = nil)
         find_or_create(
           filename: file_name,
           update_type: self.name,

--- a/lib/tariff_synchronizer/base_update.rb
+++ b/lib/tariff_synchronizer/base_update.rb
@@ -230,6 +230,19 @@ module TariffSynchronizer
         raise "Update Type should be specified in inheriting class"
       end
 
+      def rebuild
+        Dir[File.join(Rails.root, TariffSynchronizer.root_path, update_type.to_s, '*')].each do |file_path|
+          begin
+            contents = File.read(file_path)
+            validate_file!(OpenStruct.new(content: contents))
+            date, file_name = parse_file_path(file_path)
+            create_update_entry(Date.parse(date), BaseUpdate::PENDING_STATE, Pathname.new(file_path).basename.to_s)
+          rescue
+            next
+          end
+        end
+      end
+
       private
 
       def get_local_file_path(local_file_name)

--- a/lib/tariff_synchronizer/base_update.rb
+++ b/lib/tariff_synchronizer/base_update.rb
@@ -97,10 +97,6 @@ module TariffSynchronizer
       update(state: APPLIED_STATE, applied_at: Time.now, last_error: nil, last_error_at: nil, exception_backtrace: nil, exception_class: nil)
     end
 
-    def update_file_size(file_path)
-      update(filesize: File.size(file_path))
-    end
-
     def mark_as_failed
       update(state: FAILED_STATE)
     end

--- a/lib/tariff_synchronizer/base_update.rb
+++ b/lib/tariff_synchronizer/base_update.rb
@@ -233,8 +233,7 @@ module TariffSynchronizer
       def rebuild
         Dir[File.join(Rails.root, TariffSynchronizer.root_path, update_type.to_s, '*')].each do |file_path|
           begin
-            contents = File.read(file_path)
-            validate_file!(OpenStruct.new(content: contents))
+            validate_file!(File.read(file_path))
             date, file_name = parse_file_path(file_path)
             create_update_entry(Date.parse(date), BaseUpdate::PENDING_STATE, Pathname.new(file_path).basename.to_s)
           rescue
@@ -268,7 +267,7 @@ module TariffSynchronizer
 
       def validate_and_create_update(date, response, file_name)
         begin
-          validate_file!(response)
+          validate_file!(response.content)
         rescue InvalidContents => e
           instrument("invalid_contents.tariff_synchronizer", date: date, url: response.url)
           exception = e.original

--- a/lib/tariff_synchronizer/base_update.rb
+++ b/lib/tariff_synchronizer/base_update.rb
@@ -231,7 +231,7 @@ module TariffSynchronizer
       end
 
       def rebuild
-        Dir[File.join(Rails.root, TariffSynchronizer.root_path, update_type.to_s, '*')].each do |file_path|
+        Dir[File.join(Rails.root, TariffSynchronizer.root_path, update_type.to_s, "*")].each do |file_path|
           begin
             validate_file!(File.read(file_path))
             date, file_name = parse_file_path(file_path)

--- a/lib/tariff_synchronizer/base_update.rb
+++ b/lib/tariff_synchronizer/base_update.rb
@@ -236,7 +236,7 @@ module TariffSynchronizer
             validate_file!(File.read(file_path))
             date, file_name = parse_file_path(file_path)
             create_update_entry(Date.parse(date), BaseUpdate::PENDING_STATE, Pathname.new(file_path).basename.to_s)
-          rescue
+          rescue InvalidContents
             next
           end
         end

--- a/lib/tariff_synchronizer/base_update.rb
+++ b/lib/tariff_synchronizer/base_update.rb
@@ -234,8 +234,9 @@ module TariffSynchronizer
         Dir[File.join(Rails.root, TariffSynchronizer.root_path, update_type.to_s, "*")].each do |file_path|
           begin
             validate_file!(File.read(file_path))
-            date, file_name = parse_file_path(file_path)
-            create_update_entry(Date.parse(date), BaseUpdate::PENDING_STATE, Pathname.new(file_path).basename.to_s)
+            filename = Pathname.new(file_path).basename.to_s
+            file_date = Date.parse(filename.match(/^(\d{4}-\d{2}-\d{2})_.*$/)[1])
+            create_update_entry(file_date, BaseUpdate::PENDING_STATE, filename)
           rescue InvalidContents
             next
           end
@@ -314,11 +315,6 @@ module TariffSynchronizer
         else
           TariffSynchronizer.initial_update_date_for(update_type)
         end
-      end
-
-      def parse_file_path(file_path)
-        filename = Pathname.new(file_path).basename.to_s
-        filename.match(/^(\d{4}-\d{2}-\d{2})_(.*)$/)[1,2]
       end
 
       def last_updates_are_missing?

--- a/lib/tariff_synchronizer/chief_update.rb
+++ b/lib/tariff_synchronizer/chief_update.rb
@@ -32,8 +32,6 @@ module TariffSynchronizer
         CSV.parse(cvs_string)
       rescue CSV::MalformedCSVError => e
         raise InvalidContents.new(e.message, e)
-      else
-        true
       end
     end
   end

--- a/lib/tariff_synchronizer/chief_update.rb
+++ b/lib/tariff_synchronizer/chief_update.rb
@@ -13,14 +13,6 @@ module TariffSynchronizer
       def update_type
         :chief
       end
-
-      def rebuild
-        Dir[File.join(Rails.root, TariffSynchronizer.root_path, 'chief', '*.txt')].each do |file_path|
-          date, file_name = parse_file_path(file_path)
-
-          create_update_entry(Date.parse(date), BaseUpdate::PENDING_STATE, Pathname.new(file_path).basename.to_s)
-        end
-      end
     end
 
     def import!

--- a/lib/tariff_synchronizer/chief_update.rb
+++ b/lib/tariff_synchronizer/chief_update.rb
@@ -27,9 +27,9 @@ module TariffSynchronizer
 
     private
 
-    def self.validate_file!(response)
+    def self.validate_file!(cvs_string)
       begin
-        CSV.parse(response.content)
+        CSV.parse(cvs_string)
       rescue CSV::MalformedCSVError => e
         raise InvalidContents.new(e.message, e)
       else

--- a/lib/tariff_synchronizer/logger.rb
+++ b/lib/tariff_synchronizer/logger.rb
@@ -82,14 +82,6 @@ module TariffSynchronizer
       Mailer.file_not_found_on_filesystem(event.payload[:path]).deliver_now
     end
 
-    def created_chief(event)
-      info "Created/Updated CHIEF entry for #{event.payload[:date]} and #{event.payload[:filename]}"
-    end
-
-    def created_taric(event)
-      info "Created/Updated TARIC entry for #{event.payload[:date]} and #{event.payload[:filename]}"
-    end
-
     def created_tariff(event)
       info "Created/Updated #{event.payload[:type].upcase}  entry for #{event.payload[:date]} and #{event.payload[:filename]}"
     end
@@ -98,19 +90,9 @@ module TariffSynchronizer
       info "Downloaded #{event.payload[:type].upcase} update for #{event.payload[:date]} at #{event.payload[:url]}, looking for file #{event.payload[:filename]}"
     end
 
-    # Download chief update
-    def download_chief(event)
-      info "Downloaded CHIEF update for #{event.payload[:date]} at #{event.payload[:url]}, looking for file #{event.payload[:filename]}"
-    end
-
     # Apply CHIEF update
     def apply_chief(event)
       info "Applied CHIEF update #{event.payload[:filename]}"
-    end
-
-    # Download TARIC update
-    def download_taric(event)
-      info "Downloaded TARIC update for #{event.payload[:date]} at #{event.payload[:url]}"
     end
 
     # Apply TARIC update

--- a/lib/tariff_synchronizer/taric_file_name_generator.rb
+++ b/lib/tariff_synchronizer/taric_file_name_generator.rb
@@ -11,7 +11,8 @@ class TaricFileNameGenerator
   end
 
   def get_info_from_response(string)
-    string.split("\n")
+    string
+      .split("\n")
       .map { |name| remove_invalid_characters(name) }
       .map { |name| { filename: local_filename(name), url: update_url(name) } }
   end

--- a/lib/tariff_synchronizer/taric_file_name_generator.rb
+++ b/lib/tariff_synchronizer/taric_file_name_generator.rb
@@ -1,5 +1,4 @@
 class TaricFileNameGenerator
-
   attr_reader :date
   delegate :taric_query_url_template, :taric_update_url_template, :host, to: TariffSynchronizer
 
@@ -12,9 +11,9 @@ class TaricFileNameGenerator
   end
 
   def get_info_from_response(string)
-    string.split("\n").
-    map {|name| remove_invalid_characters(name)}.
-    map {|name| {filename: local_filename(name), url: update_url(name)} }
+    string.split("\n")
+      .map { |name| remove_invalid_characters(name) }
+      .map { |name| { filename: local_filename(name), url: update_url(name) } }
   end
 
   private
@@ -28,6 +27,6 @@ class TaricFileNameGenerator
   end
 
   def remove_invalid_characters(name)
-    name.gsub(/[^0-9a-zA-Z\.]/i, '')
+    name.gsub(/[^0-9a-zA-Z\.]/i, "")
   end
 end

--- a/lib/tariff_synchronizer/taric_file_name_generator.rb
+++ b/lib/tariff_synchronizer/taric_file_name_generator.rb
@@ -1,7 +1,7 @@
 class TaricFileNameGenerator
 
   attr_reader :date
-  delegate :taric_query_url_template, :host, to: TariffSynchronizer
+  delegate :taric_query_url_template, :taric_update_url_template, :host, to: TariffSynchronizer
 
   def initialize(date)
     @date = date
@@ -9,5 +9,25 @@ class TaricFileNameGenerator
 
   def url
     format(taric_query_url_template, host: host, date: date.strftime("%Y%m%d"))
+  end
+
+  def get_info_from_response(string)
+    string.split("\n").
+    map {|name| remove_invalid_characters(name)}.
+    map {|name| {filename: local_filename(name), url: update_url(name)} }
+  end
+
+  private
+
+  def update_url(name)
+    format(taric_update_url_template, host: host, filename: name)
+  end
+
+  def local_filename(name)
+    "#{date}_#{name}"
+  end
+
+  def remove_invalid_characters(name)
+    name.gsub(/[^0-9a-zA-Z\.]/i, '')
   end
 end

--- a/lib/tariff_synchronizer/taric_update.rb
+++ b/lib/tariff_synchronizer/taric_update.rb
@@ -29,7 +29,7 @@ module TariffSynchronizer
                               }
 
             taric_updates.each do |taric_update|
-              local_file_name = file_name_for(date, taric_update.file_name)
+              local_file_name = "#{date}_#{taric_update.file_name}"
               perform_download(local_file_name, taric_update.url, date)
             end
           else
@@ -48,10 +48,6 @@ module TariffSynchronizer
             false
           end
         end
-      end
-
-      def file_name_for(date, update_name)
-        "#{date}_#{update_name}"
       end
 
       def update_type

--- a/lib/tariff_synchronizer/taric_update.rb
+++ b/lib/tariff_synchronizer/taric_update.rb
@@ -71,10 +71,8 @@ module TariffSynchronizer
 
     def self.validate_file!(xml_string)
       begin
-        Nokogiri::XML(xml_string) do |config|
-          config.options = Nokogiri::XML::ParseOptions::STRICT
-        end
-      rescue Nokogiri::XML::SyntaxError => e
+        Ox.parse(xml_string)
+      rescue Ox::ParseError => e
         raise InvalidContents.new(e.message, e)
       else
         true

--- a/lib/tariff_synchronizer/taric_update.rb
+++ b/lib/tariff_synchronizer/taric_update.rb
@@ -74,8 +74,6 @@ module TariffSynchronizer
         Ox.parse(xml_string)
       rescue Ox::ParseError => e
         raise InvalidContents.new(e.message, e)
-      else
-        true
       end
     end
   end

--- a/lib/tariff_synchronizer/taric_update.rb
+++ b/lib/tariff_synchronizer/taric_update.rb
@@ -53,14 +53,6 @@ module TariffSynchronizer
       def update_type
         :taric
       end
-
-      def rebuild
-        Dir[File.join(Rails.root, TariffSynchronizer.root_path, 'taric', '*.xml')].each do |file_path|
-          date, file_name = parse_file_path(file_path)
-
-          create_update_entry(Date.parse(date), BaseUpdate::PENDING_STATE, Pathname.new(file_path).basename.to_s)
-        end
-      end
     end
 
     def import!

--- a/lib/tariff_synchronizer/taric_update.rb
+++ b/lib/tariff_synchronizer/taric_update.rb
@@ -33,19 +33,19 @@ module TariffSynchronizer
       private
 
       def create_record_for_empty_response(date, response)
-        create_update_entry(date, BaseUpdate::FAILED_STATE, missing_update_name_for(date))
+        create_or_update(date, BaseUpdate::FAILED_STATE, missing_update_name_for(date))
         instrument("blank_update.tariff_synchronizer", date: date, url: response.url)
       end
 
       def create_record_for_retries_exceeded(date, response)
-        create_update_entry(date, BaseUpdate::FAILED_STATE, missing_update_name_for(date))
+        create_or_update(date, BaseUpdate::FAILED_STATE, missing_update_name_for(date))
         instrument("retry_exceeded.tariff_synchronizer", date: date, url: response.url)
       end
 
       def create_missing_record(date, initial_url)
         # Do not create missing record until we are sure until the next day
         if date < Date.current
-          create_update_entry(date, BaseUpdate::MISSING_STATE, missing_update_name_for(date))
+          create_or_update(date, BaseUpdate::MISSING_STATE, missing_update_name_for(date))
           instrument("not_found.tariff_synchronizer", date: date, url: initial_url)
         end
       end

--- a/lib/tariff_synchronizer/taric_update.rb
+++ b/lib/tariff_synchronizer/taric_update.rb
@@ -69,9 +69,9 @@ module TariffSynchronizer
       update(filesize: File.size(file_path))
     end
 
-    def self.validate_file!(response)
+    def self.validate_file!(xml_string)
       begin
-        Nokogiri::XML(response.content) do |config|
+        Nokogiri::XML(xml_string) do |config|
           config.options = Nokogiri::XML::ParseOptions::STRICT
         end
       rescue Nokogiri::XML::SyntaxError => e

--- a/lib/tariff_synchronizer/taric_update.rb
+++ b/lib/tariff_synchronizer/taric_update.rb
@@ -77,6 +77,10 @@ module TariffSynchronizer
 
     private
 
+    def update_file_size(file_path)
+      update(filesize: File.size(file_path))
+    end
+
     def self.validate_file!(response)
       begin
         Nokogiri::XML(response.content) do |config|

--- a/lib/tariff_synchronizer/taric_update.rb
+++ b/lib/tariff_synchronizer/taric_update.rb
@@ -58,14 +58,14 @@ module TariffSynchronizer
     def import!
       instrument("apply_taric.tariff_synchronizer", filename: filename) do
         TaricImporter.new(file_path, issue_date).import
-        update_file_size(file_path)
+        update_file_size
         mark_as_applied
       end
     end
 
     private
 
-    def update_file_size(file_path)
+    def update_file_size
       update(filesize: File.size(file_path))
     end
 

--- a/spec/factories/taric_update_factory.rb
+++ b/spec/factories/taric_update_factory.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :taric_update, parent: :base_update, class: TariffSynchronizer::TaricUpdate do
     issue_date { example_date }
-    filename { TariffSynchronizer::TaricUpdate.file_name_for(example_date, "TGB#{example_date.strftime("%y")}#{example_date.yday}.xml")  }
+    filename { "#{example_date}_TGB#{example_date.strftime("%y")}#{example_date.yday}.xml"  }
     update_type { 'TariffSynchronizer::TaricUpdate' }
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -73,6 +73,3 @@ RSpec.configure do |config|
     DatabaseCleaner.clean
   end
 end
-
-
-TariffSynchronizer.host = "http://example.com"

--- a/spec/support/adjust_tariff_synchronizer.rb
+++ b/spec/support/adjust_tariff_synchronizer.rb
@@ -2,3 +2,4 @@ TariffSynchronizer.request_throttle = 0
 TariffSynchronizer.retry_count = 1
 TariffSynchronizer.exception_retry_count = 1
 TariffSynchronizer.root_path = "tmp/data"
+TariffSynchronizer.host = "http://example.com"

--- a/spec/unit/tariff_synchronizer/logger_spec.rb
+++ b/spec/unit/tariff_synchronizer/logger_spec.rb
@@ -420,7 +420,7 @@ describe TariffSynchronizer::Logger, truncation: true do
       allow(TariffSynchronizer::ChiefUpdate).to receive(:download_content)
                                              .and_return(success_response)
       # Stub creation of the record
-      allow(TariffSynchronizer::ChiefUpdate).to receive(:create_update_entry)
+      allow(TariffSynchronizer::ChiefUpdate).to receive(:create_or_update)
                                              .and_return(nil)
       # Simulate I/O exception
       allow(File).to receive(:open).and_raise(Errno::EACCES)

--- a/spec/unit/tariff_synchronizer/logger_spec.rb
+++ b/spec/unit/tariff_synchronizer/logger_spec.rb
@@ -306,45 +306,6 @@ describe TariffSynchronizer::Logger, truncation: true do
     end
   end
 
-  describe '#download_chief logging' do
-    let(:success_response) { build :response, :success }
-
-    before {
-      # Download mock response
-      expect(TariffSynchronizer::ChiefUpdate).to receive(:download_content).and_return(success_response)
-      # Do not write file to file system
-      expect(TariffSynchronizer::ChiefUpdate).to receive(:create_entry).and_return(true)
-      # Actual Download
-      TariffSynchronizer::ChiefUpdate.download(Date.today)
-    }
-
-    it 'logs an info event' do
-      expect(@logger.logged(:info).size).to eq 1
-      expect(@logger.logged(:info).last).to match /Downloaded CHIEF update/
-    end
-  end
-
-  describe '#download_taric logging' do
-    let(:success_response) { build :response, :success }
-    let(:query_response) { build :response, :success, :content => 'file_name', :url => 'url' }
-
-    before {
-      # Skip Taric update file name fetching
-      expect(TaricFileNameGenerator).to receive(:new).and_return(query_response)
-      # Download mock response
-      expect(TariffSynchronizer::TaricUpdate).to receive(:download_content).and_return(success_response).twice
-      # Do not write file to file system
-      expect(TariffSynchronizer::TaricUpdate).to receive(:create_entry).and_return(true)
-      # Actual Download
-      TariffSynchronizer::TaricUpdate.download(Date.today)
-    }
-
-    it 'logs an info event' do
-      expect(@logger.logged(:info).size).to eq 2
-      expect(@logger.logged(:info).last).to match /Downloaded TARIC update/
-    end
-  end
-
   describe '#get_taric_update_name logging' do
     let(:not_found_response) { build :response, :not_found }
 

--- a/spec/unit/tariff_synchronizer/logger_spec.rb
+++ b/spec/unit/tariff_synchronizer/logger_spec.rb
@@ -345,28 +345,6 @@ describe TariffSynchronizer::Logger, truncation: true do
     end
   end
 
-  describe '#apply_taric logging' do
-    let(:taric_update) { create :taric_update }
-
-    before {
-      # Test in isolation, file is not actually in the file system
-      # so bypass the check
-      expect(File).to receive(:exist?)
-                  .with(taric_update.file_path)
-                  .twice
-                  .and_return(true)
-
-      rescuing {
-        taric_update.apply
-      }
-    }
-
-    it 'logs an info event' do
-      expect(@logger.logged(:info).size).to eq 1
-      expect(@logger.logged(:info).last).to match /Applied TARIC update/
-    end
-  end
-
   describe '#get_taric_update_name logging' do
     let(:not_found_response) { build :response, :not_found }
 

--- a/spec/unit/tariff_synchronizer/taric_file_name_generator_spec.rb
+++ b/spec/unit/tariff_synchronizer/taric_file_name_generator_spec.rb
@@ -3,11 +3,27 @@ require 'tariff_synchronizer/taric_file_name_generator'
 
 describe TaricFileNameGenerator do
   let(:example_date){ Date.new(2010,1,1) }
-  let(:taric_file_name_generator) { TaricFileNameGenerator.new(example_date) }
+  let(:name_generator) { TaricFileNameGenerator.new(example_date) }
 
   describe "#url" do
     it "returns the expected url to have the taric file for a specific date" do
-      expect(taric_file_name_generator.url).to eq("http://example.com/taric/TARIC320100101")
+      expect(name_generator.url).to eq("http://example.com/taric/TARIC320100101")
+    end
+  end
+
+  describe "#get_info_from_response" do
+    it "returns an array containing a hash with filename and url" do
+      result = name_generator.get_info_from_response("XYZ.xml")
+      expect(result[0][:filename]).to eq("2010-01-01_XYZ.xml")
+      expect(result[0][:url]).to eq("http://example.com/taric/XYZ.xml")
+    end
+
+    it "returns an array containing multiple hashes if return multiple files" do
+      result = name_generator.get_info_from_response("ABC.xml\nXYZ.xml")
+      expect(result[0][:filename]).to eq("2010-01-01_ABC.xml")
+      expect(result[0][:url]).to eq("http://example.com/taric/ABC.xml")
+      expect(result[1][:filename]).to eq("2010-01-01_XYZ.xml")
+      expect(result[1][:url]).to eq("http://example.com/taric/XYZ.xml")
     end
   end
 end

--- a/spec/unit/tariff_synchronizer/taric_update_spec.rb
+++ b/spec/unit/tariff_synchronizer/taric_update_spec.rb
@@ -314,9 +314,9 @@ describe TariffSynchronizer::TaricUpdate do
 
   describe "#apply", truncation: true do
     let(:state) { :pending }
-    let!(:example_taric_update) { create :taric_update, example_date: example_date }
 
     before do
+      create :taric_update, example_date: example_date
       prepare_synchronizer_folders
       create_taric_file example_date
     end
@@ -376,13 +376,11 @@ describe TariffSynchronizer::TaricUpdate do
     end
 
     context "entry for the day/update exists already" do
-      let!(:example_taric_update) { create :taric_update, example_date: example_date }
-
       it "does not create db record if it is already available for the day/update type combo" do
+        create :taric_update, example_date: example_date
+
         expect(TariffSynchronizer::BaseUpdate.count).to eq 1
-
         TariffSynchronizer::TaricUpdate.rebuild
-
         expect(TariffSynchronizer::BaseUpdate.count).to eq 1
       end
     end

--- a/spec/unit/tariff_synchronizer/taric_update_spec.rb
+++ b/spec/unit/tariff_synchronizer/taric_update_spec.rb
@@ -1,17 +1,17 @@
-require 'rails_helper'
-require 'tariff_synchronizer'
+require "rails_helper"
+require "tariff_synchronizer"
 
 describe TariffSynchronizer::TaricUpdate do
-  it_behaves_like 'Base Update'
+  it_behaves_like "Base Update"
 
   let(:example_date) { Forgery(:date).date }
 
-  describe '.download' do
+  describe ".download" do
     let(:taric_update_name)  { "TGB#{example_date.strftime("%y")}#{example_date.yday}.xml" }
     let(:taric_query_url)    { "#{TariffSynchronizer.host}/taric/TARIC3#{example_date.strftime("%Y%m%d")}" }
     let(:blank_response)     { build :response, content: nil }
     let(:not_found_response) { build :response, :not_found }
-    let(:success_response)   { build :response, :success, content: 'abc' }
+    let(:success_response)   { build :response, :success, content: "abc" }
     let(:failed_response)    { build :response, :failed }
     let(:update_url)         { "#{TariffSynchronizer.host}/taric/#{taric_update_name}" }
 
@@ -41,9 +41,9 @@ describe TariffSynchronizer::TaricUpdate do
                                        .and_return(query_response)
       end
 
-      context 'update not downloaded yet' do
+      context "update not downloaded yet" do
 
-        it 'downloads Taric file for specific date' do
+        it "downloads Taric file for specific date" do
           expect(TariffSynchronizer::TaricUpdate).to receive(:download_content)
                                          .with(update_url)
                                          .and_return(blank_response)
@@ -51,7 +51,7 @@ describe TariffSynchronizer::TaricUpdate do
           TariffSynchronizer::TaricUpdate.download(example_date)
         end
 
-        it 'writes Taric file contents to file if they are not blank' do
+        it "writes Taric file contents to file if they are not blank" do
           expect(TariffSynchronizer::TaricUpdate).to receive(:download_content)
                                          .with(update_url)
                                          .and_return(success_response)
@@ -60,10 +60,10 @@ describe TariffSynchronizer::TaricUpdate do
 
           file_path = "#{TariffSynchronizer.root_path}/taric/#{local_file_name}"
           expect(File.exist?(file_path)).to be_truthy
-          expect(File.read(file_path)).to eq 'abc'
+          expect(File.read(file_path)).to eq "abc"
         end
 
-        it 'does not write Taric file contents to file if they are blank' do
+        it "does not write Taric file contents to file if they are blank" do
           expect(TariffSynchronizer::TaricUpdate).to receive(:download_content)
                                          .with(update_url)
                                          .and_return(blank_response)
@@ -93,7 +93,7 @@ describe TariffSynchronizer::TaricUpdate do
     end
 
 
-    context 'update already downloaded' do
+    context "update already downloaded" do
       let(:query_response) do
         build :response, :success, url: taric_query_url, content: taric_update_name
       end
@@ -109,10 +109,10 @@ describe TariffSynchronizer::TaricUpdate do
         expect(TariffSynchronizer::TaricUpdate).to receive(
           :download_content).with(taric_query_url).and_return(query_response)
         file_path = "#{TariffSynchronizer.root_path}/taric/#{local_file_name}"
-        File.new(file_path, "w").write('abc')
+        File.new(file_path, "w").write("abc")
       end
 
-      it 'does not download TARIC file for date' do
+      it "does not download TARIC file for date" do
         expect(TariffSynchronizer::TaricUpdate).to receive(:download_content)
                                        .with(update_url)
                                        .never
@@ -120,7 +120,7 @@ describe TariffSynchronizer::TaricUpdate do
         TariffSynchronizer::TaricUpdate.download(example_date)
       end
 
-      it 'does not create additional TaricUpdate entries' do
+      it "does not create additional TaricUpdate entries" do
         TariffSynchronizer::TaricUpdate.download(example_date)
         expect(
           TariffSynchronizer::TaricUpdate.where(issue_date: example_date).count
@@ -133,18 +133,18 @@ describe TariffSynchronizer::TaricUpdate do
       let(:query_response)     { build :response, :success, url: taric_query_url,
                                                             content: taric_update_names.join("\n") }
       let(:taric_update_url)    { "#{TariffSynchronizer.host}/taric/%{name}" }
-      let(:success_response_1)  { build :response, :success, content: 'abc' }
-      let(:success_response_2)  { build :response, :success, content: 'def' }
+      let(:success_response_1)  { build :response, :success, content: "abc" }
+      let(:success_response_2)  { build :response, :success, content: "def" }
 
-      before {
+      before do
         expect(TariffSynchronizer::TaricUpdate).to receive(:download_content)
                                        .with(taric_query_url)
                                        .and_return(query_response)
-      }
+      end
 
       after  { purge_synchronizer_folders }
 
-      it 'downloads Taric file for specific date' do
+      it "downloads Taric file for specific date" do
         taric_update_names.each do |name|
           expect(TariffSynchronizer::TaricUpdate).to receive(:download_content)
                                          .with(taric_update_url % { name: name })
@@ -154,7 +154,7 @@ describe TariffSynchronizer::TaricUpdate do
         TariffSynchronizer::TaricUpdate.download(example_date)
       end
 
-      it 'writes Taric file contents to file if they are not blank' do
+      it "writes Taric file contents to file if they are not blank" do
         expect(TariffSynchronizer::TaricUpdate).to receive(:download_content)
                                        .with(taric_update_url % { name: taric_update_names.first })
                                        .and_return(success_response_1)
@@ -168,12 +168,12 @@ describe TariffSynchronizer::TaricUpdate do
         second_file_path = "#{TariffSynchronizer.root_path}/taric/#{local_file_name(taric_update_names.last)}"
 
         expect(File.exist?(first_file_path)).to be_truthy
-        expect(File.read(first_file_path)).to eq 'abc'
+        expect(File.read(first_file_path)).to eq "abc"
         expect(File.exist?(second_file_path)).to be_truthy
-        expect(File.read(second_file_path)).to eq 'def'
+        expect(File.read(second_file_path)).to eq "def"
       end
 
-      it 'does not write Taric file contents to file if they are blank' do
+      it "does not write Taric file contents to file if they are blank" do
         expect(TariffSynchronizer::TaricUpdate).to receive(:download_content)
                                        .with(taric_update_url % { name: taric_update_names.first })
                                        .and_return(blank_response)
@@ -192,13 +192,13 @@ describe TariffSynchronizer::TaricUpdate do
       end
     end
 
-    context 'when file for the day is not found' do
-      before {
+    context "when file for the day is not found" do
+      before do
         expect(TariffSynchronizer::TaricUpdate).to receive(:download_content)
                                        .and_return(not_found_response)
-      }
+      end
 
-      it 'does not write Taric file contents to file' do
+      it "does not write Taric file contents to file" do
         TariffSynchronizer::TaricUpdate.download(example_date)
 
         expect(
@@ -206,7 +206,7 @@ describe TariffSynchronizer::TaricUpdate do
         ).to be_falsy
       end
 
-      it 'does not create not found entry if update is still for today' do
+      it "does not create not found entry if update is still for today" do
         TariffSynchronizer::TaricUpdate.download(Date.current)
 
         expect(
@@ -216,7 +216,7 @@ describe TariffSynchronizer::TaricUpdate do
         ).to be_falsy
       end
 
-      it 'creates not found entry if date has passed' do
+      it "creates not found entry if date has passed" do
         TariffSynchronizer::TaricUpdate.download(Date.yesterday)
 
         expect(
@@ -227,11 +227,11 @@ describe TariffSynchronizer::TaricUpdate do
       end
     end
 
-    context 'retry count exceeded (failed update)' do
+    context "retry count exceeded (failed update)" do
       let(:update_url)   { "#{TariffSynchronizer.host}/taric/abc" }
       let(:example_date) { Date.yesterday }
 
-      before {
+      before do
         TariffSynchronizer.retry_count = 1
 
         expect(TariffSynchronizer::TaricUpdate).to receive(:send_request)
@@ -244,15 +244,15 @@ describe TariffSynchronizer::TaricUpdate do
                                        .and_return(failed_response)
 
         TariffSynchronizer::TaricUpdate.download(example_date)
-      }
+      end
 
-      it 'does not write file to file system' do
+      it "does not write file to file system" do
         expect(
           File.exist?("#{TariffSynchronizer.root_path}/taric/#{example_date}_#{taric_update_name}")
         ).to be_falsy
       end
 
-      it 'creates failed update entry' do
+      it "creates failed update entry" do
         expect(
           TariffSynchronizer::TaricUpdate.failed
                                        .with_issue_date(example_date)
@@ -261,11 +261,11 @@ describe TariffSynchronizer::TaricUpdate do
       end
     end
 
-    context 'downloaded file is blank' do
+    context "downloaded file is blank" do
       let(:update_url) { "#{TariffSynchronizer.host}/taric/abc" }
-      let(:blank_success_response)   { build :response, :success, content: '' }
+      let(:blank_success_response) { build :response, :success, content: "" }
 
-      before {
+      before do
         expect(TariffSynchronizer::TaricUpdate).to receive(:send_request)
                                        .with(taric_query_url)
                                        .and_return(success_response)
@@ -275,15 +275,15 @@ describe TariffSynchronizer::TaricUpdate do
                                        .and_return(blank_success_response)
 
         TariffSynchronizer::TaricUpdate.download(example_date)
-      }
+      end
 
-      it 'does not write file to file system' do
+      it "does not write file to file system" do
         expect(
           File.exist?("#{TariffSynchronizer.root_path}/taric/#{example_date}_#{taric_update_name}")
         ).to be_falsy
       end
 
-      it 'creates failed update entry' do
+      it "creates failed update entry" do
         expect(
           TariffSynchronizer::TaricUpdate.failed
                                        .with_issue_date(example_date)
@@ -316,20 +316,20 @@ describe TariffSynchronizer::TaricUpdate do
     let(:state) { :pending }
     let!(:example_taric_update) { create :taric_update, example_date: example_date }
 
-    before {
+    before do
       prepare_synchronizer_folders
       create_taric_file example_date
-    }
+    end
 
-    it 'executes Taric importer' do
-      mock_importer = double('importer').as_null_object
+    it "executes Taric importer" do
+      mock_importer = double("importer").as_null_object
       expect(TariffImporter).to receive(:new).and_return(mock_importer)
 
       TariffSynchronizer::TaricUpdate.first.apply
     end
 
-    it 'updates file entry state to processed' do
-      mock_importer = double('importer').as_null_object
+    it "updates file entry state to processed" do
+      mock_importer = double("importer").as_null_object
       expect(TariffImporter).to receive(:new).and_return(mock_importer)
 
       expect(TariffSynchronizer::TaricUpdate.pending.count).to eq 1
@@ -338,7 +338,7 @@ describe TariffSynchronizer::TaricUpdate do
       expect(TariffSynchronizer::TaricUpdate.applied.count).to eq 1
     end
 
-    it 'does not move file to processed if import fails' do
+    it "does not move file to processed if import fails" do
       mock_importer = double
       expect(mock_importer).to receive(:import).and_raise(TaricImporter::ImportException)
       expect(TariffImporter).to receive(:new).and_return(mock_importer)
@@ -355,16 +355,16 @@ describe TariffSynchronizer::TaricUpdate do
     after  { purge_synchronizer_folders }
   end
 
-  describe '.rebuild' do
-    before {
+  describe ".rebuild" do
+    before do
       prepare_synchronizer_folders
       create_taric_file example_date
-    }
+    end
 
     after { purge_synchronizer_folders }
 
-    context 'entry for the day/update does not exist yet' do
-      it 'creates db record from available file name' do
+    context "entry for the day/update does not exist yet" do
+      it "creates db record from available file name" do
         expect(TariffSynchronizer::BaseUpdate.count).to eq 0
 
         TariffSynchronizer::TaricUpdate.rebuild
@@ -375,10 +375,10 @@ describe TariffSynchronizer::TaricUpdate do
       end
     end
 
-    context 'entry for the day/update exists already' do
+    context "entry for the day/update exists already" do
       let!(:example_taric_update) { create :taric_update, example_date: example_date }
 
-      it 'does not create db record if it is already available for the day/update type combo' do
+      it "does not create db record if it is already available for the day/update type combo" do
         expect(TariffSynchronizer::BaseUpdate.count).to eq 1
 
         TariffSynchronizer::TaricUpdate.rebuild
@@ -420,7 +420,7 @@ describe TariffSynchronizer::TaricUpdate do
       expect(taric_update.reload).to be_applied
     end
 
-    it 'logs an info event' do
+    it "logs an info event" do
       tariff_synchronizer_logger_listener
       allow_any_instance_of(TaricImporter).to receive(:import)
       taric_update.import!

--- a/spec/unit/tariff_synchronizer/taric_update_spec.rb
+++ b/spec/unit/tariff_synchronizer/taric_update_spec.rb
@@ -87,7 +87,7 @@ describe TariffSynchronizer::TaricUpdate do
         it "marks an update as failed if the file contents cannot be parsed" do
           TariffSynchronizer::TaricUpdate.download(example_date)
           update_entry = TariffSynchronizer::TaricUpdate.last
-          expect(update_entry.exception_class).to include("XML::SyntaxError")
+          expect(update_entry.exception_class).to include("Ox::ParseError: invalid format")
         end
       end
     end


### PR DESCRIPTION
#### What this PR does:

- Move `update_file_size` method from BaseUpdate to TaricUpdate where is the only place used.
- Move TariffSynchronizer.host test initialization to `support/adjust_tariff_synchronizer.rb`
- Add tests for the `import!` method in `TaricUpdate` class
- Remove deprecations
- Remove duplication in the `rebuild` method, move this method to `BaseUpdate` and validate files
- Remove mocking of exceptions, this was leading to false positives.
- Replace Nokogiri for xml validations with Ox
-Add `get_info_from_response` method to `TaricFileNameGenerator` class to help get the filenames and urls from the initial request for Taric Updates.
- Refactor `download` method from TariffSynchronizer implementing to the  `get_info_from_response` method.
- Remove unused logger methods. YAGNI
- Ruby style updates
- Extract methods from `download` in TaricUpdate.


#### Notes

This PR is ready for code review, this is part of a bigger refactor to reduce complexity and add more test coverage.