### PR TITLE
Tariff updates

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,40 +7,40 @@ Rails.application.routes.draw do
     # How (or even if) API versioning will be implemented is still an open question. We can defer
     # the choice until we need to expose the API to clients which we don't control.
     scope module: :v1, constraints: ApiConstraints.new(version: 1, default: true) do
-      resources :sections, only: [:index, :show], constraints: { id: /\d+/ } do
-        scope module: 'sections', constraints: { section_id: /\d+/, id: /\d+/ } do
+      resources :sections, only: [:index, :show], constraints: { id: /\d{1,2}/ } do
+        scope module: 'sections', constraints: { section_id: /\d{1,2}/, id: /\d+/ } do
           resource :section_note, only: [:show, :create, :update, :destroy]
           resources :search_references, only: [:show, :index, :destroy, :create, :update]
         end
       end
 
-      resources :chapters, only: [:index, :show], constraints: { id: /\d+/ } do
+      resources :chapters, only: [:index, :show], constraints: { id: /\d{2}/ } do
         member {
           get :changes
         }
 
-        scope module: 'chapters', constraints: { chapter_id: /\d+/, id: /\d+/ } do
+        scope module: 'chapters', constraints: { chapter_id: /\d{2}/, id: /\d+/ } do
           resource :chapter_note, only: [:show, :create, :update, :destroy]
           resources :search_references, only: [:show, :index, :destroy, :create, :update]
         end
       end
 
-      resources :headings, only: [:show], constraints: { id: /\d+/ } do
+      resources :headings, only: [:show], constraints: { id: /\d{4}/ } do
         member {
           get :changes
         }
 
-        scope module: 'headings', constraints: { heading_id: /\d+/, id: /\d+/ } do
+        scope module: 'headings', constraints: { heading_id: /\d{4}/, id: /\d+/ } do
           resources :search_references, only: [:show, :index, :destroy, :create, :update]
         end
       end
 
-      resources :commodities, only: [:show], constraints: { id: /\d+/ } do
+      resources :commodities, only: [:show], constraints: { id: /\d{10}/ } do
         member {
           get :changes
         }
 
-        scope module: 'commodities', constraints: { commodity_id: /\d+/, id: /\d+/ } do
+        scope module: 'commodities', constraints: { commodity_id: /\d{10}/, id: /\d+/ } do
           resources :search_references, only: [:show, :index, :destroy, :create, :update]
         end
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,40 +7,40 @@ Rails.application.routes.draw do
     # How (or even if) API versioning will be implemented is still an open question. We can defer
     # the choice until we need to expose the API to clients which we don't control.
     scope module: :v1, constraints: ApiConstraints.new(version: 1, default: true) do
-      resources :sections, only: [:index, :show], constraints: { id: /\d{1,4}/ } do
-        scope module: 'sections', constraints: { section_id: /\d{1,2}/, id: /\d+/ } do
+      resources :sections, only: [:index, :show], constraints: { id: /\d+/ } do
+        scope module: 'sections', constraints: { section_id: /\d+/, id: /\d+/ } do
           resource :section_note, only: [:show, :create, :update, :destroy]
           resources :search_references, only: [:show, :index, :destroy, :create, :update]
         end
       end
 
-      resources :chapters, only: [:index, :show], constraints: { id: /\d{2}/ } do
+      resources :chapters, only: [:index, :show], constraints: { id: /\d+/ } do
         member {
           get :changes
         }
 
-        scope module: 'chapters', constraints: { chapter_id: /\d{2}/, id: /\d+/ } do
+        scope module: 'chapters', constraints: { chapter_id: /\d+/, id: /\d+/ } do
           resource :chapter_note, only: [:show, :create, :update, :destroy]
           resources :search_references, only: [:show, :index, :destroy, :create, :update]
         end
       end
 
-      resources :headings, only: [:show], constraints: { id: /\d{4}/ } do
+      resources :headings, only: [:show], constraints: { id: /\d+/ } do
         member {
           get :changes
         }
 
-        scope module: 'headings', constraints: { heading_id: /\d{4}/, id: /\d+/ } do
+        scope module: 'headings', constraints: { heading_id: /\d+/, id: /\d+/ } do
           resources :search_references, only: [:show, :index, :destroy, :create, :update]
         end
       end
 
-      resources :commodities, only: [:show], constraints: { id: /\d{10}/ } do
+      resources :commodities, only: [:show], constraints: { id: /\d+/ } do
         member {
           get :changes
         }
 
-        scope module: 'commodities', constraints: { commodity_id: /\d{10}/, id: /\d+/ } do
+        scope module: 'commodities', constraints: { commodity_id: /\d+/, id: /\d+/ } do
           resources :search_references, only: [:show, :index, :destroy, :create, :update]
         end
       end

--- a/lib/tariff_synchronizer/base_update.rb
+++ b/lib/tariff_synchronizer/base_update.rb
@@ -204,10 +204,6 @@ module TariffSynchronizer
         TariffDownloader.new(local_file_name, tariff_url, date, self).perform
       end
 
-      def update_file_exists?(filename)
-        dataset.where(filename: filename).present?
-      end
-
       def update_type
         raise "Update Type should be specified in inheriting class"
       end
@@ -233,10 +229,6 @@ module TariffSynchronizer
           update_type: self.name,
           issue_date: date
         ).update(state: state, filesize: filesize)
-      end
-
-      def missing_update_name_for(date)
-        "#{date}_#{update_type}"
       end
 
       def pending_from

--- a/lib/tariff_synchronizer/logger.rb
+++ b/lib/tariff_synchronizer/logger.rb
@@ -153,10 +153,6 @@ module TariffSynchronizer
       info "Giving up fetching: #{event.payload[:url]}, too many DownloadExceptions"
     end
 
-    def invalid_contents
-      error "File contents are not parseable for #{event.payload[:date]}"
-    end
-
     # We missed three update files in a row
     # Might be okay for Taric, but most likely not ok for CHIEF
     # this is precautionary measure

--- a/lib/tariff_synchronizer/response.rb
+++ b/lib/tariff_synchronizer/response.rb
@@ -6,8 +6,6 @@ module TariffSynchronizer
 
     attr_reader :response_code, :url
 
-    delegate :present?, :size, to: :content, prefix: true, allow_nil: true
-
     def initialize(url, response_code, content)
       @url = url
       @response_code = response_code
@@ -37,6 +35,14 @@ module TariffSynchronizer
 
     def not_found?
       response_code == 404
+    end
+
+    def present?
+      response_code == 200 && @content.present?
+    end
+
+    def empty?
+      response_code == 200 && @content.empty?
     end
 
     def content

--- a/lib/tariff_synchronizer/taric_update.rb
+++ b/lib/tariff_synchronizer/taric_update.rb
@@ -13,11 +13,11 @@ module TariffSynchronizer
         instrument("get_taric_update_name.tariff_synchronizer", date: date, url: initial_url)
         response = download_content(initial_url)
 
-        if response.success? && response.content_present?
+        if response.present?
           generator.get_info_from_response(response.content).each do |update|
             perform_download(update[:filename], update[:url], date)
           end
-        elsif response.success? && !response.content_present?
+        elsif response.empty?
           create_record_for_empty_response(date, response)
         elsif response.retry_count_exceeded?
           create_record_for_retries_exceeded

--- a/lib/tariff_synchronizer/taric_update.rb
+++ b/lib/tariff_synchronizer/taric_update.rb
@@ -33,20 +33,24 @@ module TariffSynchronizer
       private
 
       def create_record_for_empty_response(date, response)
-        create_or_update(date, BaseUpdate::FAILED_STATE, missing_update_name_for(date))
+        create_or_update(date, BaseUpdate::FAILED_STATE, missing_filename(date))
         instrument("blank_update.tariff_synchronizer", date: date, url: response.url)
       end
 
       def create_record_for_retries_exceeded(date, response)
-        create_or_update(date, BaseUpdate::FAILED_STATE, missing_update_name_for(date))
+        create_or_update(date, BaseUpdate::FAILED_STATE, missing_filename(date))
         instrument("retry_exceeded.tariff_synchronizer", date: date, url: response.url)
       end
 
       def create_missing_record(date, initial_url)
         # Do not create missing record until we are sure until the next day
         return if date >= Date.current
-        create_or_update(date, BaseUpdate::MISSING_STATE, missing_update_name_for(date))
+        create_or_update(date, BaseUpdate::MISSING_STATE, missing_filename(date))
         instrument("not_found.tariff_synchronizer", date: date, url: initial_url)
+      end
+
+      def missing_filename(date)
+        "#{date}_#{update_type}"
       end
     end
 

--- a/lib/tariff_synchronizer/taric_update.rb
+++ b/lib/tariff_synchronizer/taric_update.rb
@@ -44,10 +44,9 @@ module TariffSynchronizer
 
       def create_missing_record(date, initial_url)
         # Do not create missing record until we are sure until the next day
-        if date < Date.current
-          create_or_update(date, BaseUpdate::MISSING_STATE, missing_update_name_for(date))
-          instrument("not_found.tariff_synchronizer", date: date, url: initial_url)
-        end
+        return if date >= Date.current
+        create_or_update(date, BaseUpdate::MISSING_STATE, missing_update_name_for(date))
+        instrument("not_found.tariff_synchronizer", date: date, url: initial_url)
       end
     end
 

--- a/lib/tariff_synchronizer/tariff_downloader.rb
+++ b/lib/tariff_synchronizer/tariff_downloader.rb
@@ -53,9 +53,9 @@ module TariffSynchronizer
     end
 
     def create_entry(response)
-      if response.success? && response.content_present?
+      if response.present?
         validate_and_create_update(response)
-      elsif response.success? && !response.content_present?
+      elsif response.empty?
         create_record_for_empty_response(response)
       elsif response.retry_count_exceeded?
         create_record_for_retries_exceeded(response)

--- a/lib/tariff_synchronizer/tariff_downloader.rb
+++ b/lib/tariff_synchronizer/tariff_downloader.rb
@@ -1,0 +1,108 @@
+# Download pending updates for TARIC and CHIEF data
+# Gets latest downloaded file present in (inbox/failbox/processed) and tries
+# to download any further updates to current day.
+# require "tariff_synchronizer/file_service"
+module TariffSynchronizer
+  class TariffDownloader
+    include FileService
+
+    delegate :instrument, :subscribe, to: ActiveSupport::Notifications
+
+    attr_reader :local_file_name, :tariff_url, :date, :update_klass
+
+    def initialize(local_file_name, tariff_url, date, update_klass)
+      @local_file_name = local_file_name
+      @tariff_url = tariff_url
+      @date = date
+      @update_klass = update_klass
+    end
+
+    def perform
+      if File.exists?(local_file_path)
+        if update = update_klass.find(filename: local_file_name, update_type: update_klass.name, issue_date: date)
+          update.update(filesize: File.read(local_file_path).size)
+        else
+          create_or_update(
+            date,
+            BaseUpdate::PENDING_STATE,
+            local_file_name,
+            File.read(local_file_path).size
+          )
+        end
+        instrument("created_tariff.tariff_synchronizer", date: date, filename: local_file_name, type: update_klass.update_type)
+      else
+        instrument("download_tariff.tariff_synchronizer", date: date, url: tariff_url, filename: local_file_name, type: update_klass.update_type) do
+          TariffDownloader.download_content(tariff_url).tap do |response|
+            create_entry(date, response, local_file_name)
+          end
+        end
+      end
+    end
+
+    private
+
+    def local_file_path
+      File.join(TariffSynchronizer.root_path, update_klass.update_type.to_s, local_file_name)
+    end
+
+    def create_entry(date, response, file_name)
+      if response.success? && response.content_present?
+        validate_and_create_update(date, response, file_name)
+      elsif response.success? && !response.content_present?
+        create_or_update(date, BaseUpdate::FAILED_STATE, file_name)
+        instrument("blank_update.tariff_synchronizer", date: date, url: response.url)
+      elsif response.retry_count_exceeded?
+        create_or_update(date, BaseUpdate::FAILED_STATE, file_name)
+        instrument("retry_exceeded.tariff_synchronizer", date: date, url: response.url)
+      elsif response.not_found?
+        if date < Date.current
+          create_or_update(date, BaseUpdate::MISSING_STATE, missing_update_name_for(date))
+          instrument("not_found.tariff_synchronizer", date: date, url: response.url)
+        end
+      end
+    end
+
+    def create_or_update(date, state, file_name, filesize = nil)
+      update_klass.find_or_create(
+        filename: file_name,
+        update_type: update_klass.name,
+        issue_date: date
+      ).update(state: state, filesize: filesize)
+    end
+
+    def validate_and_create_update(date, response, file_name)
+      begin
+        update_klass.validate_file!(response.content)
+      rescue BaseUpdate::InvalidContents => e
+        instrument("invalid_contents.tariff_synchronizer", date: date, url: response.url)
+        exception = e.original
+        create_or_update(date, BaseUpdate::FAILED_STATE, file_name).tap do |entry|
+          entry.update(
+            exception_class: "#{exception.class}: #{exception.message}",
+            exception_backtrace: exception.backtrace.try(:join, "\n")
+          )
+        end
+      else
+        # file is valid
+        create_or_update(date, BaseUpdate::PENDING_STATE, file_name, response.content.size)
+        write_update_file(date, response, file_name)
+      end
+    end
+
+    def write_update_file(date, response, file_name)
+      update_path = update_path(file_name)
+
+      instrument("update_written.tariff_synchronizer", date: date, path: update_path, size: response.content.size) do
+        TariffDownloader.write_file(update_path, response.content)
+      end
+    end
+
+    def update_path(file_name)
+      File.join(TariffSynchronizer.root_path, update_klass.update_type.to_s, file_name)
+    end
+
+    def missing_update_name_for(date)
+      "#{date}_#{update_klass.update_type}"
+    end
+  end
+end

--- a/lib/tariff_synchronizer/tariff_downloader.rb
+++ b/lib/tariff_synchronizer/tariff_downloader.rb
@@ -90,7 +90,7 @@ module TariffSynchronizer
       create_or_update(filename, BaseUpdate::PENDING_STATE, response.content.size)
       write_update_file(response)
     rescue BaseUpdate::InvalidContents => exception
-      persist_exception_for_review(exception, response)
+      persist_exception_for_review(exception)
     end
 
     def create_or_update(file_name, state, file_size = nil)
@@ -114,8 +114,7 @@ module TariffSynchronizer
       "#{date}_#{update_klass.update_type}"
     end
 
-    def persist_exception_for_review
-      instrument("invalid_contents.tariff_synchronizer", date: date, url: response.url)
+    def persist_exception_for_review(exception)
       create_or_update(filename, BaseUpdate::FAILED_STATE)
         .update(exception_class: "#{exception.original.class}: #{exception.original.message}",
                 exception_backtrace: exception.original.backtrace.try(:join, "\n"))

--- a/lib/tasks/tariff.rake
+++ b/lib/tasks/tariff.rake
@@ -18,15 +18,17 @@ namespace :tariff do
   task sync: %w[environment sync:apply]
 
   namespace :sync do
-    desc 'Download pending Taric and CHIEF updates'
-    task apply: [:environment, :class_eager_load] do
-      # Download pending updates for CHIEF and Taric
-      TariffSynchronizer.check_failures
+    desc 'Download pending Taric and CHIEF update files, Update tariff_updates table'
+    task download: [:environment, :class_eager_load] do
       TariffSynchronizer.download
+    end
+
+    desc 'Apply pending updates Taric and CHIEF'
+    task apply: [:environment, :class_eager_load] do
       TariffSynchronizer.apply
     end
 
-    desc 'Apply pending Taric and CHIEF'
+    desc 'Transform CHIEF updates'
     task transform: %w[environment] do
       require 'chief_transformer'
 

--- a/spec/factories/chief_record_factory.rb
+++ b/spec/factories/chief_record_factory.rb
@@ -328,42 +328,6 @@ FactoryGirl.define do
     footn_id { Forgery(:basic).text(exactly: 3).upcase }
   end
 
-  factory :response, class: TariffSynchronizer::Response do
-    url { Forgery::Internet.domain_name }
-    response_code { [200, 404, 403].sample }
-    content { Forgery(:basic).text }
-
-    trait :success do
-      response_code { 200 }
-    end
-
-    trait :not_found do
-      response_code { 404 }
-      content { nil }
-    end
-
-    trait :failed do
-      response_code { 403 }
-      content { nil }
-    end
-
-    trait :blank do
-      success
-
-      content { nil }
-    end
-
-    trait :retry_exceeded do
-      failed
-
-      after(:build) { |response| response.retry_count_exceeded! }
-    end
-
-    initialize_with {
-      new(url, response_code, content)
-    }
-  end
-
   factory :comm, class: Chief::Comm do
     fe_tsmp { Date.today.ago(2.years) }
     le_tsmp { nil }

--- a/spec/factories/response_factory.rb
+++ b/spec/factories/response_factory.rb
@@ -1,0 +1,37 @@
+FactoryGirl.define do
+  factory :response, class: TariffSynchronizer::Response do
+    url { Forgery::Internet.domain_name }
+    response_code { [200, 404, 403].sample }
+    content { Forgery(:basic).text }
+
+    trait :success do
+      response_code { 200 }
+    end
+
+    trait :not_found do
+      response_code { 404 }
+      content { nil }
+    end
+
+    trait :failed do
+      response_code { 403 }
+      content { nil }
+    end
+
+    trait :blank do
+      success
+
+      content { "" }
+    end
+
+    trait :retry_exceeded do
+      failed
+
+      after(:build) { |response| response.retry_count_exceeded! }
+    end
+
+    initialize_with {
+      new(url, response_code, content)
+    }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,7 +7,6 @@ WebMock.disable_net_connect!(allow_localhost: true)
 
 require 'simplecov'
 require 'simplecov-rcov'
-require 'database_cleaner'
 
 SimpleCov.start 'rails'
 SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
@@ -48,7 +47,6 @@ RSpec.configure do |config|
   RedisLockDb.redis = redis
 
   config.before(:suite) do
-    DatabaseCleaner.clean_with(:truncation)
     redis.flushdb
   end
 
@@ -57,19 +55,6 @@ RSpec.configure do |config|
   end
 
   config.before(:each) do
-    DatabaseCleaner.strategy = :transaction
     Sidekiq::Worker.clear_all
-  end
-
-  config.before(:each, :truncation => true) do
-    DatabaseCleaner.strategy = :truncation
-  end
-
-  config.before(:each) do
-    DatabaseCleaner.start
-  end
-
-  config.after(:each) do
-    DatabaseCleaner.clean
   end
 end

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,0 +1,21 @@
+RSpec.configure do |config|
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  config.before(:each, :truncation => true) do
+    DatabaseCleaner.strategy = :truncation
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do
+    DatabaseCleaner.clean
+  end
+end

--- a/spec/unit/tariff_synchronizer/chief_update_spec.rb
+++ b/spec/unit/tariff_synchronizer/chief_update_spec.rb
@@ -14,7 +14,7 @@ describe TariffSynchronizer::ChiefUpdate do
   end
 
   describe '.download' do
-    let(:blank_response)     { build :response, content: nil }
+    let(:blank_response)     { build :response, :blank }
     let(:not_found_response) { build :response, :not_found }
     let(:success_response)   { build :response, :success, content: 'abc' }
     let(:update_name)        { "KBT009(10001).txt" }

--- a/spec/unit/tariff_synchronizer/chief_update_spec.rb
+++ b/spec/unit/tariff_synchronizer/chief_update_spec.rb
@@ -27,7 +27,7 @@ describe TariffSynchronizer::ChiefUpdate do
 
         context 'file for the day not downloaded yet' do
           it 'downloads CHIEF file for specific date' do
-            expect(TariffSynchronizer::ChiefUpdate).to receive(:download_content)
+            expect(TariffSynchronizer::TariffDownloader).to receive(:download_content)
                                            .with(url)
                                            .and_return(blank_response)
 
@@ -35,7 +35,7 @@ describe TariffSynchronizer::ChiefUpdate do
           end
 
           it 'writes CHIEF file contents to file if they are not blank' do
-            expect(TariffSynchronizer::ChiefUpdate).to receive(:download_content)
+            expect(TariffSynchronizer::TariffDownloader).to receive(:download_content)
                                            .with(url)
                                            .and_return(success_response)
 
@@ -50,7 +50,7 @@ describe TariffSynchronizer::ChiefUpdate do
           end
 
           it 'creates pending ChiefUpdate entry in the table' do
-            expect(TariffSynchronizer::ChiefUpdate).to receive(:download_content)
+            expect(TariffSynchronizer::TariffDownloader).to receive(:download_content)
                                            .with(url)
                                            .and_return(success_response)
             TariffSynchronizer::ChiefUpdate.download(example_date)
@@ -61,28 +61,24 @@ describe TariffSynchronizer::ChiefUpdate do
         end
 
         context 'file for the day already downloaded' do
-          let!(:present_chief_update) {
-            create :chief_update,
-              :applied,
-              issue_date: example_date,
-              filename: chief_file.name
-          }
-
-          before {
-            expect(TariffSynchronizer::ChiefUpdate).to receive(
-              :download_content
-            ).with(url).and_return(success_response)
+          before do
+            create :chief_update, :applied,
+                                  issue_date: example_date,
+                                  filename: chief_file.name
+            allow(TariffSynchronizer::TariffDownloader).to receive(:download_content)
+                                                           .with(url)
+                                                           .and_return(success_response)
 
             TariffSynchronizer::ChiefUpdate.download(example_date)
 
             expect(
               File.exists?("#{TariffSynchronizer.root_path}/chief/#{chief_file.name}")
             ).to be_truthy
-          }
+          end
 
           it 'does not download CHIEF file for date when it exists' do
-            expect(TariffSynchronizer::ChiefUpdate).to receive(:download_content)
-                                           .never
+            # expect(TariffSynchronizer::TariffDownloader).to receive(:download_content)
+            #                                                 .never
 
             TariffSynchronizer::ChiefUpdate.download(example_date)
           end
@@ -103,17 +99,15 @@ describe TariffSynchronizer::ChiefUpdate do
             TariffSynchronizer::ChiefUpdate.last
           }
 
-          before {
-            expect(
-              TariffSynchronizer::ChiefUpdate
-            ).to receive(:download_content)
-             .with(url)
-             .and_return(success_response)
+          before do
+            allow(TariffSynchronizer::TariffDownloader).to receive(:download_content)
+                                                           .with(url)
+                                                           .and_return(success_response)
 
             # unstub
             allow(TariffSynchronizer::ChiefUpdate).to receive(:validate_file!)
-                                                  .and_call_original
-          }
+                                                      .and_call_original
+          end
 
           it {
             TariffSynchronizer::ChiefUpdate.download(example_date)
@@ -127,7 +121,7 @@ describe TariffSynchronizer::ChiefUpdate do
         let(:not_found_response) { build :response, :not_found }
 
         before {
-          expect(TariffSynchronizer::ChiefUpdate).to receive(:download_content)
+          expect(TariffSynchronizer::TariffDownloader).to receive(:download_content)
                                          .and_return(not_found_response)
         }
 
@@ -171,7 +165,7 @@ describe TariffSynchronizer::ChiefUpdate do
       end
 
       it 'logs error about permissions' do
-        expect(TariffSynchronizer::ChiefUpdate).to receive(:download_content)
+        expect(TariffSynchronizer::TariffDownloader).to receive(:download_content)
                                                .with(url)
                                                .and_return(success_response)
 
@@ -197,10 +191,10 @@ describe TariffSynchronizer::ChiefUpdate do
       let!(:chief_update2) { create :chief_update, :missing, issue_date: Date.today.ago(3.days) }
       let!(:stub_logger)   { double.as_null_object }
 
-      before {
-        allow(TariffSynchronizer::ChiefUpdate).to receive(:download_content)
-                                              .and_return(not_found_response)
-      }
+      before do
+        allow(TariffSynchronizer::TariffDownloader).to receive(:download_content)
+                                                       .and_return(not_found_response)
+      end
 
       it 'notifies about several missing updates in a row' do
         expect(TariffSynchronizer::ChiefUpdate).to receive(:notify_about_missing_updates).and_return(true)

--- a/spec/unit/tariff_synchronizer/logger_spec.rb
+++ b/spec/unit/tariff_synchronizer/logger_spec.rb
@@ -193,7 +193,7 @@ describe TariffSynchronizer::Logger, truncation: true do
     let(:failed_response) { build :response, :retry_exceeded }
 
     before {
-      expect(TariffSynchronizer::ChiefUpdate).to receive(:download_content).and_return(failed_response)
+      expect(TariffSynchronizer::TariffDownloader).to receive(:download_content).and_return(failed_response)
 
       TariffSynchronizer::ChiefUpdate.download(Date.today)
     }
@@ -214,7 +214,7 @@ describe TariffSynchronizer::Logger, truncation: true do
     let(:not_found_response) { build :response, :not_found }
 
     before {
-      expect(TariffSynchronizer::ChiefUpdate).to receive(:download_content).and_return(not_found_response)
+      expect(TariffSynchronizer::TariffDownloader).to receive(:download_content).and_return(not_found_response)
 
       TariffSynchronizer::ChiefUpdate.download(Date.yesterday)
     }
@@ -268,9 +268,9 @@ describe TariffSynchronizer::Logger, truncation: true do
 
     before {
       # Download mock response
-      expect(TariffSynchronizer::ChiefUpdate).to receive(:download_content).and_return(success_response)
+      expect(TariffSynchronizer::TariffDownloader).to receive(:download_content).and_return(success_response)
       # Do not write file to file system
-      expect(TariffSynchronizer::ChiefUpdate).to receive(:write_file).and_return(true)
+      expect(TariffSynchronizer::TariffDownloader).to receive(:write_file).and_return(true)
       # Actual Download
       TariffSynchronizer::ChiefUpdate.download(Date.today)
     }
@@ -286,7 +286,7 @@ describe TariffSynchronizer::Logger, truncation: true do
 
     before {
       # Download mock response
-      expect(TariffSynchronizer::ChiefUpdate).to receive(:download_content)
+      expect(TariffSynchronizer::TariffDownloader).to receive(:download_content)
                                              .and_return(blank_response)
       # Actual Download
       TariffSynchronizer::ChiefUpdate.download(Date.today)
@@ -309,7 +309,7 @@ describe TariffSynchronizer::Logger, truncation: true do
 
     before {
       # Download mock response
-      expect(TariffSynchronizer::ChiefUpdate).to receive(:download_content)
+      expect(TariffSynchronizer::TariffDownloader).to receive(:download_content)
                                              .and_return(success_response)
 
       # Simulate I/O exception
@@ -335,7 +335,7 @@ describe TariffSynchronizer::Logger, truncation: true do
 
     before {
       # Download mock response
-      expect(TariffSynchronizer::ChiefUpdate).to receive(:download_content)
+      expect(TariffSynchronizer::TariffDownloader).to receive(:download_content)
                                              .and_return(success_response)
       # Simulate I/O exception
       expect(File).to receive(:open).and_raise(IOError)
@@ -360,7 +360,7 @@ describe TariffSynchronizer::Logger, truncation: true do
 
     before {
       # Download mock response
-      allow(TariffSynchronizer::ChiefUpdate).to receive(:download_content)
+      allow(TariffSynchronizer::TariffDownloader).to receive(:download_content)
                                              .and_return(success_response)
       # Stub creation of the record
       allow(TariffSynchronizer::ChiefUpdate).to receive(:create_or_update)
@@ -389,7 +389,7 @@ describe TariffSynchronizer::Logger, truncation: true do
 
     before {
       TariffSynchronizer.retry_count = 10
-      expect(TariffSynchronizer::ChiefUpdate).to receive(:send_request)
+      expect(TariffSynchronizer::TariffDownloader).to receive(:send_request)
                                              .exactly(3).times
                                              .and_return(failed_response, failed_response, success_response)
       TariffSynchronizer::ChiefUpdate.download(Date.today)
@@ -406,7 +406,7 @@ describe TariffSynchronizer::Logger, truncation: true do
     before {
       create :chief_update, :missing, issue_date: Date.today.ago(2.days)
       create :chief_update, :missing, issue_date: Date.today.ago(3.days)
-      allow(TariffSynchronizer::ChiefUpdate).to receive(:download_content)
+      allow(TariffSynchronizer::TariffDownloader).to receive(:download_content)
                                             .and_return(not_found_response)
       TariffSynchronizer::ChiefUpdate.sync
     }

--- a/spec/unit/tariff_synchronizer/taric_update_spec.rb
+++ b/spec/unit/tariff_synchronizer/taric_update_spec.rb
@@ -44,7 +44,7 @@ describe TariffSynchronizer::TaricUpdate do
       context "update not downloaded yet" do
 
         it "downloads Taric file for specific date" do
-          expect(TariffSynchronizer::TaricUpdate).to receive(:download_content)
+          expect(TariffSynchronizer::TariffDownloader).to receive(:download_content)
                                          .with(update_url)
                                          .and_return(blank_response)
 
@@ -52,7 +52,7 @@ describe TariffSynchronizer::TaricUpdate do
         end
 
         it "writes Taric file contents to file if they are not blank" do
-          expect(TariffSynchronizer::TaricUpdate).to receive(:download_content)
+          expect(TariffSynchronizer::TariffDownloader).to receive(:download_content)
                                          .with(update_url)
                                          .and_return(success_response)
 
@@ -64,7 +64,7 @@ describe TariffSynchronizer::TaricUpdate do
         end
 
         it "does not write Taric file contents to file if they are blank" do
-          expect(TariffSynchronizer::TaricUpdate).to receive(:download_content)
+          expect(TariffSynchronizer::TariffDownloader).to receive(:download_content)
                                          .with(update_url)
                                          .and_return(blank_response)
 
@@ -76,7 +76,7 @@ describe TariffSynchronizer::TaricUpdate do
 
       describe "content validation" do
         before do
-          allow(TariffSynchronizer::TaricUpdate).to receive(:download_content)
+          allow(TariffSynchronizer::TariffDownloader).to receive(:download_content)
                                                     .with(update_url)
                                                     .and_return(success_response)
           # unstub
@@ -91,7 +91,6 @@ describe TariffSynchronizer::TaricUpdate do
         end
       end
     end
-
 
     context "update already downloaded" do
       let(:query_response) do
@@ -146,7 +145,7 @@ describe TariffSynchronizer::TaricUpdate do
 
       it "downloads Taric file for specific date" do
         taric_update_names.each do |name|
-          expect(TariffSynchronizer::TaricUpdate).to receive(:download_content)
+          expect(TariffSynchronizer::TariffDownloader).to receive(:download_content)
                                          .with(taric_update_url % { name: name })
                                          .and_return(blank_response)
         end
@@ -155,10 +154,10 @@ describe TariffSynchronizer::TaricUpdate do
       end
 
       it "writes Taric file contents to file if they are not blank" do
-        expect(TariffSynchronizer::TaricUpdate).to receive(:download_content)
+        expect(TariffSynchronizer::TariffDownloader).to receive(:download_content)
                                        .with(taric_update_url % { name: taric_update_names.first })
                                        .and_return(success_response_1)
-        expect(TariffSynchronizer::TaricUpdate).to receive(:download_content)
+        expect(TariffSynchronizer::TariffDownloader).to receive(:download_content)
                                        .with(taric_update_url % { name: taric_update_names.last })
                                        .and_return(success_response_2)
 
@@ -174,10 +173,10 @@ describe TariffSynchronizer::TaricUpdate do
       end
 
       it "does not write Taric file contents to file if they are blank" do
-        expect(TariffSynchronizer::TaricUpdate).to receive(:download_content)
+        expect(TariffSynchronizer::TariffDownloader).to receive(:download_content)
                                        .with(taric_update_url % { name: taric_update_names.first })
                                        .and_return(blank_response)
-        expect(TariffSynchronizer::TaricUpdate).to receive(:download_content)
+        expect(TariffSynchronizer::TariffDownloader).to receive(:download_content)
                                        .with(taric_update_url % { name: taric_update_names.last })
                                        .and_return(blank_response)
 
@@ -238,7 +237,7 @@ describe TariffSynchronizer::TaricUpdate do
                                        .with(taric_query_url)
                                        .and_return(success_response)
 
-        expect(TariffSynchronizer::TaricUpdate).to receive(:send_request)
+        expect(TariffSynchronizer::TariffDownloader).to receive(:send_request)
                                        .with(update_url)
                                        .twice
                                        .and_return(failed_response)
@@ -270,7 +269,7 @@ describe TariffSynchronizer::TaricUpdate do
                                        .with(taric_query_url)
                                        .and_return(success_response)
 
-        expect(TariffSynchronizer::TaricUpdate).to receive(:send_request)
+        expect(TariffSynchronizer::TariffDownloader).to receive(:send_request)
                                        .with(update_url)
                                        .and_return(blank_success_response)
 

--- a/spec/unit/tariff_synchronizer/taric_update_spec.rb
+++ b/spec/unit/tariff_synchronizer/taric_update_spec.rb
@@ -9,7 +9,7 @@ describe TariffSynchronizer::TaricUpdate do
   describe ".download" do
     let(:taric_update_name)  { "TGB#{example_date.strftime("%y")}#{example_date.yday}.xml" }
     let(:taric_query_url)    { "#{TariffSynchronizer.host}/taric/TARIC3#{example_date.strftime("%Y%m%d")}" }
-    let(:blank_response)     { build :response, content: nil }
+    let(:blank_response)     { build :response, :blank }
     let(:not_found_response) { build :response, :not_found }
     let(:success_response)   { build :response, :success, content: "abc" }
     let(:failed_response)    { build :response, :failed }

--- a/spec/unit/tariff_synchronizer/tariff_downloader_spec.rb
+++ b/spec/unit/tariff_synchronizer/tariff_downloader_spec.rb
@@ -1,0 +1,6 @@
+require "rails_helper"
+require "tariff_synchronizer/tariff_downloader"
+
+describe TariffSynchronizer::TariffDownloader do
+
+end


### PR DESCRIPTION
#### What this PR does:

Extract the complexity of the `perform_download` in the BaseUpdate class to it's own class.

#### Notes

Extracting this complexity we reveal intentions and make the code more clearer.
This is also an attempt to reduce the overuse of class methods in the app.

#### ToDo

Move specs from ChiefUpdate and TaricUpdate to TariffDownloader. To be done in the next PR

#### Edit 

Because of the route contraints in the length of the id parameter, if you call more than 99 times the  `Section` factory you will start seeing errors of routes not found, to fix this please run:

`bundle exec rake db:test:prepare`

That will drop, create and load the `structure.sql` file.