### PR TITLE
Reduce the Index search max size

### DIFF
--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -15,10 +15,10 @@ class SearchService
   autoload :FuzzySearch, 'search_service/fuzzy_search'
   autoload :NullSearch,  'search_service/null_search'
 
-  INDEX_SIZE_MAX = 1000000 # ElasticSearch does default pagination for 10 entries
-                           # per page. We do not do pagination when displaying
-                           # results so have a constant much bigger than possible
-                           # index size for size value.
+  INDEX_SIZE_MAX = 10000 # ElasticSearch does default pagination for 10 entries
+                         # per page. We do not do pagination when displaying
+                         # results so have a constant much bigger than possible
+                         # index size for size value.
 
   include ActiveModel::Validations
   include ActiveModel::Conversion


### PR DESCRIPTION
the ElasticSearch 2.3.3 the maximum size by default is 10k records

After the whole test suite and testing manually the app.. this is the only change necessary to make the app compatible with elasticsearch 2.3.3.