### PR TITLE
Replace Airbrake with Sentry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,6 @@ gem "curb", "~> 0.8"
 
 gem "nokogiri", "~> 1.6"
 
-gem "airbrake", "~> 4.3"
 gem "aws-ses", "~> 0.6", require: "aws/ses" #used for sync emails
 gem "logstasher", "~> 0.6"
 gem "responders", "~> 2.1"
@@ -37,6 +36,7 @@ gem "uglifier", "~> 2.7"
 group :production do
   gem "newrelic_rpm", "~> 3.12"
   gem "rails_12factor"
+  gem "sentry-raven"
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,9 +44,6 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.3.8)
-    airbrake (4.3.0)
-      builder
-      multi_json
     ansi (1.5.0)
     arel (6.0.3)
     aws-ses (0.6.0)
@@ -245,6 +242,8 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (~> 1.1)
+    sentry-raven (0.15.6)
+      faraday (>= 0.7.6)
     sequel (4.32.0)
     sequel-rails (0.9.12)
       actionpack (>= 3.2.0)
@@ -303,7 +302,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  airbrake (~> 4.3)
   ansi (~> 1.5)
   aws-ses (~> 0.6)
   brakeman (~> 3.0)
@@ -338,6 +336,7 @@ DEPENDENCIES
   rspec_junit_formatter
   sass (~> 3.4)
   sass-rails (~> 5.0)
+  sentry-raven
   sequel (~> 4.32)
   sequel-rails (~> 0.9)
   sidekiq (~> 4.1.1)

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,6 +1,0 @@
-Airbrake.configure do |config|
-  config.port    = 443
-  config.secure  = true
-  config.host    = Rails.application.secrets.errbit_host
-  config.api_key = Rails.application.secrets.errbit_api_key
-end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -20,6 +20,4 @@ test:
 # instead read values from the environment.
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
-  errbit_api_key: <%= ENV["ERRBIT_API_KEY"] %>
-  errbit_host: <%= ENV["ERRBIT_HOST"] %>
   mailer_env: <%= ENV["MAILER_ENV"] %>


### PR DESCRIPTION
Set your SENTRY_DSN environment variable and the gem will capture and
send exceptions to the Sentry server.

Raven only runs when SENTRY_DSN is set