### PR TITLE
Remove logstasher

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,6 @@ gem "curb", "~> 0.8"
 gem "nokogiri", "~> 1.6"
 
 gem "aws-ses", "~> 0.6", require: "aws/ses" #used for sync emails
-gem "logstasher", "~> 0.6"
 gem "responders", "~> 2.1"
 
 gem "sass", "~> 3.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,10 +128,6 @@ GEM
     json_pure (1.8.3)
     jwt (1.4.1)
     libv8 (3.16.14.13)
-    logstash-event (1.2.02)
-    logstasher (0.6.5)
-      logstash-event (~> 1.2.0)
-      request_store
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.3)
@@ -213,7 +209,6 @@ GEM
     rake (11.1.2)
     redis (3.2.2)
     ref (1.0.5)
-    request_store (1.2.0)
     responders (2.1.0)
       railties (>= 4.2.0, < 5)
     rspec-core (3.4.4)
@@ -328,7 +323,6 @@ DEPENDENCIES
   gds-sso (~> 11.0)
   hashie (~> 3.4)
   json_expressions
-  logstasher (~> 0.6)
   multi_json (~> 1.11)
   newrelic_rpm (~> 3.12)
   nokogiri (~> 1.6)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -70,9 +70,4 @@ Rails.application.configure do
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
-
-  # Enable JSON-style logging
-  config.logstasher.enabled = true
-  config.logstasher.logger = Logger.new("#{Rails.root}/log/#{Rails.env}.json.log")
-  config.logstasher.supress_app_log = true
 end

--- a/config/initializers/logstasher.rb
+++ b/config/initializers/logstasher.rb
@@ -1,9 +1,0 @@
-if Object.const_defined?('LogStasher') && LogStasher.enabled
-  LogStasher.add_custom_fields do |fields|
-    # Mirrors Nginx request logging, e.g GET /path/here HTTP/1.1
-    fields[:request] = "#{request.request_method} #{request.fullpath} #{request.headers['SERVER_PROTOCOL']}"
-    # Pass the request id to logging
-    fields[:govuk_request_id] = request.headers['GOVUK-Request-Id']
-    fields[:varnish_id] = request.headers['X-Varnish']
-  end
-end


### PR DESCRIPTION
We are going to use papertrail in the CF environment. Papertrail will read the the log stream in cloud foundry, no need to add code in the app.