### PR TITLE
Remove code that overrided elasticsearch connection

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -49,9 +49,6 @@ Rails.application.configure do
   config.after_initialize do
     TradeTariffBackend.configure do |tariff|
       tariff.search_namespace = 'tariff-test' # default is just tariff
-      tariff.search_options = {
-        log: false
-      }
       # We need search index to be refreshed after each operation
       # in order to assert record presence in the index (in integration specs)
       # Elasticsearch has a 1 second interval between index refreshes

--- a/lib/trade_tariff_backend.rb
+++ b/lib/trade_tariff_backend.rb
@@ -72,17 +72,12 @@ module TradeTariffBackend
 
     def search_client
       @search_client ||= SearchClient.new(
-        Elasticsearch::Client.new(search_options),
+        Elasticsearch::Client.new,
         namespace: search_namespace,
         indexed_models: indexed_models,
         search_operation_options: search_operation_options
       )
     end
-
-    def search_host
-      @search_host ||= "http://localhost:#{search_port}"
-    end
-    attr_writer :search_host
 
     def search_namespace
       @search_namespace ||= 'tariff'
@@ -96,20 +91,6 @@ module TradeTariffBackend
 
       "#{index_name}Index".constantize.new(search_namespace)
     end
-
-    def search_port
-      @search_port ||= 9200
-    end
-    attr_writer :search_port
-
-    def default_search_options
-      { host: search_host, logger: Rails.logger }
-    end
-
-    def search_options
-      default_search_options.merge(@search_options || {})
-    end
-    attr_writer :search_options
 
     def search_operation_options
       @search_operation_options || {}


### PR DESCRIPTION
#### What this PR does:

Remove the code that sets the host and port, a better to handle this config would be using an environment variable `ELASTICSEARCH_URL`