### PR TITLE
Update sidekiq workers

### DIFF
--- a/app/workers/rollback_worker.rb
+++ b/app/workers/rollback_worker.rb
@@ -1,7 +1,7 @@
 class RollbackWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: :rollbacks, retry: false, backtrace: true
+  sidekiq_options queue: :rollbacks, retry: false
 
   def perform(date, redownload = false)
     TariffSynchronizer.rollback(date, redownload)

--- a/app/workers/updates_synchronizer_worker.rb
+++ b/app/workers/updates_synchronizer_worker.rb
@@ -1,5 +1,8 @@
 class UpdatesSynchronizerWorker
   include Sidekiq::Worker
+
+  sidekiq_options queue: :sync, retry: false
+
   def perform
     TariffSynchronizer.download
     TariffSynchronizer.apply

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -2,6 +2,7 @@
 :concurrency:  1
 :queues:
   - [rollbacks, 2]
+  - [sync, 2]
   - [default, 5]
 :schedule:
   UpdatesSynchronizerWorker:


### PR DESCRIPTION
#### What this PR does:

- Do not retry the UpdatesSynchronizerWorker
- Add custom queue `sync`

#### Notes

Disable the backtrace logging now that we use a service for that ( Sentry ).

https://github.com/mperham/sidekiq/wiki/Error-Handling#backtrace-logging
> Enabling backtrace logging for a job will cause the backtrace to be persisted throughout the lifetime of the job. This can cause your Redis memory usage to grow without new jobs being added if a large quantity of jobs are failing repeatedly and being requeued.

>You should use caution when enabling backtrace by limiting it to a couple of lines, or use an error service to keep track of failures.