### PR TITLE
Refactor XML parser

### DIFF
--- a/lib/tasks/tariff_importer.rake
+++ b/lib/tasks/tariff_importer.rake
@@ -20,7 +20,8 @@ namespace :importer do
         # so unrestrict it for all models.
         Sequel::Model.subclasses.each(&:unrestrict_primary_key)
         Sequel::Model.plugin :skip_create_refresh
-        TaricImporter.new(ENV["TARGET"], ENV["DATE"]).import(validate: false)
+        dummy_update = OpenStruct.new(file_path: ENV["TARGET"], issue_date: nil)
+        TaricImporter.new(dummy_update).import(validate: false)
       else
         puts "Please provide TARGET environment variable pointing to Tariff file to import"
       end


### PR DESCRIPTION
- Update the `XmlParser::Reader` class to include nodes with the same name as their parent, the previous version had a conflict with nested nodes with same name.

- Update the rake task `importer:taric:import`, the `TaricImporter` expects a tariff update like object, the initializer expects only one argument.