### PR TITLE
Bugfix invalid encoding when reading the CHIEF file

### DIFF
--- a/lib/chief_importer.rb
+++ b/lib/chief_importer.rb
@@ -35,7 +35,8 @@ class ChiefImporter
 
   def import
     file = TariffSynchronizer::FileService.file_as_stringio(@chief_update)
-    CSV.parse(file, encoding: "ISO-8859-1") do |line|
+    file.set_encoding("ISO-8859-1")
+    CSV.parse(file) do |line|
       entry = Entry.build(line)
 
       if entry.is_a?(StartEntry)

--- a/lib/tasks/tariff_importer.rake
+++ b/lib/tasks/tariff_importer.rake
@@ -1,17 +1,5 @@
-# Import CHIEF or Taric file manually. Usually for initial seed files.
+# Import Taric file manually. Usually for initial seed files.
 namespace :importer do
-  namespace :chief do
-    desc "Import CHIEF file"
-    task import: :environment do
-
-      if ENV["TARGET"] && File.exists?(ENV["TARGET"])
-        ChiefImporter.new(ENV["TARGET"], ENV["DATE"]).import
-      else
-        puts "Please provide TARGET environment variable pointing to CHIEF file to import"
-      end
-    end
-  end
-
   namespace :taric do
     desc "Import Tariff file"
     task import: [:environment, :class_eager_load] do


### PR DESCRIPTION
The CSV#parse method ignores the `encoding` parameter, so these files were readed as `UTF8` when they are `ISO-8859-1`.

This PR sets the encoding to the StringIO object so the `parse` method will read the string in this encoding.



##### Notes

Remove unused rake task for initial seed files.

The process for initial seed files is described in the project’s wiki, this rake task is not used.