### PR TITLE
Do not call the text method in the XML parser

### DIFF
--- a/lib/taric_importer/xml_parser.rb
+++ b/lib/taric_importer/xml_parser.rb
@@ -21,6 +21,7 @@ module XmlParser
     end
 
     def text(val)
+      return unless @in_target
       @node[:__content__] = val
     end
 


### PR DESCRIPTION
Add a guard clause to prevent running code If we are not in the node we want.