### PR TITLE
Add guard clause to prevent request if update exists

### DIFF
--- a/lib/tariff_synchronizer/taric_update_downloader.rb
+++ b/lib/tariff_synchronizer/taric_update_downloader.rb
@@ -14,6 +14,7 @@ module TariffSynchronizer
     end
 
     def perform
+      return if check_date_already_downloaded?
       log_request_to_taric_update
       send("create_record_for_#{response.state}_response")
     end
@@ -22,6 +23,10 @@ module TariffSynchronizer
 
     def response
       @response ||= TariffUpdatesRequester.perform(url)
+    end
+
+    def check_date_already_downloaded?
+      TaricUpdate.find(issue_date: date).present?
     end
 
     def create_record_for_successful_response


### PR DESCRIPTION
The process of downloading Taric files is a little bit different from the CHIEF files.

With Chief files, given a date, we can generate the exact url we expect the file will exists, but with the Taric files, given a date we generate a url with a file with a reference of 1 or more files.

That's why we have the `TaricUpdateDownloader` class which will make a request before calling the `TariffDownloader` class.

Now, if we have already downloaded the files and created the TaricUpdate records for this date the process still makes a request to check the reference of the Taric files.

We are assuming that if the TaricUpdate record already exists, this process has been ran for this specific date, so there is no need to run again.

The only purpose of the download process is to pull the contents of the chief and taric files, store this files, and create a record with the reference.

