### PR TITLE
Fix spec, geographical_area needs to be valid on or before measure

### DIFF
--- a/spec/integration/chief_transformer/custom_spec.rb
+++ b/spec/integration/chief_transformer/custom_spec.rb
@@ -235,12 +235,21 @@ describe 'CHIEF: Custom scenarios' do
   end
 
   describe 'Scenario: single CHIEF update contains MFCM Insert and Update operations' do
+    let!(:geographical_area)  { create :geographical_area, :erga_omnes, validity_start_date: DateTime.new(2010,2,22,12,27) }
     let!(:gono) { create :goods_nomenclature, :declarable, :with_indent,
                                              goods_nomenclature_sid: 97701,
                                              goods_nomenclature_item_id: '1104291710',
                                              producline_suffix: "80",
                                              validity_start_date: Date.new(2013,7,1),
                                              validity_end_date: nil}
+
+     let!(:tame) { create :tame,
+                          fe_tsmp: DateTime.new(2010,2,22,12,27),
+                          msrgp_code: 'VT',
+                          msr_type: 'Z',
+                          tty_code: 'B00',
+                          le_tsmp: nil }
+
     let!(:mfcm_insert) { create :mfcm, msrgp_code: 'VT',
                                 msr_type: 'Z',
                                 tty_code: 'B00',
@@ -262,15 +271,6 @@ describe 'CHIEF: Custom scenarios' do
                                 origin: "2013-07-11_KBT009(13192).txt",
                                 amend_indicator: 'U' }
 
-    let!(:geographical_area)  { create :geographical_area, :erga_omnes }
-    let!(:tame) {
-      create :tame,
-        fe_tsmp: DateTime.new(2010,2,22,12,27),
-        msrgp_code: 'VT',
-        msr_type: 'Z',
-        tty_code: 'B00',
-        le_tsmp: nil
-    }
 
 
     before {


### PR DESCRIPTION
```(byebug) GeographicalArea.all.first.validity_start_date
2013-07-11 00:00:00 UTC
(byebug) validity_start_date
2013-07-10 10:27:00 UTC
(byebug) GeographicalArea.all.first.validity_start_date < validity_start_date
false```