### PR TITLE
Restore sidekiq cron reference to run only at 20:00 and 23:00

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -6,5 +6,5 @@
   - [default, 5]
 :schedule:
   UpdatesSynchronizerWorker:
-    cron: "0 * * * *"
+    cron: "0 20,23 * * *"
     description: "This job will run at 20:00 and 23:00 every day."


### PR DESCRIPTION
Revert temporal change in this job, from running at 20:00 and 23:00, to running every hour.