### PR TITLE
Add missing data migration

### DIFF
--- a/db/data_migrations/20160713094915_fix_chapter_id_length_in_chapter_notes.rb
+++ b/db/data_migrations/20160713094915_fix_chapter_id_length_in_chapter_notes.rb
@@ -1,0 +1,23 @@
+TradeTariffBackend::DataMigrator.migration do
+  name "Fix chapter_id attribute at least 2 chars in the ChapterNote model"
+
+  up do
+    applicable {
+      ChapterNote.where("char_length(chapter_id) < 2").any?
+    }
+    apply {
+      ChapterNote.all do |chapter_note|
+        chapter_note.update(chapter_id: sprintf("%02d", chapter_note.chapter_id.to_i))
+      end
+    }
+  end
+
+  down do
+    applicable {
+      false
+    }
+    apply {
+      # noop
+    }
+  end
+end


### PR DESCRIPTION
There was a data migrations within a schema migrations.

This is a bad practice because we load the structure file when running db:setup.

The file that added this data migration is this:
`db/migrate/20130809075350_change_chapter_note_foreign_key_type.rb`

This new data migration fixes the issued caused because of this code is
never run.