### PR TITLE
Fix expected order, match the same results from mysql

### DIFF
--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -6,7 +6,9 @@ class Commodity < GoodsNomenclature
   plugin :elasticsearch
 
   set_dataset filter("goods_nomenclatures.goods_nomenclature_item_id NOT LIKE ?", '____000000').
-              order(Sequel.asc(:goods_nomenclatures__goods_nomenclature_item_id))
+              order(Sequel.asc(:goods_nomenclatures__goods_nomenclature_item_id),
+                    Sequel.asc(:goods_nomenclatures__producline_suffix),
+                    Sequel.asc(:goods_nomenclatures__goods_nomenclature_sid))
 
   set_primary_key [:goods_nomenclature_sid]
 


### PR DESCRIPTION

#### What this PR does:

Bugfix of the indentation issue because of the commodities order in the Headings page.

#### Notes

The sql query to return the commoditines of a specific heading will be like:

```sql
SELECT * FROM goods_nomenclatures WHERE ((goods_nomenclatures.goods_nomenclature_item_id NOT LIKE '____000000') AND (goods_nomenclatures.goods_nomenclature_item_id LIKE '0403______') AND (goods_nomenclatures.goods_nomenclature_item_id NOT IN ('9900000000', '9905000000', '9919000000', '9930000000', '9930240000', '9930270000', '9930990000', '9931000000', '9931240000', '9931270000', '9931990000', '9950000000'))) ORDER BY goods_nomenclatures.goods_nomenclature_item_id ASC
```

But the results from postgresql and mysql are different, It is well know that MySQL has a lot of differences from Standard SQL and that is why we see a different order in Postgresql, This is quick fix to produce the same results from the mysql query.