### PR TITLE
Fix sibling calculation

### DIFF
--- a/.byebug_history
+++ b/.byebug_history
@@ -1,0 +1,17 @@
+continue
+Commodity.actual.by_code("0106130000").first
+continue
+cexit
+x
+omodt.culb_oe"16300)frtCmmodity.culb_oe"1100".is
+omdt.cua.b_oe"16300)frt
+continue
+econtinue
+ @commodity @
+e
+continue
+@commodity.children.count
+@commodity.children.any?
+continue
+@commodity.children:q
+@commodity.children

--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -78,24 +78,27 @@ class Commodity < GoodsNomenclature
     @_uptree ||= [ancestors, heading, chapter, self].flatten.compact
   end
 
-  def children
-    sibling = heading.commodities_dataset
-                     .join(:goods_nomenclature_indents, goods_nomenclature_sid: :goods_nomenclature_sid)
-                     .where("goods_nomenclature_indents.number_indents = ?", goods_nomenclature_indent.number_indents)
-                     .where("goods_nomenclatures.goods_nomenclature_sid != ?", goods_nomenclature_sid)
-                     .where("goods_nomenclatures.goods_nomenclature_item_id > ?", goods_nomenclature_item_id)
-                     .where("goods_nomenclature_indents.validity_start_date <= ? AND (goods_nomenclature_indents.validity_end_date >= ? OR goods_nomenclature_indents.validity_end_date IS NULL)", point_in_time, point_in_time)
-                     .order(nil)
-                     .first
+  def next_sibling
+    heading.commodities_dataset
+      .join(:goods_nomenclature_indents, goods_nomenclature_sid: :goods_nomenclature_sid)
+      .where("goods_nomenclature_indents.number_indents = ?", goods_nomenclature_indent.number_indents)
+      .where("goods_nomenclatures.goods_nomenclature_sid != ?", goods_nomenclature_sid)
+      .where("goods_nomenclatures.goods_nomenclature_item_id > ?", goods_nomenclature_item_id)
+      .where("goods_nomenclature_indents.validity_start_date <= ? AND (goods_nomenclature_indents.validity_end_date >= ? OR goods_nomenclature_indents.validity_end_date IS NULL)", point_in_time, point_in_time)
+      .order(2)
+      .first
+  end
 
-    if sibling.present?
+
+  def children
+    if next_sibling.present?
       heading.commodities_dataset
              .join(:goods_nomenclature_indents, goods_nomenclature_sid: :goods_nomenclature_sid)
              .where("goods_nomenclature_indents.number_indents > ?", goods_nomenclature_indent.number_indents)
              .where("goods_nomenclatures.goods_nomenclature_sid != ?", goods_nomenclature_sid)
              .where("goods_nomenclatures.producline_suffix >= ?", producline_suffix)
              .where("goods_nomenclature_indents.validity_start_date <= ? AND (goods_nomenclature_indents.validity_end_date >= ? OR goods_nomenclature_indents.validity_end_date IS NULL)", point_in_time, point_in_time)
-             .where("goods_nomenclatures.goods_nomenclature_item_id >= ? AND goods_nomenclatures.goods_nomenclature_item_id < ?", goods_nomenclature_item_id, sibling.goods_nomenclature_item_id)
+             .where("goods_nomenclatures.goods_nomenclature_item_id >= ? AND goods_nomenclatures.goods_nomenclature_item_id < ?", goods_nomenclature_item_id, next_sibling.goods_nomenclature_item_id)
              .order(nil)
              .all
     else

--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -78,8 +78,8 @@ class Commodity < GoodsNomenclature
     @_uptree ||= [ancestors, heading, chapter, self].flatten.compact
   end
 
-  def next_sibling
-    heading.commodities_dataset
+  def children
+    next_sibling = heading.commodities_dataset
       .join(:goods_nomenclature_indents, goods_nomenclature_sid: :goods_nomenclature_sid)
       .where("goods_nomenclature_indents.number_indents = ?", goods_nomenclature_indent.number_indents)
       .where("goods_nomenclatures.goods_nomenclature_sid != ?", goods_nomenclature_sid)
@@ -87,10 +87,7 @@ class Commodity < GoodsNomenclature
       .where("goods_nomenclature_indents.validity_start_date <= ? AND (goods_nomenclature_indents.validity_end_date >= ? OR goods_nomenclature_indents.validity_end_date IS NULL)", point_in_time, point_in_time)
       .order(2)
       .first
-  end
 
-
-  def children
     if next_sibling.present?
       heading.commodities_dataset
              .join(:goods_nomenclature_indents, goods_nomenclature_sid: :goods_nomenclature_sid)


### PR DESCRIPTION
Fixed commodities sibling calculation which is necesary to find the children of the commodity. Since the children method included more items than expected and commodities with children are not shown, the issue was preventing some links to be found in the PG version.

.order(2) refers to the second column of the select clause (goods_nomenclatures.goods_nomenclature_item_id)
`order(:goods_nomenclature_item_id)` is ambiguous
and 
`order("goods_nomenclatures.goods_nomenclature_item_id")` doesn't work because the PG connector doesn't escape it properly.