### PR TITLE
[DO NOT MERGE] Change ancestors tree to not include the current commodity code

### DIFF
--- a/app/formatters/description_trim_formatter.rb
+++ b/app/formatters/description_trim_formatter.rb
@@ -3,6 +3,7 @@ class DescriptionTrimFormatter
     raise ArgumentError.new("DescriptionFormatter expects :using arg to be a single value") if opts.keys.many?
 
     str = opts.values.first
+    str.gsub!("&nbsp;", " ")
     str.gsub!("|", " ")
     str.gsub!("!1!", "")
     str.gsub!("!X!", "")

--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -75,7 +75,7 @@ class Commodity < GoodsNomenclature
   end
 
   def uptree
-    @_uptree ||= [chapter, heading, ancestors].flatten.compact.uniq
+    @_uptree ||= [chapter, heading, ancestors, self].flatten.compact.uniq
   end
 
   def children

--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -52,7 +52,7 @@ class Commodity < GoodsNomenclature
                  .with_actual(GoodsNomenclature)
                  .join(:goods_nomenclatures, goods_nomenclature_indents__goods_nomenclature_sid: :goods_nomenclatures__goods_nomenclature_sid)
                  .where("goods_nomenclature_indents.goods_nomenclature_item_id LIKE ?", heading_id)
-                 .where("goods_nomenclature_indents.goods_nomenclature_item_id <= ?", goods_nomenclature_item_id)
+                 .where("goods_nomenclature_indents.goods_nomenclature_item_id < ?", goods_nomenclature_item_id)
                  .order(Sequel.desc(:goods_nomenclature_indents__validity_start_date),
                         Sequel.desc(:goods_nomenclature_indents__goods_nomenclature_item_id))
                  .from_self

--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -53,7 +53,6 @@ class Commodity < GoodsNomenclature
                  .join(:goods_nomenclatures, goods_nomenclature_indents__goods_nomenclature_sid: :goods_nomenclatures__goods_nomenclature_sid)
                  .where("goods_nomenclature_indents.goods_nomenclature_item_id LIKE ?", heading_id)
                  .where("goods_nomenclature_indents.goods_nomenclature_item_id < ?", goods_nomenclature_item_id)
-                 .where("goods_nomenclature_indents.goods_nomenclature_item_id NOT LIKE ?", "#{goods_nomenclature_item_id.to_s.first(8)}__")
                  .order(Sequel.desc(:goods_nomenclature_indents__validity_start_date),
                         Sequel.desc(:goods_nomenclature_indents__goods_nomenclature_item_id))
                  .from_self

--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -75,7 +75,7 @@ class Commodity < GoodsNomenclature
   end
 
   def uptree
-    @_uptree ||= [ancestors, heading, chapter, self].flatten.compact.uniq
+    @_uptree ||= [chapter, heading, ancestors].flatten.compact.uniq
   end
 
   def children

--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -52,7 +52,7 @@ class Commodity < GoodsNomenclature
                  .with_actual(GoodsNomenclature)
                  .join(:goods_nomenclatures, goods_nomenclature_indents__goods_nomenclature_sid: :goods_nomenclatures__goods_nomenclature_sid)
                  .where("goods_nomenclature_indents.goods_nomenclature_item_id LIKE ?", heading_id)
-                 .where("goods_nomenclature_indents.goods_nomenclature_item_id < ?", goods_nomenclature_item_id)
+                 .where("goods_nomenclature_indents.goods_nomenclature_item_id <= ?", goods_nomenclature_item_id)
                  .order(Sequel.desc(:goods_nomenclature_indents__validity_start_date),
                         Sequel.desc(:goods_nomenclature_indents__goods_nomenclature_item_id))
                  .from_self
@@ -75,7 +75,7 @@ class Commodity < GoodsNomenclature
   end
 
   def uptree
-    @_uptree ||= [ancestors, heading, chapter, self].flatten.compact
+    @_uptree ||= [ancestors, heading, chapter, self].flatten.compact.uniq
   end
 
   def children

--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -53,6 +53,7 @@ class Commodity < GoodsNomenclature
                  .join(:goods_nomenclatures, goods_nomenclature_indents__goods_nomenclature_sid: :goods_nomenclatures__goods_nomenclature_sid)
                  .where("goods_nomenclature_indents.goods_nomenclature_item_id LIKE ?", heading_id)
                  .where("goods_nomenclature_indents.goods_nomenclature_item_id < ?", goods_nomenclature_item_id)
+                 .where("goods_nomenclature_indents.goods_nomenclature_item_id NOT LIKE ?", "#{goods_nomenclature_item_id.to_s.first(8)}__")
                  .order(Sequel.desc(:goods_nomenclature_indents__validity_start_date),
                         Sequel.desc(:goods_nomenclature_indents__goods_nomenclature_item_id))
                  .from_self

--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -75,7 +75,7 @@ class Commodity < GoodsNomenclature
   end
 
   def uptree
-    @_uptree ||= [chapter, heading, ancestors, self].flatten.compact.uniq
+    @_uptree ||= [chapter, heading, ancestors, self].flatten.compact
   end
 
   def children

--- a/app/models/export_refund_nomenclature.rb
+++ b/app/models/export_refund_nomenclature.rb
@@ -35,7 +35,7 @@ class ExportRefundNomenclature < Sequel::Model
   delegate :number_indents, to: :export_refund_nomenclature_indent
 
   def uptree
-    @_uptree ||= [ancestors, self].flatten.compact.uniq
+    @_uptree ||= [ancestors, self].flatten.compact
   end
 
   def ancestors

--- a/app/models/export_refund_nomenclature.rb
+++ b/app/models/export_refund_nomenclature.rb
@@ -35,7 +35,7 @@ class ExportRefundNomenclature < Sequel::Model
   delegate :number_indents, to: :export_refund_nomenclature_indent
 
   def uptree
-    @_uptree ||= [ancestors, self].flatten.compact
+    @_uptree ||= [ancestors, self].flatten.compact.uniq
   end
 
   def ancestors

--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -106,6 +106,10 @@ class GoodsNomenclature < Sequel::Model
     goods_nomenclature_sid
   end
 
+  def to_s
+    "#{number_indents}: #{goods_nomenclature_item_id}: #{description}"
+  end
+
   def heading_id
     "#{goods_nomenclature_item_id.first(4)}______"
   end

--- a/app/models/heading.rb
+++ b/app/models/heading.rb
@@ -60,7 +60,7 @@ class Heading < GoodsNomenclature
   end
 
   def uptree
-    [self, self.chapter].compact
+    [self.chapter, self].compact
   end
 
   def non_grouping?


### PR DESCRIPTION
commodity is appearing twice in the description tree, as it is included the ancestors (when it shouldn't be)