### PR TITLE
hide two specific measure types from api

### DIFF
--- a/app/presenters/measure_presenter.rb
+++ b/app/presenters/measure_presenter.rb
@@ -1,5 +1,6 @@
 class MeasurePresenter
   THIRD_COUNTRY_DUTY_ID = '103'
+  HIDDEN_MEASURE_TYPE_IDS = ['430', '447']
 
   def initialize(collection, declarable)
     @collection = collection
@@ -27,6 +28,10 @@ class MeasurePresenter
     if @collection.select{|m| m.measure_type_id == 'VTZ'}.any?
       @collection.delete_if { |m| m.measure_type_id == 'VTZ' &&
                                   m.goods_nomenclature_sid != @declarable.goods_nomenclature_sid }
+    end
+
+    @collection.delete_if do |m|
+      HIDDEN_MEASURE_TYPE_IDS.include?(m.measure_type_id)
     end
 
     @collection


### PR DESCRIPTION
hide following measure types:
- Control of particulars of the declaration (suspicious value/net weight or value/supplementary unit)

  _before_
<img width="975" alt="screen shot 2016-07-19 at 5 05 52 pm" src="https://cloud.githubusercontent.com/assets/1407000/16968234/2983d146-4dd3-11e6-8259-74f703fce59e.png">

  _after_
<img width="983" alt="screen shot 2016-07-19 at 5 06 00 pm" src="https://cloud.githubusercontent.com/assets/1407000/16968244/39a0273c-4dd3-11e6-817c-e46cfca96dfe.png">

- Confidential Export Monitoring

  _before_
<img width="989" alt="screen shot 2016-07-19 at 5 06 05 pm" src="https://cloud.githubusercontent.com/assets/1407000/16968247/3f7cc854-4dd3-11e6-99b4-672888f5b7a6.png">

  _after_
<img width="998" alt="screen shot 2016-07-19 at 5 06 10 pm" src="https://cloud.githubusercontent.com/assets/1407000/16968251/45afaab6-4dd3-11e6-9feb-77ddabf6766f.png">

related trello card https://trello.com/c/TbjOZURz/1039-tariff16-specific-measure-types-should-not-be-displayed-in-the-frontend-or-the-frontend-api-proxy