### PR TITLE
show as variable 3rd country duty measures

### DIFF
--- a/app/models/concerns/declarable.rb
+++ b/app/models/concerns/declarable.rb
@@ -79,7 +79,9 @@ module Declarable
   end
 
   def basic_duty_rate
-    basic_duty_rate_components.map(&:formatted_duty_expression).join(" ")
+    if basic_duty_rate_components.count == 1
+      basic_duty_rate_components.map(&:formatted_duty_expression).join(" ")
+    end
   end
 
   def meursing_code?


### PR DESCRIPTION
if a commodity or a header have more than 1 3rd country duty measure, show them as ‘variable’ rather than concatenating all measures

_before_
<img width="899" alt="screen shot 2016-07-20 at 3 55 39 pm" src="https://cloud.githubusercontent.com/assets/1407000/17002839/e7066b92-4e92-11e6-93ab-9f19c6e2e819.png">


_after_
<img width="636" alt="screen shot 2016-07-20 at 3 55 30 pm" src="https://cloud.githubusercontent.com/assets/1407000/17002843/eb17c17c-4e92-11e6-9fc1-4c5caea68ea2.png">


related trello card https://trello.com/c/VcqlSo4Y/1047-tariff16-3-third-country-duty-measures-should-display-variable-on-overview-tab