### PR TITLE
Add data migrations to restore missing records created manually

### DIFF
--- a/db/data_migrations/20160722114115_fix_missing_measure_types_descriptions.rb
+++ b/db/data_migrations/20160722114115_fix_missing_measure_types_descriptions.rb
@@ -1,0 +1,46 @@
+TradeTariffBackend::DataMigrator.migration do
+  name "Fix Missing measure types descriptions"
+
+  up do
+    applicable {
+      # The apply block is idempotent
+      true
+    }
+    apply {
+
+      MeasureTypeDescription.unrestrict_primary_key
+      MeasureTypeDescription.find_or_create(measure_type_id: "DBE",
+                                            language_id: "EN",
+                                            description: "EXCISE - FULL, 425, MADE-WINE OF BETWEEN 15%-22% VOL",
+                                            national: true,
+                                            operation: "U")
+
+      MeasureTypeDescription.find_or_create(measure_type_id: "AIL",
+                                            language_id: "EN",
+                                            description: "Health and Safety Executive Import Licensing Firearms and Ammunition",
+                                            national: true,
+                                            operation: "U")
+
+      MeasureTypeDescription.find_or_create(measure_type_id: "DCC",
+                                            language_id: "EN",
+                                            description: "EXCISE - FULL, 433, WINE, MADE-WINE EXC 1.2% VOL NOT EXC 4% VOL.",
+                                            national: true,
+                                            operation: "U")
+
+      MeasureTypeDescription.find_or_create(measure_type_id: "DCE",
+                                            language_id: "EN",
+                                            description: "EXCISE - FULL, 435, WINE, MADE-WINE EXC 4% VOL NOT EXC 5.5% VOL.",
+                                            national: true,
+                                            operation: "U")
+    }
+  end
+
+  down do
+    applicable {
+      false
+    }
+    apply {
+      # noop
+    }
+  end
+end

--- a/db/data_migrations/20160722122015_fix_missing_footnotes_descriptions.rb
+++ b/db/data_migrations/20160722122015_fix_missing_footnotes_descriptions.rb
@@ -1,0 +1,37 @@
+TradeTariffBackend::DataMigrator.migration do
+  name "Fix Missing Footnotes descriptions"
+
+  up do
+    applicable {
+      # The apply block is idempotent
+      true
+    }
+    apply {
+
+      FootnoteDescription.unrestrict_primary_key
+      FootnoteDescription.find_or_create(footnote_description_period_sid: "-109",
+                                         footnote_type_id: "01",
+                                         footnote_id: "425",
+                                         language_id: "EN",
+                                         description: "MADE-WINE OF BETWEEN 15%-22% VOL",
+                                         national: true,
+                                         operation: "U")
+      FootnoteDescription.find_or_create(footnote_description_period_sid: "-162",
+                                         footnote_type_id: "04",
+                                         footnote_id: "001",
+                                         language_id: "EN",
+                                         description: "<p>Health and Safety Executive</p><p>Import Licensing</p><p>For further information concerning import prohibitions and restrictions for this commodity, please contact:</p><p>Health and Safety Executive</p><p>Mines, Quarries &amp; Explosives Policy</p><p>Rose Court</p><p>2 Southwark Bridge</p><p>London</p><p>SE1 9HS</p><p></p><p>Tel: 0207 717 6205</p><p>Fax: 0207 717 6690</p><p><a href='https://www.gov.uk/import-controls'>www.gov.uk/import-controls</a></p>",
+                                         national: true,
+                                         operation: "U")
+    }
+  end
+
+  down do
+    applicable {
+      false
+    }
+    apply {
+      # noop
+    }
+  end
+end


### PR DESCRIPTION
Some records were edited manually through the administration app. so these records are outdated.

This data migration adds missing records present in the production DB.