### PR TITLE
Remove referenced node from the search reference response

### DIFF
--- a/app/controllers/api/v1/search_references_controller.rb
+++ b/app/controllers/api/v1/search_references_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     class SearchReferencesController < ApiController
       def index
-        @search_references = SearchReference.eager(:referenced).for_letter(letter).by_title.all
+        @search_references = SearchReference.for_letter(letter).by_title.all
 
         respond_to do |format|
           format.json {

--- a/app/views/api/v1/search_references_base/index.json.rabl
+++ b/app/views/api/v1/search_references_base/index.json.rabl
@@ -1,11 +1,3 @@
 collection @search_references
 
 attributes :id, :title, :referenced_id, :referenced_class
-
-node :referenced do |s|
-  # use serializers:
-  # ChapterSerializer, CommoditySerializer,
-  # HeadingSerializer, SectionSerializer
-  serializer_klass = "#{s.referenced_class}Serializer".constantize
-  serializer_klass.new(s.referenced).serializable_hash
-end

--- a/spec/controllers/api/v1/rollbacks_controller_spec.rb
+++ b/spec/controllers/api/v1/rollbacks_controller_spec.rb
@@ -61,7 +61,7 @@ describe Api::V1::RollbacksController, "GET to #index" do
           id: rollback.id,
           user_id: rollback.user_id,
           reason: rollback.reason,
-          enqueued_at: rollback.enqueued_at.to_s,
+          enqueued_at: wildcard_matcher,
           date: rollback.date.to_s,
           keep: rollback.keep
         }.ignore_extra_keys!

--- a/spec/controllers/api/v1/search_references_controller_spec.rb
+++ b/spec/controllers/api/v1/search_references_controller_spec.rb
@@ -21,8 +21,8 @@ describe Api::V1::SearchReferencesController, "GET to #index"do
   context 'with letter param provided' do
     let(:pattern) {
       [
-        {id: Integer, title: String, referenced: Hash, referenced_class: 'Section', referenced_id: String },
-        {id: Integer, title: String, referenced: Hash, referenced_class: 'Chapter', referenced_id: String }
+        {id: Integer, title: String, referenced_class: 'Section', referenced_id: String },
+        {id: Integer, title: String, referenced_class: 'Chapter', referenced_id: String }
       ]
     }
 
@@ -36,7 +36,7 @@ describe Api::V1::SearchReferencesController, "GET to #index"do
   context 'with no letter param provided' do
     let(:pattern) {
       [
-        {id: Integer, title: String, referenced: Hash, referenced_class: 'Heading', referenced_id: String }
+        {id: Integer, title: String, referenced_class: 'Heading', referenced_id: String }
       ]
     }
 

--- a/spec/support/shared_examples/search_reference_controller_examples.rb
+++ b/spec/support/shared_examples/search_reference_controller_examples.rb
@@ -10,7 +10,7 @@ shared_examples_for 'search references controller' do
   describe "GET #index" do
     let(:pattern) {
       [
-        {id: Integer, title: String, referenced: Hash, referenced_class: String, referenced_id: String }
+        {id: Integer, title: String, referenced_class: String, referenced_id: String }
       ]
     }
 


### PR DESCRIPTION
#### What this PR does:

The response of the request for Search References has a node called `referenced` which has some expensive operations that make this endpoint slow, but this node is not necessary for the frontend or admin app.

This PR removes the dependency of having this node.
