### PR TITLE
run sync in every hour except between 9am-5pm

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -6,8 +6,8 @@
   - [default, 5]
 :schedule:
   UpdatesSynchronizerWorker:
-    cron: "0 * * * *"
-    description: "This job will run every hour, every day."
+    cron: "0 0-9,18-23 * * *"
+    description: "UpdatesSynchronizerWorker will run at every 0th minute past the 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 18, 19, 20, 21, 22 and 23rd hour."
   ReindexModelsWorker:
     cron: "0 1 * * *"
     description: "This job will run at 01:00 every day."


### PR DESCRIPTION
so that we don’t slow down the app at peak hours