### PR TITLE
Implement low level caching in changes endpoints

### DIFF
--- a/app/controllers/api/v1/chapters_controller.rb
+++ b/app/controllers/api/v1/chapters_controller.rb
@@ -21,9 +21,12 @@ module Api
       end
 
       def changes
-        @changes = ChangeLog.new(@chapter.changes.where { |o|
-          o.operation_date <= actual_date
-        })
+        key = "chapter-#{@chapter.goods_nomenclature_sid}-#{actual_date}/changes"
+        @changes = Rails.cache.fetch(key, expires_in: 12.hours) do
+          ChangeLog.new(@chapter.changes.where { |o|
+            o.operation_date <= actual_date
+          })
+        end
 
         render 'api/v1/changes/changes'
       end

--- a/app/controllers/api/v1/commodities_controller.rb
+++ b/app/controllers/api/v1/commodities_controller.rb
@@ -35,9 +35,12 @@ module Api
       end
 
       def changes
-        @changes = ChangeLog.new(@commodity.changes.where { |o|
-          o.operation_date <= actual_date
-        })
+        key = "commodity-#{@commodity.goods_nomenclature_sid}-#{actual_date}/changes"
+        @changes = Rails.cache.fetch(key, expires_in: 12.hours) do
+          ChangeLog.new(@commodity.changes.where { |o|
+            o.operation_date <= actual_date
+          })
+        end
 
         render 'api/v1/changes/changes'
       end

--- a/app/controllers/api/v1/headings_controller.rb
+++ b/app/controllers/api/v1/headings_controller.rb
@@ -44,9 +44,12 @@ module Api
       end
 
       def changes
-        @changes = ChangeLog.new(@heading.changes.where { |o|
-          o.operation_date <= actual_date
-        })
+        key = "heading-#{@heading.goods_nomenclature_sid}-#{actual_date}/changes"
+        @changes = Rails.cache.fetch(key, expires_in: 12.hours) do
+          ChangeLog.new(@heading.changes.where { |o|
+            o.operation_date <= actual_date
+          })
+        end
 
         render 'api/v1/changes/changes'
       end


### PR DESCRIPTION
Implement low level caching in changes endpoints for chapters, headings and commodities.

Store the content for 12 hours, the `key` is manually generated since `sequel` does not generate a `cache_key` method, so we compose a new key based on the id, date and changes endpoint.

Before the change:

`Completed 200 OK in 847ms (Views: 81.9ms | Models: 758.7ms)`

After the change: 

`Completed 200 OK in 121ms (Views: 68.1ms | Models: 50.5ms)`