### PR TITLE
do not log smoke requests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -42,6 +42,13 @@ class ApplicationController < ActionController::Base
     render nothing: true
   end
 
+  protected
+
+  def append_info_to_payload(payload)
+    super
+    payload[:user_agent] = request.headers["HTTP_X_ORIGINAL_USER_AGENT"].presence || request.env["HTTP_USER_AGENT"]
+  end
+
   private
 
   def actual_date

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,6 +53,14 @@ Rails.application.configure do
       params: event.payload[:params].except('controller', 'action', 'format', 'utf8'),
     }.merge(JSON.parse(ENV['VCAP_APPLICATION']))
   end
+  config.lograge.ignore_custom = lambda do |event, *args|
+    [
+      "Smokey Test / Ruby",
+      "updown.io"
+    ].any? do |ignored_user_agent|
+      event[:payload][:user_agent] == ignored_user_agent
+    end
+  end
 
   # Use a different cache store in production.
   config.cache_store = :dalli_store, nil, {


### PR DESCRIPTION
from following user agents:

- Smokey Test / Ruby
- updown.io

the frontend will forward the client’s original User agent in `X_ORIGINAL_USER_AGENT` header, so we’ll be preferring this as the user agent