### PR TITLE
Fix flaky specs when running with seed 29644

### DIFF
--- a/lib/chief_importer.rb
+++ b/lib/chief_importer.rb
@@ -1,3 +1,4 @@
+require "tariff_importer/logger"
 require "chief_importer/entry"
 require "chief_importer/start_entry"
 require "chief_importer/end_entry"

--- a/lib/taric_importer.rb
+++ b/lib/taric_importer.rb
@@ -1,5 +1,6 @@
 require 'nokogiri'
 
+require 'tariff_importer/logger'
 require 'taric_importer/transaction'
 require 'taric_importer/record_processor'
 require 'taric_importer/xml_parser'

--- a/spec/support/logger_helper.rb
+++ b/spec/support/logger_helper.rb
@@ -3,21 +3,22 @@ require 'active_support/log_subscriber/test_helper'
 module LoggerHelper
   include ActiveSupport::LogSubscriber::TestHelper
 
-  def tariff_importer_logger_listener
+  def tariff_importer_logger
     setup # Setup LogSubscriber::TestHelper
     TariffImporter::Logger.attach_to :tariff_importer
-    TariffImporter::Logger.logger = @logger
+    yield
+    teardown
   end
 
   def tariff_synchronizer_logger_listener
     setup # Setup LogSubscriber::TestHelper
-    allow_any_instance_of(TariffSynchronizer::Logger).to receive(:logger).and_return(@logger)
     TariffSynchronizer::Logger.attach_to :tariff_synchronizer
   end
 
-  def chief_transformer_logger_listener
+  def chief_transformer_logger
     setup # Setup LogSubscriber::TestHelper
     ChiefTransformer::Logger.attach_to :chief_transformer
-    ChiefTransformer::Logger.logger = @logger
+    yield
+    teardown
   end
 end

--- a/spec/unit/chief_importer_spec.rb
+++ b/spec/unit/chief_importer_spec.rb
@@ -25,10 +25,11 @@ describe ChiefImporter do
       end
 
       it "logs an info event" do
-        tariff_importer_logger_listener
-        importer = ChiefImporter.new(chief_update)
-        importer.import
-        expect(@logger.logged(:info).last).to eq("Parsed 1506 CHIEF records from 2012-02-13_KBT009(12044).txt")
+        tariff_importer_logger do
+          importer = ChiefImporter.new(chief_update)
+          importer.import
+          expect(@logger.logged(:info).last).to eq("Parsed 1506 CHIEF records from 2012-02-13_KBT009(12044).txt")
+        end
       end
     end
 
@@ -58,10 +59,11 @@ describe ChiefImporter do
       end
 
       it "raises ChiefImportException and sends a log" do
-        tariff_importer_logger_listener
-        importer = ChiefImporter.new(chief_update)
-        expect { importer.import }.to raise_error ChiefImporter::ImportException
-        expect(@logger.logged(:error).last).to eq("CHIEF import of 2012-02-13_KBT009(12044).txt failed: Reason: Unclosed quoted field on line 1.")
+        tariff_importer_logger do
+          importer = ChiefImporter.new(chief_update)
+          expect { importer.import }.to raise_error ChiefImporter::ImportException
+          expect(@logger.logged(:error).last).to eq("CHIEF import of 2012-02-13_KBT009(12044).txt failed: Reason: Unclosed quoted field on line 1.")
+        end
       end
     end
   end

--- a/spec/unit/chief_transformer/logger_spec.rb
+++ b/spec/unit/chief_transformer/logger_spec.rb
@@ -1,54 +1,45 @@
-require 'rails_helper'
-require 'chief_transformer'
+require "rails_helper"
+require "chief_transformer"
 
 describe ChiefTransformer::Logger do
-  before { chief_transformer_logger_listener }
-
-  describe '#start_transform logging' do
-    before { ChiefTransformer.instance.invoke }
-
-    it 'logs an info event' do
-      expect(@logger.logged(:info).size).to be >= 1
-      expect(@logger.logged(:info).first).to match /CHIEF Transformer started/
+  describe "#start_transform logging" do
+    it "logs an info event" do
+      chief_transformer_logger do
+        ChiefTransformer.instance.invoke
+        expect(@logger.logged(:info).size).to be >= 1
+        expect(@logger.logged(:info).first).to match /CHIEF Transformer started/
+      end
     end
   end
 
-  describe '#transform logging' do
-    before { ChiefTransformer.instance.invoke }
-
-    context 'transformation with errors' do
+  describe "#transform logging" do
+    context "transformation with errors" do
       let!(:tame)    { create :tame, :unprocessed }
       let!(:measure) { create :measure }
 
-      before {
-        allow_any_instance_of(
-          Chief::Tame
-        ).to receive(:mark_as_processed!)
-        .and_raise(Sequel::ValidationFailed.new(measure))
+      it "logs an error event and sends an error email" do
+        allow_any_instance_of(Chief::Tame).to receive(:mark_as_processed!)
+          .and_raise(Sequel::ValidationFailed.new(measure))
 
-        rescuing { ChiefTransformer.instance.invoke }
-      }
+        chief_transformer_logger do
+          expect{ ChiefTransformer.instance.invoke }.to raise_error(ChiefTransformer::TransformException)
 
-      it 'logs an error event' do
-        expect(@logger.logged(:error).size).to eq 1
-        expect(@logger.logged(:error).last).to match /Could not transform/i
-      end
+          expect(@logger.logged(:error).size).to eq 1
+          expect(@logger.logged(:error).last).to match /Could not transform/i
 
-      it 'sends an error email' do
-        expect(ActionMailer::Base.deliveries).to_not be_empty
-        email = ActionMailer::Base.deliveries.last
-        expect(email.encoded).to match /invalid CHIEF operation/
+          expect(ActionMailer::Base.deliveries).to_not be_empty
+          email = ActionMailer::Base.deliveries.last
+          expect(email.encoded).to match /invalid CHIEF operation/
+        end
       end
     end
   end
 
-  describe '#process logging' do
-    let!(:tame) { create :tame }
-
-    context 'successful process' do
-      before { ChiefTransformer.instance.invoke }
-
-      it 'logs an info event' do
+  describe "#process logging" do
+    it "when successful process logs an info event" do
+      create :tame
+      chief_transformer_logger do
+        ChiefTransformer.instance.invoke
         expect(@logger.logged(:info).size).to be >= 1
         expect(@logger.logged(:info)[1]).to match /processed/i
       end

--- a/spec/unit/taric_importer_spec.rb
+++ b/spec/unit/taric_importer_spec.rb
@@ -1,5 +1,4 @@
 require "rails_helper"
-require "taric_importer"
 
 describe TaricImporter do
   describe "#import" do
@@ -20,11 +19,12 @@ describe TaricImporter do
       end
 
       it "logs an error event" do
-        tariff_importer_logger_listener
-        importer = TaricImporter.new(taric_update)
-        expect { importer.import }.to raise_error TaricImporter::ImportException
-        expect(@logger.logged(:error).size).to eq(1)
-        expect(@logger.logged(:error).last).to include("Taric import failed: uninitialized constant")
+        tariff_importer_logger do
+          importer = TaricImporter.new(taric_update)
+          expect { importer.import }.to raise_error TaricImporter::ImportException
+          expect(@logger.logged(:error).size).to eq(1)
+          expect(@logger.logged(:error).last).to include("Taric import failed: uninitialized constant")
+        end
       end
     end
 
@@ -99,11 +99,12 @@ describe TaricImporter do
       after { ExplicitAbrogationRegulation.restrict_primary_key }
 
       it "logs an info event" do
-        tariff_importer_logger_listener
-        importer = TaricImporter.new(taric_update)
-        importer.import
-        expect(@logger.logged(:info).size).to eq(1)
-        expect(@logger.logged(:info).last).to eq("Successfully imported Taric file: 2013-08-02_TGB13214.xml")
+        tariff_importer_logger do
+          importer = TaricImporter.new(taric_update)
+          importer.import
+          expect(@logger.logged(:info).size).to eq(1)
+          expect(@logger.logged(:info).last).to eq("Successfully imported Taric file: 2013-08-02_TGB13214.xml")
+        end
       end
     end
 
@@ -115,10 +116,11 @@ describe TaricImporter do
       end
 
       it "logs an error event" do
-        tariff_importer_logger_listener
-        importer = TaricImporter.new(taric_update)
-        expect { importer.import }.to raise_error TaricImporter::ImportException
-        expect(@logger.logged(:error).first).to include("Unexpected Taric operation type:")
+        tariff_importer_logger do
+          importer = TaricImporter.new(taric_update)
+          expect { importer.import }.to raise_error TaricImporter::ImportException
+          expect(@logger.logged(:error).first).to include("Unexpected Taric operation type:")
+        end
       end
   end
 end


### PR DESCRIPTION
Fix flaky specs related to the logging system.

Causes a weird bug, when triggering the instrument method to this logger, it logs twice.

Ensure the teardown call of the log mocker from `ActiveSupport::LogSubscriber::TestHelper`