### PR TITLE
Update rack timeout config

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -3,6 +3,7 @@ TARIFF_SYNC_PASSWORD=tariff_sync_password
 TARIFF_SYNC_HOST=https://webservices.hmrc.gov.uk
 TARIFF_SYNC_EMAIL=user@example.com
 TARIFF_FROM_EMAIL=no-reply@tariff-email.bitzesty.com
+RACK_TIMEOUT_SERVICE=15
 AWS_ACCESS_KEY_ID=aws_access_key_id
 AWS_SECRET_ACCESS_KEY=aws_secret_access_key
 AWS_REGION=aws_region

--- a/app/controllers/api/v1/commodities_controller.rb
+++ b/app/controllers/api/v1/commodities_controller.rb
@@ -31,6 +31,7 @@ module Api
                                                       :full_temporary_stop_regulations,
                                                       :measure_partial_temporary_stops).all, @commodity).validate!
 
+        @commodity_cache_key = "commodity-#{@commodity.goods_nomenclature_sid}-#{actual_date}"
         respond_with @commodity
       end
 

--- a/app/controllers/api/v1/headings_controller.rb
+++ b/app/controllers/api/v1/headings_controller.rb
@@ -40,6 +40,7 @@ module Api
 
         end
 
+        @heading_cache_key = "heading-#{@heading.goods_nomenclature_sid}-#{actual_date}-#{@heading.declarable?}"
         respond_with @heading
       end
 

--- a/app/views/api/v1/commodities/show.json.rabl
+++ b/app/views/api/v1/commodities/show.json.rabl
@@ -1,5 +1,5 @@
 object @commodity
-cache [ actual_date, @commodity ], expires_in: 1.day
+cache @commodity_cache_key, expires_in: 1.day
 
 attributes :producline_suffix, :description, :number_indents,
            :goods_nomenclature_item_id, :bti_url, :formatted_description,

--- a/app/views/api/v1/headings/show.json.rabl
+++ b/app/views/api/v1/headings/show.json.rabl
@@ -1,5 +1,5 @@
 object @heading
-cache [ actual_date, @heading ], expires_in: 1.day
+cache @heading_cache_key, expires_in: 1.day
 
 attributes :goods_nomenclature_item_id, :description, :bti_url,
            :formatted_description

--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -1,1 +1,1 @@
-Rack::Timeout.service_timeout = 6 # seconds
+Rack::Timeout.service_timeout = Integer(ENV.fetch("RACK_TIMEOUT_SERVICE", 6))


### PR DESCRIPTION
#### What this PR does:

- Set the timeout as an environment variable, there are some endpoints that could take more than 6 seconds to generate the response, because this is failing, no cache could be generated to that response.

- Fix the cache, currently the cache was working only for a few minutes, this is because the object does not respond to the cache_key method. This add a custom key to cache responses from heading and commodities.

Cache behaviour before the fix:

![1 cf ruby 2016-07-28 11-05-13](https://cloud.githubusercontent.com/assets/1143421/17220778/5d1a073e-54b6-11e6-8883-fb094b3c5391.png)

Cache behaviour after the fix:
![after2](https://cloud.githubusercontent.com/assets/1143421/17220779/5f8e7f72-54b6-11e6-88c1-ad51919d6ff5.png)


#### Notes

This add the `RACK_TIMEOUT_SERVICE` environment variable, so before deploying it will be nice to have that variable already set.