### PR TITLE
Optimize geographical area association

### DIFF
--- a/app/controllers/api/v1/geographical_areas_controller.rb
+++ b/app/controllers/api/v1/geographical_areas_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     class GeographicalAreasController < ApiController
       def countries
-        @geographical_areas = GeographicalArea.eager(:geographical_area_descriptions)
+        @geographical_areas = GeographicalArea.eager_graph(:geographical_area_descriptions)
                                               .actual
                                               .countries
                                               .all

--- a/app/models/geographical_area.rb
+++ b/app/models/geographical_area.rb
@@ -19,7 +19,7 @@ class GeographicalArea < Sequel::Model
   end
 
   def geographical_area_description
-    geographical_area_descriptions(true).first
+    geographical_area_descriptions.first
   end
 
   many_to_one :parent_geographical_area, class: self

--- a/app/views/api/v1/measures/_measure.json.rabl
+++ b/app/views/api/v1/measures/_measure.json.rabl
@@ -37,24 +37,16 @@ node(:suspension_legal_act, if: ->(measure) { !measure.national && measure.suspe
   }
 end
 
-child(measure_conditions: :measure_conditions) do
+child(:measure_conditions) do
   attributes :condition, :document_code, :requirement, :action, :duty_expression
 end
 
-child(geographical_area: :geographical_area) do |geographical_area|
-  attributes :id
-
-  node(:description) { |ga|
-    ga.geographical_area_description.description
-  }
+child(:geographical_area) do
+  attributes :id, :description
 
   unless locals[:object].third_country?
     child(contained_geographical_areas: :children_geographical_areas) do
-      attributes :id
-
-      node(:description) { |ga|
-        ga.geographical_area_description.description
-      }
+      attributes :id, :description
     end
   end
 end

--- a/spec/models/geographical_area_spec.rb
+++ b/spec/models/geographical_area_spec.rb
@@ -43,7 +43,6 @@ describe GeographicalArea do
             expect(
               GeographicalArea.where(geographical_area_sid: geographical_area.geographical_area_sid)
                           .eager(:geographical_area_descriptions)
-                          .all
                           .first
                           .geographical_area_description.pk
             ).to eq geographical_area_description1.pk
@@ -52,23 +51,19 @@ describe GeographicalArea do
 
         it 'loads correct description respecting given time' do
           TimeMachine.at(1.year.ago) do
-            expect(
-              GeographicalArea.where(geographical_area_sid: geographical_area.geographical_area_sid)
-                          .eager(:geographical_area_descriptions)
-                          .all
-                          .first
-                          .geographical_area_description.pk
-            ).to eq geographical_area_description1.pk
+            result = GeographicalArea.eager(:geographical_area_descriptions)
+                      .where(geographical_area_sid: geographical_area.geographical_area_sid)
+                      .first.geographical_area_description.pk
+            expect(result).to eq(geographical_area_description1.pk)
           end
+        end
 
+        it 'loads correct description respecting given time' do
           TimeMachine.at(4.years.ago) do
-            expect(
-              GeographicalArea.where(geographical_area_sid: geographical_area.geographical_area_sid)
-                          .eager(:geographical_area_descriptions)
-                          .all
-                          .first
-                          .geographical_area_description.pk
-            ).to eq geographical_area_description2.pk
+            result = GeographicalArea.where(geographical_area_sid: geographical_area.geographical_area_sid)
+                      .eager(:geographical_area_descriptions)
+                      .first.geographical_area_description.pk
+            expect(result).to eq(geographical_area_description2.pk)
           end
         end
       end


### PR DESCRIPTION
This PR fixes a bug with sequel associations not caching or caching when is not required.

This will speed up the response times:


Before:

```
[2016-07-28T23:44:43.204807 #1652]  INFO -- : Started GET "/commodities/6202129090?as_of=2016-07-28" for 127.0.0.1 at 2016-07-28 23:44:43 -0500
[2016-07-28T23:44:43.266070 #1652]  INFO -- : Processing by Api::V1::CommoditiesController#show as JSON
[2016-07-28T23:44:43.266242 #1652]  INFO -- :   Parameters: {"as_of"=>"2016-07-28", "id"=>"6202129090"}
[2016-07-28T23:44:51.072439 #1652]  INFO -- :   Rendered api/v1/commodities/show.json.rabl (6648.0ms)
[2016-07-28T23:44:51.072976 #1652]  INFO -- : Completed 200 OK in 7807ms (Views: 3209.5ms | Models: 3906.9ms)
```

After:

```
[2016-07-28T23:42:21.006828 #1450]  INFO -- : Started GET "/commodities/6202129090?as_of=2016-07-28" for 127.0.0.1 at 2016-07-28 23:42:21 -0500
[2016-07-28T23:42:21.073762 #1450]  INFO -- : Processing by Api::V1::CommoditiesController#show as JSON
[2016-07-28T23:42:21.073942 #1450]  INFO -- :   Parameters: {"as_of"=>"2016-07-28", "id"=>"6202129090"}
[2016-07-28T23:42:23.506844 #1450]  INFO -- :   Rendered api/v1/commodities/show.json.rabl (1234.4ms)
[2016-07-28T23:42:23.507241 #1450]  INFO -- : Completed 200 OK in 2433ms (Views: 751.9ms | Models: 971.9ms)
```


