### PR TITLE
[WIP] Expire cache at the end of the day

### DIFF
--- a/app/controllers/api/v1/chapters_controller.rb
+++ b/app/controllers/api/v1/chapters_controller.rb
@@ -22,7 +22,7 @@ module Api
 
       def changes
         key = "chapter-#{@chapter.goods_nomenclature_sid}-#{actual_date}/changes"
-        @changes = Rails.cache.fetch(key, expires_in: 12.hours) do
+        @changes = Rails.cache.fetch(key, expires_at: actual_date.end_of_day) do
           ChangeLog.new(@chapter.changes.where { |o|
             o.operation_date <= actual_date
           })

--- a/app/controllers/api/v1/commodities_controller.rb
+++ b/app/controllers/api/v1/commodities_controller.rb
@@ -37,7 +37,7 @@ module Api
 
       def changes
         key = "commodity-#{@commodity.goods_nomenclature_sid}-#{actual_date}/changes"
-        @changes = Rails.cache.fetch(key, expires_in: 12.hours) do
+        @changes = Rails.cache.fetch(key, expires_at: actual_date.end_of_day) do
           ChangeLog.new(@commodity.changes.where { |o|
             o.operation_date <= actual_date
           })

--- a/app/controllers/api/v1/headings_controller.rb
+++ b/app/controllers/api/v1/headings_controller.rb
@@ -46,7 +46,7 @@ module Api
 
       def changes
         key = "heading-#{@heading.goods_nomenclature_sid}-#{actual_date}/changes"
-        @changes = Rails.cache.fetch(key, expires_in: 12.hours) do
+        @changes = Rails.cache.fetch(key, expires_at: actual_date.end_of_day) do
           ChangeLog.new(@heading.changes.where { |o|
             o.operation_date <= actual_date
           })

--- a/app/views/api/v1/commodities/show.json.rabl
+++ b/app/views/api/v1/commodities/show.json.rabl
@@ -1,5 +1,5 @@
 object @commodity
-cache @commodity_cache_key, expires_in: 1.day
+cache @commodity_cache_key, expires_at: actual_date.end_of_day
 
 attributes :producline_suffix, :description, :number_indents,
            :goods_nomenclature_item_id, :bti_url, :formatted_description,

--- a/app/views/api/v1/geographical_areas/countries.json.rabl
+++ b/app/views/api/v1/geographical_areas/countries.json.rabl
@@ -1,4 +1,4 @@
 collection @geographical_areas
-cache 'geographical_areas', expires_in: 1.day
+cache 'geographical_areas', expires_at: actual_date.end_of_day
 
 attributes :id, :description

--- a/app/views/api/v1/headings/show.json.rabl
+++ b/app/views/api/v1/headings/show.json.rabl
@@ -1,5 +1,5 @@
 object @heading
-cache @heading_cache_key, expires_in: 1.day
+cache @heading_cache_key, expires_at: actual_date.end_of_day
 
 attributes :goods_nomenclature_item_id, :description, :bti_url,
            :formatted_description


### PR DESCRIPTION

Expire cache at the end of the day, because we don’t know the moment the cache is created but we have to make sure that the expiration date will not overlap other dates.