### PR TITLE
Low level caching to the codes method in HiddenGoodsNomenclature

### DIFF
--- a/app/models/hidden_goods_nomenclature.rb
+++ b/app/models/hidden_goods_nomenclature.rb
@@ -8,6 +8,8 @@ class HiddenGoodsNomenclature < Sequel::Model
   end
 
   def self.codes
-    all.map(&:goods_nomenclature_item_id)
+    Rails.cache.fetch("hidden_goods_nomenclature_codes", expires_in: 24.hours) do
+      all.map(&:goods_nomenclature_item_id)
+    end
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -20,6 +20,8 @@ Rails.application.configure do
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
 
+  config.cache_store = :memory_store
+
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false
 

--- a/spec/models/hidden_goods_nomenclature_spec.rb
+++ b/spec/models/hidden_goods_nomenclature_spec.rb
@@ -7,10 +7,10 @@ describe HiddenGoodsNomenclature do
   end
 
   describe '.codes' do
-    let!(:hidden_gono1) { create :hidden_goods_nomenclature, goods_nomenclature_item_id: "9900000000" }
-    let!(:hidden_gono2) { create :hidden_goods_nomenclature, goods_nomenclature_item_id: "0101000000" }
-
     it 'returns array of hidden codes' do
+      hidden_gono1 = create :hidden_goods_nomenclature, goods_nomenclature_item_id: "9900000000"
+      hidden_gono2 = create :hidden_goods_nomenclature, goods_nomenclature_item_id: "0101000000"
+
       expect(HiddenGoodsNomenclature.codes).to eq [hidden_gono2.goods_nomenclature_item_id,
                                                    hidden_gono1.goods_nomenclature_item_id]
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -53,6 +53,7 @@ RSpec.configure do |config|
   end
 
   config.before(:each) do
+    Rails.cache.clear
     Sidekiq::Worker.clear_all
   end
 end


### PR DESCRIPTION
#### What this PR does:

Implement low level caching in the `codes` method since this array do not change frecuently.. and  this array with ids is used in different queries.

Avoid going to the db to return the same values

#### Notes:

Since we are using low level caching by default rails will use the default method (disk), so we have change it to the memory store..  and clear the cache before each test.
