### PR TITLE
[Bugfix] fix logic from last_updates_are_missing? method

### DIFF
--- a/lib/tariff_synchronizer.rb
+++ b/lib/tariff_synchronizer.rb
@@ -75,7 +75,7 @@ module TariffSynchronizer
 
   # Number of days to warn about missing updates after
   mattr_accessor :warning_day_count
-  self.warning_day_count = 4
+  self.warning_day_count = 3
 
   delegate :instrument, :subscribe, to: ActiveSupport::Notifications
 

--- a/lib/tariff_synchronizer/base_update.rb
+++ b/lib/tariff_synchronizer/base_update.rb
@@ -137,7 +137,7 @@ module TariffSynchronizer
       end
 
       def last_updates_are_missing?
-        order(Sequel.desc(:issue_date)).last(TariffSynchronizer.warning_day_count).all?(&:missing?)
+        descending.first(TariffSynchronizer.warning_day_count).all?(&:missing?)
       end
 
       def notify_about_missing_updates

--- a/spec/unit/tariff_synchronizer/chief_update_spec.rb
+++ b/spec/unit/tariff_synchronizer/chief_update_spec.rb
@@ -17,26 +17,6 @@ describe TariffSynchronizer::ChiefUpdate do
     end
   end
 
-  describe '.sync' do
-    let(:not_found_response) { build :response, :not_found }
-
-    context 'file not found for nth time in a row' do
-      let!(:chief_update1) { create :chief_update, :missing, issue_date: Date.today.ago(2.days) }
-      let!(:chief_update2) { create :chief_update, :missing, issue_date: Date.today.ago(3.days) }
-      let!(:stub_logger)   { double.as_null_object }
-
-      before do
-        allow(TariffSynchronizer::TariffUpdatesRequester).to receive(:perform)
-                                                       .and_return(not_found_response)
-      end
-
-      it 'notifies about several missing updates in a row' do
-        expect(TariffSynchronizer::ChiefUpdate).to receive(:notify_about_missing_updates).and_return(true)
-        TariffSynchronizer::ChiefUpdate.sync
-      end
-    end
-  end
-
   describe "#import!" do
 
     let(:chief_update) { create :chief_update}

--- a/spec/unit/tariff_synchronizer/taric_update_spec.rb
+++ b/spec/unit/tariff_synchronizer/taric_update_spec.rb
@@ -16,25 +16,6 @@ describe TariffSynchronizer::TaricUpdate do
     end
   end
 
-  describe ".sync" do
-    let(:not_found_response) { build :response, :not_found }
-
-    it "notifies about several missing updates in a row" do
-      allow(TariffSynchronizer::TariffUpdatesRequester).to receive(:perform).and_return(not_found_response)
-      expect(TariffSynchronizer::TaricUpdate).to receive(:notify_about_missing_updates)
-      create :taric_update, :missing, issue_date: Date.today.ago(2.days)
-      create :taric_update, :missing, issue_date: Date.today.ago(3.days)
-      TariffSynchronizer::TaricUpdate.sync
-    end
-
-    it "Calls the difference from the intial update to the current time, the donwload method" do
-      expect(TariffSynchronizer::TariffUpdatesRequester).to receive(:perform).and_return(not_found_response).exactly(3).times
-      travel_to TariffSynchronizer.taric_initial_update_date + 2 do
-        TariffSynchronizer::TaricUpdate.sync
-      end
-    end
-  end
-
   describe "#import!" do
 
     let(:taric_update) { create :taric_update}


### PR DESCRIPTION
#### What this PR does:

Fixes the logic with the `last_updates_are_missing?` method which was  returning the list of `updates` ordered by the `issue_date` descending, but taking the last x records. If we are returning a descending list we must take the first x records then.



