### PR TITLE
Auto deployment from circle ci, using deployment branches

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,1 +1,30 @@
-.gitignore
+# Ignore bundler config.
+/.bundle
+
+# Ignore bundler circle ci cache.
+vendor/bundle/*
+
+# Ignore all logfiles and tempfiles.
+/log/*
+!/log/.keep
+/tmp/*
+.byebug_history
+
+# Local tariff files
+data/*/*.xml
+data/*/*.txt
+
+# Environment files
+.env
+
+# Cloud Foundry manifest files
+*manifest.yml
+cf-ssh.yml
+
+# Other files
+config/trade_tariff_backend_secrets.yml
+*.DS_Store
+/coverage/*
+
+# Ignore git
+.git

--- a/bin/deploy
+++ b/bin/deploy
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
+set -e
 
 # Fetch deployed revision
-export GIT_OLD_REVISION=`curl "$HEALTHCHECK_URL" | grep -o -w -E '[[:alnum:]]{7}'`
+export GIT_OLD_REVISION=`curl "https://$CF_APP.$HEALTHCHECK_URL" | grep -o -w -E '[[:alnum:]]{7}'`
 # Log the new revision
 export GIT_REVISION=`git rev-parse --short HEAD`
 echo $GIT_REVISION > REVISION
+
 export GIT_MESSAGE=`git log --oneline $GIT_OLD_REVISION..$GIT_REVISION`
 
 # Check CF connectivity
@@ -23,11 +25,11 @@ cf create-app-manifest $CF_APP_WORKER
 # Database migrations
 cf push "$CF_APP"-migrations -f "$CF_APP_WORKER"_manifest.yml -c "rake db:migrate" -i 1
 
+# Deploy Worker
+cf push $CF_APP_WORKER -f "$CF_APP_WORKER"_manifest.yml
+
 # Deploy App
 cf zero-downtime-push $CF_APP -f "$CF_APP"_manifest.yml
-
-# Deploy Worker
-cf push $CF_APP_WORKER
 
 # Notify Slack deployment finished
 curl -X POST \

--- a/circle.yml
+++ b/circle.yml
@@ -7,5 +7,26 @@ machine:
   environment:
     GOVUK_APP_DOMAIN: test
 dependencies:
-  post:
-    - sudo service redis-server status || sudo service redis-server start
+  pre:
+    - curl -v -L -o cf-cli_amd64.deb 'https://cli.run.pivotal.io/stable?release=debian64&version=6.21.0'
+    - sudo dpkg -i cf-cli_amd64.deb
+    - cf -v
+    - curl -v -L -o autopilot https://github.com/contraband/autopilot/releases/download/0.0.2/autopilot-linux
+    - chmod +x autopilot
+    - yes | cf install-plugin autopilot
+deployment:
+  dev:
+    branch: master
+    commands:
+      - CF_SPACE=development CF_APP=tariff-backend-dev CF_APP_WORKER=tariff-backend-worker-dev ./bin/deploy:
+          timeout: 1200
+  staging:
+    branch: staging
+    commands:
+      - CF_SPACE=staging CF_APP=tariff-backend-staging CF_APP_WORKER=tariff-backend-worker-staging ./bin/deploy:
+          timeout: 1200
+  production:
+    branch: production
+    commands:
+      - CF_SPACE=production CF_APP=tariff-backend-production CF_APP_WORKER=tariff-backend-worker-production ./bin/deploy:
+          timeout: 1200


### PR DESCRIPTION
Auto deployment from circle ci, using deployment branches

- `.cfignore` is no longer a symlink of the `.gitignore` file.
-  Remove git folder and gems that are not for production before pushing to Cloud Foundry.

#### Notes

We notice errors like:

```
error: Error processing app files: Error uploading application.
The resource file mode is invalid: File mode '0444' is invalid.
```

Maybe related to this `cf` bug:
https://github.com/cloudfoundry/cli/issues/685

After debugging we notice that the files with these permissions were from the cache of gems used when testing, since these gems are not required for the deploy we run the bundle process without the development and test group.

Not generating these files let the process continue without issues.
