### PR TITLE
Prevent sending more than 1 email per day

### DIFF
--- a/app/views/tariff_synchronizer/mailer/applied.html.erb
+++ b/app/views/tariff_synchronizer/mailer/applied.html.erb
@@ -4,7 +4,7 @@
   Trade Tariff successfully applied <%= @update_names.size %> update(s) at <%= Time.now %>.
 </p>
 
-<p>Following updates were applied:</p>
+<h3>The following updates were applied:</h3>
 
 <ul>
   <% @update_names.each do |update_name| %>
@@ -13,6 +13,8 @@
 </ul>
 
 <% if @conformance_errors.any? %>
+  <h3>Conformance errors:</h3>
+
   <table>
     <thead>
       <tr>

--- a/lib/tariff_synchronizer.rb
+++ b/lib/tariff_synchronizer.rb
@@ -220,8 +220,10 @@ module TariffSynchronizer
 
   def check_tariff_updates_failures
     if BaseUpdate.failed.any?
-      instrument("failed_updates_present.tariff_synchronizer",
-                 file_names: BaseUpdate.failed.map(&:filename))
+      unless Rails.cache.read("failed_updates_present_notification_sent")
+        instrument("failed_updates_present.tariff_synchronizer", file_names: BaseUpdate.failed.map(&:filename))
+        Rails.cache.write("failed_updates_present_notification_sent", true, expires_in: DateTime.current.seconds_until_end_of_day)
+      end
       raise FailedUpdatesError
     end
   end

--- a/lib/tariff_synchronizer/base_update.rb
+++ b/lib/tariff_synchronizer/base_update.rb
@@ -141,9 +141,12 @@ module TariffSynchronizer
       end
 
       def notify_about_missing_updates
+        return if Rails.cache.read("missing_updates_notification_sent")
+
         instrument("missing_updates.tariff_synchronizer",
                    update_type: update_type,
                    count: TariffSynchronizer.warning_day_count)
+        Rails.cache.write("missing_updates_notification_sent", true, expires_in: DateTime.current.seconds_until_end_of_day)
       end
     end
   end


### PR DESCRIPTION
#### What this PR does:

This is a workaround to have a flag that will be switch until the end of the day.

Currently calling these methods triggers an email, and since the sync process runs every hour an email is sent every hour.

This change takes advantage of the low level caching system to invalidate after certain amount of time.

We cannot persist the state of the email sent in the db because none of this cases are for a specific tariff update.