### PR TITLE
Order the footnotes of a Measure so national comes after EU

### DIFF
--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -46,6 +46,7 @@ class Measure < Sequel::Model
                                              class_name: 'GeographicalArea'
 
   many_to_many :footnotes, join_table: :footnote_association_measures,
+                           order: Sequel.asc(:national, nulls: :first),
                            left_key: :measure_sid,
                            right_key: [:footnote_type_id, :footnote_id] do |ds|
                              ds.with_actual(Footnote)


### PR DESCRIPTION
Change the order of the footnotes of a Measure so that national ones come after the EU ones.

![order](https://cloud.githubusercontent.com/assets/1143421/18878253/8d6669fa-8495-11e6-8b15-a793d93d68b8.gif)
