### PR TITLE
Add validity_start_date to geographical area in spec

### DIFF
--- a/spec/integration/chief_transformer/custom_spec.rb
+++ b/spec/integration/chief_transformer/custom_spec.rb
@@ -350,7 +350,7 @@ describe 'CHIEF: Custom scenarios' do
   end
 
   describe 'Scenario: Excise Measure with duty type 30 and tty code 570, 571, created measure' do
-    let!(:geographical_area)           { create :geographical_area, :erga_omnes }
+    let!(:geographical_area)           { create :geographical_area, :erga_omnes, validity_start_date: DateTime.new(2013,10,1) }
     let!(:gono) { create :goods_nomenclature, :declarable, :with_indent,
                                              goods_nomenclature_sid: 79289,
                                              goods_nomenclature_item_id: "3902200010",


### PR DESCRIPTION
This PR fixes the issue with the spec failing because it was not creating the `Measure`

When we call `ChiefTransformer.instance.invoke` it sends the MFCM and TAME records to `Processor` which is going to create instances of `CandidateMeasure` class.

`CandidateMeasure` validates the existence of `GeographicalArea` where the `validity_start_date` is less or equal than the `validity_start_date` value of the `CandidateMeasure` object.

but the factory of `GeographicalArea` has this code:

```
validity_start_date   { Date.today.ago(3.years) }`
```

And the spec has `fe_tsmp: DateTime.new(2013,10,1),`

https://github.com/bitzesty/trade-tariff-backend/blob/master/spec/integration/chief_transformer/custom_spec.rb#L363

That means that after October 1st of 2016 these specs are going to fail.

Now I've fixed the validity start date of the `geographical_area` object.
