### PR TITLE
Add new migration to increase the size of the footnote_id attribute

### DIFF
--- a/db/migrate/20161209195324_alter_footnotes_foonote_id_lenght.rb
+++ b/db/migrate/20161209195324_alter_footnotes_foonote_id_lenght.rb
@@ -1,0 +1,75 @@
+Sequel.migration do
+  up do
+    run %Q{
+      -- UPDATE footnotes_oplog
+
+      DROP VIEW footnotes;
+
+      ALTER TABLE footnotes_oplog
+        ALTER COLUMN footnote_id TYPE varchar(5);
+
+      CREATE VIEW footnotes AS
+       SELECT footnotes1.footnote_id,
+          footnotes1.footnote_type_id,
+          footnotes1.validity_start_date,
+          footnotes1.validity_end_date,
+          footnotes1."national",
+          footnotes1.oid,
+          footnotes1.operation,
+          footnotes1.operation_date
+         FROM footnotes_oplog footnotes1
+        WHERE ((footnotes1.oid IN ( SELECT max(footnotes2.oid) AS MAX
+                 FROM footnotes_oplog footnotes2
+                WHERE (((footnotes1.footnote_type_id)::text = (footnotes2.footnote_type_id)::text) AND ((footnotes1.footnote_id)::text = (footnotes2.footnote_id)::text)))) AND ((footnotes1.operation)::text <> 'D'::text));
+
+
+      -- UPDATE footnote_description_periods_oplog
+
+      DROP VIEW footnote_description_periods;
+
+      ALTER TABLE footnote_description_periods_oplog
+        ALTER COLUMN footnote_id TYPE varchar(5);
+
+      CREATE VIEW footnote_description_periods AS
+       SELECT footnote_description_periods1.footnote_description_period_sid,
+          footnote_description_periods1.footnote_type_id,
+          footnote_description_periods1.footnote_id,
+          footnote_description_periods1.validity_start_date,
+          footnote_description_periods1.validity_end_date,
+          footnote_description_periods1."national",
+          footnote_description_periods1.oid,
+          footnote_description_periods1.operation,
+          footnote_description_periods1.operation_date
+         FROM footnote_description_periods_oplog footnote_description_periods1
+        WHERE ((footnote_description_periods1.oid IN ( SELECT max(footnote_description_periods2.oid) AS max
+                 FROM footnote_description_periods_oplog footnote_description_periods2
+                WHERE (((footnote_description_periods1.footnote_id)::text = (footnote_description_periods2.footnote_id)::text) AND ((footnote_description_periods1.footnote_type_id)::text = (footnote_description_periods2.footnote_type_id)::text) AND (footnote_description_periods1.footnote_description_period_sid = footnote_description_periods2.footnote_description_period_sid)))) AND ((footnote_description_periods1.operation)::text <> 'D'::text));
+
+
+      -- UPDATE footnote_descriptions_oplog
+
+      DROP VIEW footnote_descriptions;
+
+      ALTER TABLE footnote_descriptions_oplog
+        ALTER COLUMN footnote_id TYPE varchar(5);
+
+
+      CREATE VIEW footnote_descriptions AS
+      SELECT footnote_descriptions1.footnote_description_period_sid,
+        footnote_descriptions1.footnote_type_id,
+        footnote_descriptions1.footnote_id,
+        footnote_descriptions1.language_id,
+        footnote_descriptions1.description,
+        footnote_descriptions1."national",
+        footnote_descriptions1.oid,
+        footnote_descriptions1.operation,
+        footnote_descriptions1.operation_date
+       FROM footnote_descriptions_oplog footnote_descriptions1
+      WHERE ((footnote_descriptions1.oid IN ( SELECT max(footnote_descriptions2.oid) AS max
+               FROM footnote_descriptions_oplog footnote_descriptions2
+              WHERE ((footnote_descriptions1.footnote_description_period_sid = footnote_descriptions2.footnote_description_period_sid) AND ((footnote_descriptions1.footnote_id)::text = (footnote_descriptions2.footnote_id)::text) AND ((footnote_descriptions1.footnote_type_id)::text = (footnote_descriptions2.footnote_type_id)::text)))) AND ((footnote_descriptions1.operation)::text <> 'D'::text));
+
+
+    }
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,11 +2,12 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.5.0
--- Dumped by pg_dump version 9.5.0
+-- Dumped from database version 9.6.1
+-- Dumped by pg_dump version 9.6.1
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SET check_function_bodies = false;
@@ -1878,7 +1879,7 @@ ALTER SEQUENCE footnote_association_meursing_headings_oid_seq OWNED BY footnote_
 CREATE TABLE footnote_description_periods_oplog (
     footnote_description_period_sid integer,
     footnote_type_id character varying(2),
-    footnote_id character varying(3),
+    footnote_id character varying(5),
     validity_start_date timestamp without time zone,
     created_at timestamp without time zone,
     validity_end_date timestamp without time zone,
@@ -1935,7 +1936,7 @@ ALTER SEQUENCE footnote_description_periods_oid_seq OWNED BY footnote_descriptio
 CREATE TABLE footnote_descriptions_oplog (
     footnote_description_period_sid integer,
     footnote_type_id character varying(2),
-    footnote_id character varying(3),
+    footnote_id character varying(5),
     language_id character varying(5),
     description text,
     created_at timestamp without time zone,
@@ -2098,7 +2099,7 @@ ALTER SEQUENCE footnote_types_oid_seq OWNED BY footnote_types_oplog.oid;
 --
 
 CREATE TABLE footnotes_oplog (
-    footnote_id character varying(3),
+    footnote_id character varying(5),
     footnote_type_id character varying(2),
     validity_start_date timestamp without time zone,
     validity_end_date timestamp without time zone,
@@ -6224,770 +6225,770 @@ ALTER SEQUENCE users_id_seq OWNED BY users.id;
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: additional_code_description_periods_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY additional_code_description_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('additional_code_description_periods_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: additional_code_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY additional_code_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('additional_code_descriptions_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: additional_code_type_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY additional_code_type_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('additional_code_type_descriptions_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: additional_code_type_measure_types_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY additional_code_type_measure_types_oplog ALTER COLUMN oid SET DEFAULT nextval('additional_code_type_measure_types_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: additional_code_types_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY additional_code_types_oplog ALTER COLUMN oid SET DEFAULT nextval('additional_code_types_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: additional_codes_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY additional_codes_oplog ALTER COLUMN oid SET DEFAULT nextval('additional_codes_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: base_regulations_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY base_regulations_oplog ALTER COLUMN oid SET DEFAULT nextval('base_regulations_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: certificate_description_periods_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY certificate_description_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('certificate_description_periods_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: certificate_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY certificate_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('certificate_descriptions_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: certificate_type_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY certificate_type_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('certificate_type_descriptions_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: certificate_types_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY certificate_types_oplog ALTER COLUMN oid SET DEFAULT nextval('certificate_types_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: certificates_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY certificates_oplog ALTER COLUMN oid SET DEFAULT nextval('certificates_oid_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: chapter_notes id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY chapter_notes ALTER COLUMN id SET DEFAULT nextval('chapter_notes_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: chief_duty_expression id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY chief_duty_expression ALTER COLUMN id SET DEFAULT nextval('chief_duty_expression_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: chief_measure_type_footnote id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY chief_measure_type_footnote ALTER COLUMN id SET DEFAULT nextval('chief_measure_type_footnote_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: chief_measurement_unit id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY chief_measurement_unit ALTER COLUMN id SET DEFAULT nextval('chief_measurement_unit_id_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: complete_abrogation_regulations_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY complete_abrogation_regulations_oplog ALTER COLUMN oid SET DEFAULT nextval('complete_abrogation_regulations_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: duty_expression_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY duty_expression_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('duty_expression_descriptions_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: duty_expressions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY duty_expressions_oplog ALTER COLUMN oid SET DEFAULT nextval('duty_expressions_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: explicit_abrogation_regulations_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY explicit_abrogation_regulations_oplog ALTER COLUMN oid SET DEFAULT nextval('explicit_abrogation_regulations_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: export_refund_nomenclature_description_periods_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY export_refund_nomenclature_description_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('export_refund_nomenclature_description_periods_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: export_refund_nomenclature_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY export_refund_nomenclature_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('export_refund_nomenclature_descriptions_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: export_refund_nomenclature_indents_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY export_refund_nomenclature_indents_oplog ALTER COLUMN oid SET DEFAULT nextval('export_refund_nomenclature_indents_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: export_refund_nomenclatures_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY export_refund_nomenclatures_oplog ALTER COLUMN oid SET DEFAULT nextval('export_refund_nomenclatures_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: footnote_association_additional_codes_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY footnote_association_additional_codes_oplog ALTER COLUMN oid SET DEFAULT nextval('footnote_association_additional_codes_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: footnote_association_erns_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY footnote_association_erns_oplog ALTER COLUMN oid SET DEFAULT nextval('footnote_association_erns_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: footnote_association_goods_nomenclatures_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY footnote_association_goods_nomenclatures_oplog ALTER COLUMN oid SET DEFAULT nextval('footnote_association_goods_nomenclatures_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: footnote_association_measures_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY footnote_association_measures_oplog ALTER COLUMN oid SET DEFAULT nextval('footnote_association_measures_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: footnote_association_meursing_headings_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY footnote_association_meursing_headings_oplog ALTER COLUMN oid SET DEFAULT nextval('footnote_association_meursing_headings_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: footnote_description_periods_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY footnote_description_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('footnote_description_periods_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: footnote_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY footnote_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('footnote_descriptions_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: footnote_type_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY footnote_type_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('footnote_type_descriptions_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: footnote_types_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY footnote_types_oplog ALTER COLUMN oid SET DEFAULT nextval('footnote_types_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: footnotes_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY footnotes_oplog ALTER COLUMN oid SET DEFAULT nextval('footnotes_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: fts_regulation_actions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY fts_regulation_actions_oplog ALTER COLUMN oid SET DEFAULT nextval('fts_regulation_actions_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: full_temporary_stop_regulations_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY full_temporary_stop_regulations_oplog ALTER COLUMN oid SET DEFAULT nextval('full_temporary_stop_regulations_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: geographical_area_description_periods_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY geographical_area_description_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('geographical_area_description_periods_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: geographical_area_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY geographical_area_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('geographical_area_descriptions_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: geographical_area_memberships_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY geographical_area_memberships_oplog ALTER COLUMN oid SET DEFAULT nextval('geographical_area_memberships_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: geographical_areas_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY geographical_areas_oplog ALTER COLUMN oid SET DEFAULT nextval('geographical_areas_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: goods_nomenclature_description_periods_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY goods_nomenclature_description_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('goods_nomenclature_description_periods_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: goods_nomenclature_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY goods_nomenclature_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('goods_nomenclature_descriptions_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: goods_nomenclature_group_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY goods_nomenclature_group_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('goods_nomenclature_group_descriptions_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: goods_nomenclature_groups_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY goods_nomenclature_groups_oplog ALTER COLUMN oid SET DEFAULT nextval('goods_nomenclature_groups_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: goods_nomenclature_indents_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY goods_nomenclature_indents_oplog ALTER COLUMN oid SET DEFAULT nextval('goods_nomenclature_indents_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: goods_nomenclature_origins_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY goods_nomenclature_origins_oplog ALTER COLUMN oid SET DEFAULT nextval('goods_nomenclature_origins_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: goods_nomenclature_successors_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY goods_nomenclature_successors_oplog ALTER COLUMN oid SET DEFAULT nextval('goods_nomenclature_successors_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: goods_nomenclatures_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY goods_nomenclatures_oplog ALTER COLUMN oid SET DEFAULT nextval('goods_nomenclatures_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: language_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY language_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('language_descriptions_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: languages_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY languages_oplog ALTER COLUMN oid SET DEFAULT nextval('languages_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: measure_action_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY measure_action_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('measure_action_descriptions_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: measure_actions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY measure_actions_oplog ALTER COLUMN oid SET DEFAULT nextval('measure_actions_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: measure_components_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY measure_components_oplog ALTER COLUMN oid SET DEFAULT nextval('measure_components_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: measure_condition_code_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY measure_condition_code_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('measure_condition_code_descriptions_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: measure_condition_codes_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY measure_condition_codes_oplog ALTER COLUMN oid SET DEFAULT nextval('measure_condition_codes_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: measure_condition_components_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY measure_condition_components_oplog ALTER COLUMN oid SET DEFAULT nextval('measure_condition_components_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: measure_conditions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY measure_conditions_oplog ALTER COLUMN oid SET DEFAULT nextval('measure_conditions_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: measure_excluded_geographical_areas_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY measure_excluded_geographical_areas_oplog ALTER COLUMN oid SET DEFAULT nextval('measure_excluded_geographical_areas_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: measure_partial_temporary_stops_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY measure_partial_temporary_stops_oplog ALTER COLUMN oid SET DEFAULT nextval('measure_partial_temporary_stops_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: measure_type_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY measure_type_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('measure_type_descriptions_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: measure_type_series_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY measure_type_series_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('measure_type_series_descriptions_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: measure_type_series_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY measure_type_series_oplog ALTER COLUMN oid SET DEFAULT nextval('measure_type_series_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: measure_types_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY measure_types_oplog ALTER COLUMN oid SET DEFAULT nextval('measure_types_oid_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: measurement_unit_abbreviations id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY measurement_unit_abbreviations ALTER COLUMN id SET DEFAULT nextval('measurement_unit_abbreviations_id_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: measurement_unit_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY measurement_unit_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('measurement_unit_descriptions_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: measurement_unit_qualifier_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY measurement_unit_qualifier_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('measurement_unit_qualifier_descriptions_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: measurement_unit_qualifiers_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY measurement_unit_qualifiers_oplog ALTER COLUMN oid SET DEFAULT nextval('measurement_unit_qualifiers_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: measurement_units_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY measurement_units_oplog ALTER COLUMN oid SET DEFAULT nextval('measurement_units_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: measurements_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY measurements_oplog ALTER COLUMN oid SET DEFAULT nextval('measurements_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: measures_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY measures_oplog ALTER COLUMN oid SET DEFAULT nextval('measures_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: meursing_additional_codes_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY meursing_additional_codes_oplog ALTER COLUMN oid SET DEFAULT nextval('meursing_additional_codes_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: meursing_heading_texts_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY meursing_heading_texts_oplog ALTER COLUMN oid SET DEFAULT nextval('meursing_heading_texts_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: meursing_headings_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY meursing_headings_oplog ALTER COLUMN oid SET DEFAULT nextval('meursing_headings_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: meursing_subheadings_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY meursing_subheadings_oplog ALTER COLUMN oid SET DEFAULT nextval('meursing_subheadings_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: meursing_table_cell_components_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY meursing_table_cell_components_oplog ALTER COLUMN oid SET DEFAULT nextval('meursing_table_cell_components_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: meursing_table_plans_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY meursing_table_plans_oplog ALTER COLUMN oid SET DEFAULT nextval('meursing_table_plans_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: modification_regulations_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY modification_regulations_oplog ALTER COLUMN oid SET DEFAULT nextval('modification_regulations_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: monetary_exchange_periods_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY monetary_exchange_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('monetary_exchange_periods_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: monetary_exchange_rates_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY monetary_exchange_rates_oplog ALTER COLUMN oid SET DEFAULT nextval('monetary_exchange_rates_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: monetary_unit_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY monetary_unit_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('monetary_unit_descriptions_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: monetary_units_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY monetary_units_oplog ALTER COLUMN oid SET DEFAULT nextval('monetary_units_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: nomenclature_group_memberships_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY nomenclature_group_memberships_oplog ALTER COLUMN oid SET DEFAULT nextval('nomenclature_group_memberships_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: prorogation_regulation_actions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY prorogation_regulation_actions_oplog ALTER COLUMN oid SET DEFAULT nextval('prorogation_regulation_actions_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: prorogation_regulations_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY prorogation_regulations_oplog ALTER COLUMN oid SET DEFAULT nextval('prorogation_regulations_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: quota_associations_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY quota_associations_oplog ALTER COLUMN oid SET DEFAULT nextval('quota_associations_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: quota_balance_events_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY quota_balance_events_oplog ALTER COLUMN oid SET DEFAULT nextval('quota_balance_events_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: quota_blocking_periods_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY quota_blocking_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('quota_blocking_periods_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: quota_critical_events_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY quota_critical_events_oplog ALTER COLUMN oid SET DEFAULT nextval('quota_critical_events_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: quota_definitions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY quota_definitions_oplog ALTER COLUMN oid SET DEFAULT nextval('quota_definitions_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: quota_exhaustion_events_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY quota_exhaustion_events_oplog ALTER COLUMN oid SET DEFAULT nextval('quota_exhaustion_events_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: quota_order_number_origin_exclusions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY quota_order_number_origin_exclusions_oplog ALTER COLUMN oid SET DEFAULT nextval('quota_order_number_origin_exclusions_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: quota_order_number_origins_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY quota_order_number_origins_oplog ALTER COLUMN oid SET DEFAULT nextval('quota_order_number_origins_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: quota_order_numbers_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY quota_order_numbers_oplog ALTER COLUMN oid SET DEFAULT nextval('quota_order_numbers_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: quota_reopening_events_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY quota_reopening_events_oplog ALTER COLUMN oid SET DEFAULT nextval('quota_reopening_events_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: quota_suspension_periods_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY quota_suspension_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('quota_suspension_periods_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: quota_unblocking_events_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY quota_unblocking_events_oplog ALTER COLUMN oid SET DEFAULT nextval('quota_unblocking_events_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: quota_unsuspension_events_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY quota_unsuspension_events_oplog ALTER COLUMN oid SET DEFAULT nextval('quota_unsuspension_events_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: regulation_group_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY regulation_group_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('regulation_group_descriptions_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: regulation_groups_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY regulation_groups_oplog ALTER COLUMN oid SET DEFAULT nextval('regulation_groups_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: regulation_replacements_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY regulation_replacements_oplog ALTER COLUMN oid SET DEFAULT nextval('regulation_replacements_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: regulation_role_type_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY regulation_role_type_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('regulation_role_type_descriptions_oid_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: regulation_role_types_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY regulation_role_types_oplog ALTER COLUMN oid SET DEFAULT nextval('regulation_role_types_oid_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: rollbacks id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY rollbacks ALTER COLUMN id SET DEFAULT nextval('rollbacks_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: search_references id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY search_references ALTER COLUMN id SET DEFAULT nextval('search_references_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: section_notes id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY section_notes ALTER COLUMN id SET DEFAULT nextval('section_notes_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: sections id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY sections ALTER COLUMN id SET DEFAULT nextval('sections_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: tariff_update_conformance_errors id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY tariff_update_conformance_errors ALTER COLUMN id SET DEFAULT nextval('tariff_update_conformance_errors_id_seq'::regclass);
 
 
 --
--- Name: oid; Type: DEFAULT; Schema: public; Owner: -
+-- Name: transmission_comments_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY transmission_comments_oplog ALTER COLUMN oid SET DEFAULT nextval('transmission_comments_oid_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: users id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regclass);
 
 
 --
--- Name: additional_code_description_periods_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: additional_code_description_periods_oplog additional_code_description_periods_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY additional_code_description_periods_oplog
@@ -6995,7 +6996,7 @@ ALTER TABLE ONLY additional_code_description_periods_oplog
 
 
 --
--- Name: additional_code_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: additional_code_descriptions_oplog additional_code_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY additional_code_descriptions_oplog
@@ -7003,7 +7004,7 @@ ALTER TABLE ONLY additional_code_descriptions_oplog
 
 
 --
--- Name: additional_code_type_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: additional_code_type_descriptions_oplog additional_code_type_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY additional_code_type_descriptions_oplog
@@ -7011,7 +7012,7 @@ ALTER TABLE ONLY additional_code_type_descriptions_oplog
 
 
 --
--- Name: additional_code_type_measure_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: additional_code_type_measure_types_oplog additional_code_type_measure_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY additional_code_type_measure_types_oplog
@@ -7019,7 +7020,7 @@ ALTER TABLE ONLY additional_code_type_measure_types_oplog
 
 
 --
--- Name: additional_code_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: additional_code_types_oplog additional_code_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY additional_code_types_oplog
@@ -7027,7 +7028,7 @@ ALTER TABLE ONLY additional_code_types_oplog
 
 
 --
--- Name: additional_codes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: additional_codes_oplog additional_codes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY additional_codes_oplog
@@ -7035,7 +7036,7 @@ ALTER TABLE ONLY additional_codes_oplog
 
 
 --
--- Name: base_regulations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: base_regulations_oplog base_regulations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY base_regulations_oplog
@@ -7043,7 +7044,7 @@ ALTER TABLE ONLY base_regulations_oplog
 
 
 --
--- Name: certificate_description_periods_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: certificate_description_periods_oplog certificate_description_periods_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY certificate_description_periods_oplog
@@ -7051,7 +7052,7 @@ ALTER TABLE ONLY certificate_description_periods_oplog
 
 
 --
--- Name: certificate_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: certificate_descriptions_oplog certificate_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY certificate_descriptions_oplog
@@ -7059,7 +7060,7 @@ ALTER TABLE ONLY certificate_descriptions_oplog
 
 
 --
--- Name: certificate_type_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: certificate_type_descriptions_oplog certificate_type_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY certificate_type_descriptions_oplog
@@ -7067,7 +7068,7 @@ ALTER TABLE ONLY certificate_type_descriptions_oplog
 
 
 --
--- Name: certificate_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: certificate_types_oplog certificate_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY certificate_types_oplog
@@ -7075,7 +7076,7 @@ ALTER TABLE ONLY certificate_types_oplog
 
 
 --
--- Name: certificates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: certificates_oplog certificates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY certificates_oplog
@@ -7083,7 +7084,7 @@ ALTER TABLE ONLY certificates_oplog
 
 
 --
--- Name: chapter_notes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: chapter_notes chapter_notes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY chapter_notes
@@ -7091,7 +7092,7 @@ ALTER TABLE ONLY chapter_notes
 
 
 --
--- Name: chief_duty_expression_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: chief_duty_expression chief_duty_expression_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY chief_duty_expression
@@ -7099,7 +7100,7 @@ ALTER TABLE ONLY chief_duty_expression
 
 
 --
--- Name: chief_measure_type_footnote_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: chief_measure_type_footnote chief_measure_type_footnote_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY chief_measure_type_footnote
@@ -7107,7 +7108,7 @@ ALTER TABLE ONLY chief_measure_type_footnote
 
 
 --
--- Name: chief_measurement_unit_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: chief_measurement_unit chief_measurement_unit_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY chief_measurement_unit
@@ -7115,7 +7116,7 @@ ALTER TABLE ONLY chief_measurement_unit
 
 
 --
--- Name: complete_abrogation_regulations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: complete_abrogation_regulations_oplog complete_abrogation_regulations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY complete_abrogation_regulations_oplog
@@ -7123,7 +7124,7 @@ ALTER TABLE ONLY complete_abrogation_regulations_oplog
 
 
 --
--- Name: duty_expression_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: duty_expression_descriptions_oplog duty_expression_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY duty_expression_descriptions_oplog
@@ -7131,7 +7132,7 @@ ALTER TABLE ONLY duty_expression_descriptions_oplog
 
 
 --
--- Name: duty_expressions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: duty_expressions_oplog duty_expressions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY duty_expressions_oplog
@@ -7139,7 +7140,7 @@ ALTER TABLE ONLY duty_expressions_oplog
 
 
 --
--- Name: explicit_abrogation_regulations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: explicit_abrogation_regulations_oplog explicit_abrogation_regulations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY explicit_abrogation_regulations_oplog
@@ -7147,7 +7148,7 @@ ALTER TABLE ONLY explicit_abrogation_regulations_oplog
 
 
 --
--- Name: export_refund_nomenclature_description_periods_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: export_refund_nomenclature_description_periods_oplog export_refund_nomenclature_description_periods_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY export_refund_nomenclature_description_periods_oplog
@@ -7155,7 +7156,7 @@ ALTER TABLE ONLY export_refund_nomenclature_description_periods_oplog
 
 
 --
--- Name: export_refund_nomenclature_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: export_refund_nomenclature_descriptions_oplog export_refund_nomenclature_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY export_refund_nomenclature_descriptions_oplog
@@ -7163,7 +7164,7 @@ ALTER TABLE ONLY export_refund_nomenclature_descriptions_oplog
 
 
 --
--- Name: export_refund_nomenclature_indents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: export_refund_nomenclature_indents_oplog export_refund_nomenclature_indents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY export_refund_nomenclature_indents_oplog
@@ -7171,7 +7172,7 @@ ALTER TABLE ONLY export_refund_nomenclature_indents_oplog
 
 
 --
--- Name: export_refund_nomenclatures_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: export_refund_nomenclatures_oplog export_refund_nomenclatures_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY export_refund_nomenclatures_oplog
@@ -7179,7 +7180,7 @@ ALTER TABLE ONLY export_refund_nomenclatures_oplog
 
 
 --
--- Name: footnote_association_additional_codes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: footnote_association_additional_codes_oplog footnote_association_additional_codes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY footnote_association_additional_codes_oplog
@@ -7187,7 +7188,7 @@ ALTER TABLE ONLY footnote_association_additional_codes_oplog
 
 
 --
--- Name: footnote_association_erns_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: footnote_association_erns_oplog footnote_association_erns_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY footnote_association_erns_oplog
@@ -7195,7 +7196,7 @@ ALTER TABLE ONLY footnote_association_erns_oplog
 
 
 --
--- Name: footnote_association_goods_nomenclatures_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: footnote_association_goods_nomenclatures_oplog footnote_association_goods_nomenclatures_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY footnote_association_goods_nomenclatures_oplog
@@ -7203,7 +7204,7 @@ ALTER TABLE ONLY footnote_association_goods_nomenclatures_oplog
 
 
 --
--- Name: footnote_association_measures_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: footnote_association_measures_oplog footnote_association_measures_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY footnote_association_measures_oplog
@@ -7211,7 +7212,7 @@ ALTER TABLE ONLY footnote_association_measures_oplog
 
 
 --
--- Name: footnote_association_meursing_headings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: footnote_association_meursing_headings_oplog footnote_association_meursing_headings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY footnote_association_meursing_headings_oplog
@@ -7219,7 +7220,7 @@ ALTER TABLE ONLY footnote_association_meursing_headings_oplog
 
 
 --
--- Name: footnote_description_periods_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: footnote_description_periods_oplog footnote_description_periods_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY footnote_description_periods_oplog
@@ -7227,7 +7228,7 @@ ALTER TABLE ONLY footnote_description_periods_oplog
 
 
 --
--- Name: footnote_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: footnote_descriptions_oplog footnote_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY footnote_descriptions_oplog
@@ -7235,7 +7236,7 @@ ALTER TABLE ONLY footnote_descriptions_oplog
 
 
 --
--- Name: footnote_type_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: footnote_type_descriptions_oplog footnote_type_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY footnote_type_descriptions_oplog
@@ -7243,7 +7244,7 @@ ALTER TABLE ONLY footnote_type_descriptions_oplog
 
 
 --
--- Name: footnote_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: footnote_types_oplog footnote_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY footnote_types_oplog
@@ -7251,7 +7252,7 @@ ALTER TABLE ONLY footnote_types_oplog
 
 
 --
--- Name: footnotes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: footnotes_oplog footnotes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY footnotes_oplog
@@ -7259,7 +7260,7 @@ ALTER TABLE ONLY footnotes_oplog
 
 
 --
--- Name: fts_regulation_actions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: fts_regulation_actions_oplog fts_regulation_actions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY fts_regulation_actions_oplog
@@ -7267,7 +7268,7 @@ ALTER TABLE ONLY fts_regulation_actions_oplog
 
 
 --
--- Name: full_temporary_stop_regulations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: full_temporary_stop_regulations_oplog full_temporary_stop_regulations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY full_temporary_stop_regulations_oplog
@@ -7275,7 +7276,7 @@ ALTER TABLE ONLY full_temporary_stop_regulations_oplog
 
 
 --
--- Name: geographical_area_description_periods_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: geographical_area_description_periods_oplog geographical_area_description_periods_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY geographical_area_description_periods_oplog
@@ -7283,7 +7284,7 @@ ALTER TABLE ONLY geographical_area_description_periods_oplog
 
 
 --
--- Name: geographical_area_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: geographical_area_descriptions_oplog geographical_area_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY geographical_area_descriptions_oplog
@@ -7291,7 +7292,7 @@ ALTER TABLE ONLY geographical_area_descriptions_oplog
 
 
 --
--- Name: geographical_area_memberships_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: geographical_area_memberships_oplog geographical_area_memberships_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY geographical_area_memberships_oplog
@@ -7299,7 +7300,7 @@ ALTER TABLE ONLY geographical_area_memberships_oplog
 
 
 --
--- Name: geographical_areas_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: geographical_areas_oplog geographical_areas_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY geographical_areas_oplog
@@ -7307,7 +7308,7 @@ ALTER TABLE ONLY geographical_areas_oplog
 
 
 --
--- Name: goods_nomenclature_description_periods_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: goods_nomenclature_description_periods_oplog goods_nomenclature_description_periods_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY goods_nomenclature_description_periods_oplog
@@ -7315,7 +7316,7 @@ ALTER TABLE ONLY goods_nomenclature_description_periods_oplog
 
 
 --
--- Name: goods_nomenclature_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: goods_nomenclature_descriptions_oplog goods_nomenclature_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY goods_nomenclature_descriptions_oplog
@@ -7323,7 +7324,7 @@ ALTER TABLE ONLY goods_nomenclature_descriptions_oplog
 
 
 --
--- Name: goods_nomenclature_group_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: goods_nomenclature_group_descriptions_oplog goods_nomenclature_group_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY goods_nomenclature_group_descriptions_oplog
@@ -7331,7 +7332,7 @@ ALTER TABLE ONLY goods_nomenclature_group_descriptions_oplog
 
 
 --
--- Name: goods_nomenclature_groups_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: goods_nomenclature_groups_oplog goods_nomenclature_groups_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY goods_nomenclature_groups_oplog
@@ -7339,7 +7340,7 @@ ALTER TABLE ONLY goods_nomenclature_groups_oplog
 
 
 --
--- Name: goods_nomenclature_indents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: goods_nomenclature_indents_oplog goods_nomenclature_indents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY goods_nomenclature_indents_oplog
@@ -7347,7 +7348,7 @@ ALTER TABLE ONLY goods_nomenclature_indents_oplog
 
 
 --
--- Name: goods_nomenclature_origins_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: goods_nomenclature_origins_oplog goods_nomenclature_origins_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY goods_nomenclature_origins_oplog
@@ -7355,7 +7356,7 @@ ALTER TABLE ONLY goods_nomenclature_origins_oplog
 
 
 --
--- Name: goods_nomenclature_successors_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: goods_nomenclature_successors_oplog goods_nomenclature_successors_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY goods_nomenclature_successors_oplog
@@ -7363,7 +7364,7 @@ ALTER TABLE ONLY goods_nomenclature_successors_oplog
 
 
 --
--- Name: goods_nomenclatures_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: goods_nomenclatures_oplog goods_nomenclatures_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY goods_nomenclatures_oplog
@@ -7371,7 +7372,7 @@ ALTER TABLE ONLY goods_nomenclatures_oplog
 
 
 --
--- Name: language_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: language_descriptions_oplog language_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY language_descriptions_oplog
@@ -7379,7 +7380,7 @@ ALTER TABLE ONLY language_descriptions_oplog
 
 
 --
--- Name: languages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: languages_oplog languages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY languages_oplog
@@ -7387,7 +7388,7 @@ ALTER TABLE ONLY languages_oplog
 
 
 --
--- Name: measure_action_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: measure_action_descriptions_oplog measure_action_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY measure_action_descriptions_oplog
@@ -7395,7 +7396,7 @@ ALTER TABLE ONLY measure_action_descriptions_oplog
 
 
 --
--- Name: measure_actions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: measure_actions_oplog measure_actions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY measure_actions_oplog
@@ -7403,7 +7404,7 @@ ALTER TABLE ONLY measure_actions_oplog
 
 
 --
--- Name: measure_components_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: measure_components_oplog measure_components_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY measure_components_oplog
@@ -7411,7 +7412,7 @@ ALTER TABLE ONLY measure_components_oplog
 
 
 --
--- Name: measure_condition_code_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: measure_condition_code_descriptions_oplog measure_condition_code_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY measure_condition_code_descriptions_oplog
@@ -7419,7 +7420,7 @@ ALTER TABLE ONLY measure_condition_code_descriptions_oplog
 
 
 --
--- Name: measure_condition_codes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: measure_condition_codes_oplog measure_condition_codes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY measure_condition_codes_oplog
@@ -7427,7 +7428,7 @@ ALTER TABLE ONLY measure_condition_codes_oplog
 
 
 --
--- Name: measure_condition_components_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: measure_condition_components_oplog measure_condition_components_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY measure_condition_components_oplog
@@ -7435,7 +7436,7 @@ ALTER TABLE ONLY measure_condition_components_oplog
 
 
 --
--- Name: measure_conditions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: measure_conditions_oplog measure_conditions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY measure_conditions_oplog
@@ -7443,7 +7444,7 @@ ALTER TABLE ONLY measure_conditions_oplog
 
 
 --
--- Name: measure_excluded_geographical_areas_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: measure_excluded_geographical_areas_oplog measure_excluded_geographical_areas_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY measure_excluded_geographical_areas_oplog
@@ -7451,7 +7452,7 @@ ALTER TABLE ONLY measure_excluded_geographical_areas_oplog
 
 
 --
--- Name: measure_partial_temporary_stops_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: measure_partial_temporary_stops_oplog measure_partial_temporary_stops_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY measure_partial_temporary_stops_oplog
@@ -7459,7 +7460,7 @@ ALTER TABLE ONLY measure_partial_temporary_stops_oplog
 
 
 --
--- Name: measure_type_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: measure_type_descriptions_oplog measure_type_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY measure_type_descriptions_oplog
@@ -7467,7 +7468,7 @@ ALTER TABLE ONLY measure_type_descriptions_oplog
 
 
 --
--- Name: measure_type_series_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: measure_type_series_descriptions_oplog measure_type_series_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY measure_type_series_descriptions_oplog
@@ -7475,7 +7476,7 @@ ALTER TABLE ONLY measure_type_series_descriptions_oplog
 
 
 --
--- Name: measure_type_series_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: measure_type_series_oplog measure_type_series_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY measure_type_series_oplog
@@ -7483,7 +7484,7 @@ ALTER TABLE ONLY measure_type_series_oplog
 
 
 --
--- Name: measure_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: measure_types_oplog measure_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY measure_types_oplog
@@ -7491,7 +7492,7 @@ ALTER TABLE ONLY measure_types_oplog
 
 
 --
--- Name: measurement_unit_abbreviations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: measurement_unit_abbreviations measurement_unit_abbreviations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY measurement_unit_abbreviations
@@ -7499,7 +7500,7 @@ ALTER TABLE ONLY measurement_unit_abbreviations
 
 
 --
--- Name: measurement_unit_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: measurement_unit_descriptions_oplog measurement_unit_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY measurement_unit_descriptions_oplog
@@ -7507,7 +7508,7 @@ ALTER TABLE ONLY measurement_unit_descriptions_oplog
 
 
 --
--- Name: measurement_unit_qualifier_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: measurement_unit_qualifier_descriptions_oplog measurement_unit_qualifier_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY measurement_unit_qualifier_descriptions_oplog
@@ -7515,7 +7516,7 @@ ALTER TABLE ONLY measurement_unit_qualifier_descriptions_oplog
 
 
 --
--- Name: measurement_unit_qualifiers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: measurement_unit_qualifiers_oplog measurement_unit_qualifiers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY measurement_unit_qualifiers_oplog
@@ -7523,7 +7524,7 @@ ALTER TABLE ONLY measurement_unit_qualifiers_oplog
 
 
 --
--- Name: measurement_units_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: measurement_units_oplog measurement_units_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY measurement_units_oplog
@@ -7531,7 +7532,7 @@ ALTER TABLE ONLY measurement_units_oplog
 
 
 --
--- Name: measurements_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: measurements_oplog measurements_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY measurements_oplog
@@ -7539,7 +7540,7 @@ ALTER TABLE ONLY measurements_oplog
 
 
 --
--- Name: measures_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: measures_oplog measures_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY measures_oplog
@@ -7547,7 +7548,7 @@ ALTER TABLE ONLY measures_oplog
 
 
 --
--- Name: meursing_additional_codes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: meursing_additional_codes_oplog meursing_additional_codes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY meursing_additional_codes_oplog
@@ -7555,7 +7556,7 @@ ALTER TABLE ONLY meursing_additional_codes_oplog
 
 
 --
--- Name: meursing_heading_texts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: meursing_heading_texts_oplog meursing_heading_texts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY meursing_heading_texts_oplog
@@ -7563,7 +7564,7 @@ ALTER TABLE ONLY meursing_heading_texts_oplog
 
 
 --
--- Name: meursing_headings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: meursing_headings_oplog meursing_headings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY meursing_headings_oplog
@@ -7571,7 +7572,7 @@ ALTER TABLE ONLY meursing_headings_oplog
 
 
 --
--- Name: meursing_subheadings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: meursing_subheadings_oplog meursing_subheadings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY meursing_subheadings_oplog
@@ -7579,7 +7580,7 @@ ALTER TABLE ONLY meursing_subheadings_oplog
 
 
 --
--- Name: meursing_table_cell_components_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: meursing_table_cell_components_oplog meursing_table_cell_components_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY meursing_table_cell_components_oplog
@@ -7587,7 +7588,7 @@ ALTER TABLE ONLY meursing_table_cell_components_oplog
 
 
 --
--- Name: meursing_table_plans_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: meursing_table_plans_oplog meursing_table_plans_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY meursing_table_plans_oplog
@@ -7595,7 +7596,7 @@ ALTER TABLE ONLY meursing_table_plans_oplog
 
 
 --
--- Name: modification_regulations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: modification_regulations_oplog modification_regulations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY modification_regulations_oplog
@@ -7603,7 +7604,7 @@ ALTER TABLE ONLY modification_regulations_oplog
 
 
 --
--- Name: monetary_exchange_periods_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: monetary_exchange_periods_oplog monetary_exchange_periods_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY monetary_exchange_periods_oplog
@@ -7611,7 +7612,7 @@ ALTER TABLE ONLY monetary_exchange_periods_oplog
 
 
 --
--- Name: monetary_exchange_rates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: monetary_exchange_rates_oplog monetary_exchange_rates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY monetary_exchange_rates_oplog
@@ -7619,7 +7620,7 @@ ALTER TABLE ONLY monetary_exchange_rates_oplog
 
 
 --
--- Name: monetary_unit_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: monetary_unit_descriptions_oplog monetary_unit_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY monetary_unit_descriptions_oplog
@@ -7627,7 +7628,7 @@ ALTER TABLE ONLY monetary_unit_descriptions_oplog
 
 
 --
--- Name: monetary_units_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: monetary_units_oplog monetary_units_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY monetary_units_oplog
@@ -7635,7 +7636,7 @@ ALTER TABLE ONLY monetary_units_oplog
 
 
 --
--- Name: nomenclature_group_memberships_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: nomenclature_group_memberships_oplog nomenclature_group_memberships_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY nomenclature_group_memberships_oplog
@@ -7643,7 +7644,7 @@ ALTER TABLE ONLY nomenclature_group_memberships_oplog
 
 
 --
--- Name: prorogation_regulation_actions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: prorogation_regulation_actions_oplog prorogation_regulation_actions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY prorogation_regulation_actions_oplog
@@ -7651,7 +7652,7 @@ ALTER TABLE ONLY prorogation_regulation_actions_oplog
 
 
 --
--- Name: prorogation_regulations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: prorogation_regulations_oplog prorogation_regulations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY prorogation_regulations_oplog
@@ -7659,7 +7660,7 @@ ALTER TABLE ONLY prorogation_regulations_oplog
 
 
 --
--- Name: quota_associations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: quota_associations_oplog quota_associations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY quota_associations_oplog
@@ -7667,7 +7668,7 @@ ALTER TABLE ONLY quota_associations_oplog
 
 
 --
--- Name: quota_balance_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: quota_balance_events_oplog quota_balance_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY quota_balance_events_oplog
@@ -7675,7 +7676,7 @@ ALTER TABLE ONLY quota_balance_events_oplog
 
 
 --
--- Name: quota_blocking_periods_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: quota_blocking_periods_oplog quota_blocking_periods_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY quota_blocking_periods_oplog
@@ -7683,7 +7684,7 @@ ALTER TABLE ONLY quota_blocking_periods_oplog
 
 
 --
--- Name: quota_critical_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: quota_critical_events_oplog quota_critical_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY quota_critical_events_oplog
@@ -7691,7 +7692,7 @@ ALTER TABLE ONLY quota_critical_events_oplog
 
 
 --
--- Name: quota_definitions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: quota_definitions_oplog quota_definitions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY quota_definitions_oplog
@@ -7699,7 +7700,7 @@ ALTER TABLE ONLY quota_definitions_oplog
 
 
 --
--- Name: quota_exhaustion_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: quota_exhaustion_events_oplog quota_exhaustion_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY quota_exhaustion_events_oplog
@@ -7707,7 +7708,7 @@ ALTER TABLE ONLY quota_exhaustion_events_oplog
 
 
 --
--- Name: quota_order_number_origin_exclusions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: quota_order_number_origin_exclusions_oplog quota_order_number_origin_exclusions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY quota_order_number_origin_exclusions_oplog
@@ -7715,7 +7716,7 @@ ALTER TABLE ONLY quota_order_number_origin_exclusions_oplog
 
 
 --
--- Name: quota_order_number_origins_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: quota_order_number_origins_oplog quota_order_number_origins_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY quota_order_number_origins_oplog
@@ -7723,7 +7724,7 @@ ALTER TABLE ONLY quota_order_number_origins_oplog
 
 
 --
--- Name: quota_order_numbers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: quota_order_numbers_oplog quota_order_numbers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY quota_order_numbers_oplog
@@ -7731,7 +7732,7 @@ ALTER TABLE ONLY quota_order_numbers_oplog
 
 
 --
--- Name: quota_reopening_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: quota_reopening_events_oplog quota_reopening_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY quota_reopening_events_oplog
@@ -7739,7 +7740,7 @@ ALTER TABLE ONLY quota_reopening_events_oplog
 
 
 --
--- Name: quota_suspension_periods_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: quota_suspension_periods_oplog quota_suspension_periods_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY quota_suspension_periods_oplog
@@ -7747,7 +7748,7 @@ ALTER TABLE ONLY quota_suspension_periods_oplog
 
 
 --
--- Name: quota_unblocking_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: quota_unblocking_events_oplog quota_unblocking_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY quota_unblocking_events_oplog
@@ -7755,7 +7756,7 @@ ALTER TABLE ONLY quota_unblocking_events_oplog
 
 
 --
--- Name: quota_unsuspension_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: quota_unsuspension_events_oplog quota_unsuspension_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY quota_unsuspension_events_oplog
@@ -7763,7 +7764,7 @@ ALTER TABLE ONLY quota_unsuspension_events_oplog
 
 
 --
--- Name: regulation_group_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: regulation_group_descriptions_oplog regulation_group_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY regulation_group_descriptions_oplog
@@ -7771,7 +7772,7 @@ ALTER TABLE ONLY regulation_group_descriptions_oplog
 
 
 --
--- Name: regulation_groups_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: regulation_groups_oplog regulation_groups_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY regulation_groups_oplog
@@ -7779,7 +7780,7 @@ ALTER TABLE ONLY regulation_groups_oplog
 
 
 --
--- Name: regulation_replacements_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: regulation_replacements_oplog regulation_replacements_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY regulation_replacements_oplog
@@ -7787,7 +7788,7 @@ ALTER TABLE ONLY regulation_replacements_oplog
 
 
 --
--- Name: regulation_role_type_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: regulation_role_type_descriptions_oplog regulation_role_type_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY regulation_role_type_descriptions_oplog
@@ -7795,7 +7796,7 @@ ALTER TABLE ONLY regulation_role_type_descriptions_oplog
 
 
 --
--- Name: regulation_role_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: regulation_role_types_oplog regulation_role_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY regulation_role_types_oplog
@@ -7803,7 +7804,7 @@ ALTER TABLE ONLY regulation_role_types_oplog
 
 
 --
--- Name: rollbacks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: rollbacks rollbacks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY rollbacks
@@ -7811,7 +7812,7 @@ ALTER TABLE ONLY rollbacks
 
 
 --
--- Name: schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY schema_migrations
@@ -7819,7 +7820,7 @@ ALTER TABLE ONLY schema_migrations
 
 
 --
--- Name: search_references_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: search_references search_references_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY search_references
@@ -7827,7 +7828,7 @@ ALTER TABLE ONLY search_references
 
 
 --
--- Name: section_notes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: section_notes section_notes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY section_notes
@@ -7835,7 +7836,7 @@ ALTER TABLE ONLY section_notes
 
 
 --
--- Name: sections_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: sections sections_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY sections
@@ -7843,7 +7844,7 @@ ALTER TABLE ONLY sections
 
 
 --
--- Name: tariff_update_conformance_errors_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: tariff_update_conformance_errors tariff_update_conformance_errors_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY tariff_update_conformance_errors
@@ -7851,7 +7852,7 @@ ALTER TABLE ONLY tariff_update_conformance_errors
 
 
 --
--- Name: tariff_updates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: tariff_updates tariff_updates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY tariff_updates
@@ -7859,7 +7860,7 @@ ALTER TABLE ONLY tariff_updates
 
 
 --
--- Name: transmission_comments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: transmission_comments_oplog transmission_comments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY transmission_comments_oplog
@@ -7867,7 +7868,7 @@ ALTER TABLE ONLY transmission_comments_oplog
 
 
 --
--- Name: users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY users
@@ -9959,3 +9960,4 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20150406165721_add_disable
 INSERT INTO "schema_migrations" ("filename") VALUES ('20150507133620_add_organisation_content_id_to_user.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20151214224024_add_model_views_reloaded.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20151214230831_quota_critical_events_view_reloaded.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20161209195324_alter_footnotes_foonote_id_lenght.rb');


### PR DESCRIPTION
It is required to recreate the views in order to change the size of an attribute used in a view.