### PR TITLE
Add auditing plugin

### DIFF
--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -1,0 +1,27 @@
+class Audit < Sequel::Model
+
+  many_to_one :auditable, reciprocal: :audits,
+                          setter: (proc do |auditable|
+                              self[:auditable_id] = (auditable.pk if auditable)
+                              self[:auditable_type] = (auditable.class.name if auditable)
+                            end),
+                            dataset: (proc do
+                              klass = auditable_type.constantize
+                              klass.where(klassprimary_key: auditable_id)
+                            end),
+                            eager_loader: (proc do |eo|
+                              id_map = {}
+                              eo[:rows].each do |asset|
+                                asset.associations[:auditable] = nil
+                                ((id_map[asset.auditable_type] ||= {})[asset.auditable_id] ||= []) << asset
+                              end
+                              id_map.each do |klass_name, id_map|
+                                klass = klass_name.constantize
+                                klass.where(klassprimary_key: id_map.keys).all do |attach|
+                                  id_map[attach.pk].each do |asset|
+                                    asset.associations[:auditable] = attach
+                                  end
+                                end
+                              end
+                            end)
+end

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -7,7 +7,7 @@ class Audit < Sequel::Model
                             end),
                             dataset: (proc do
                               klass = auditable_type.constantize
-                              klass.where(klassprimary_key: auditable_id)
+                              klass.where(klass.primary_key => auditable_id)
                             end),
                             eager_loader: (proc do |eo|
                               id_map = {}
@@ -17,7 +17,7 @@ class Audit < Sequel::Model
                               end
                               id_map.each do |klass_name, id_map|
                                 klass = klass_name.constantize
-                                klass.where(klassprimary_key: id_map.keys).all do |attach|
+                                klass.where(klass.primary_key => id_map.keys).all do |attach|
                                   id_map[attach.pk].each do |asset|
                                     asset.associations[:auditable] = attach
                                   end

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -28,11 +28,16 @@ class Audit < Sequel::Model
 
   def before_create
     set_version_number
+    set_created_at
     super
   end
 
   def set_version_number
     max = Audit.where(auditable_id: auditable_id, auditable_type: auditable_type).reverse(:version).first.try(:version) || 0
     self.version = max + 1
+  end
+
+  def set_created_at
+    self.created_at = DateTime.now
   end
 end

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -1,6 +1,6 @@
 class Audit < Sequel::Model
 
-  many_to_one :auditable, reciprocal: :audits,
+  many_to_one :auditable, reciprocal: :audits, reciprocal_type: :many_to_one,
                           setter: (proc do |auditable|
                               self[:auditable_id] = (auditable.pk if auditable)
                               self[:auditable_type] = (auditable.class.name if auditable)
@@ -24,4 +24,15 @@ class Audit < Sequel::Model
                                 end
                               end
                             end)
+
+
+  def before_create
+    set_version_number
+    super
+  end
+
+  def set_version_number
+    max = Audit.where(auditable_id: auditable_id, auditable_type: auditable_type).reverse(:version).first.try(:version) || 0
+    self.version = max + 1
+  end
 end

--- a/app/models/chapter_note.rb
+++ b/app/models/chapter_note.rb
@@ -1,6 +1,7 @@
 class ChapterNote < Sequel::Model
   plugin :json_serializer
   plugin :active_model
+  plugin :auditable
 
   many_to_one :chapter, dataset: -> {
     Chapter.where(goods_nomenclature_item_id: chapter_goods_id)

--- a/app/models/search_reference.rb
+++ b/app/models/search_reference.rb
@@ -3,6 +3,7 @@ class SearchReference < Sequel::Model
 
   plugin :active_model
   plugin :elasticsearch
+  plugin :auditable
 
   many_to_one :referenced, reciprocal: :search_references, reciprocal_type: :many_to_one,
     setter: (proc do |referenced|

--- a/app/models/section_note.rb
+++ b/app/models/section_note.rb
@@ -1,6 +1,7 @@
 class SectionNote < Sequel::Model
   plugin :json_serializer
   plugin :active_model
+  plugin :auditable
 
   many_to_one :section
 

--- a/config/initializers/sequel.rb
+++ b/config/initializers/sequel.rb
@@ -1,1 +1,2 @@
 Sequel.default_timezone = :utc
+Sequel.extension :pg_json

--- a/db/migrate/20170117212158_create_audits.rb
+++ b/db/migrate/20170117212158_create_audits.rb
@@ -7,6 +7,7 @@ Sequel.migration do
       String :action, null: false
       json :changes, null: false
       integer :version, null: false
+      DateTime :created_at, null: false
     end
   end
 end

--- a/db/migrate/20170117212158_create_audits.rb
+++ b/db/migrate/20170117212158_create_audits.rb
@@ -2,11 +2,11 @@ Sequel.migration do
   change do
     create_table :audits do
       primary_key :id
-      Integer :auditable_id, null: false
+      integer :auditable_id, null: false
       String :auditable_type, null: false
       String :action, null: false
-      String :changes, null: false, text: true
-      Integer :version, null: false
+      json :changes, null: false
+      integer :version, null: false
     end
   end
 end

--- a/db/migrate/20170117212158_create_audits.rb
+++ b/db/migrate/20170117212158_create_audits.rb
@@ -1,0 +1,12 @@
+Sequel.migration do
+  change do
+    create_table :audits do
+      primary_key :id
+      Integer :auditable_id, null: false
+      String :auditable_type, null: false
+      String :action, null: false
+      String :changes, null: false, text: true
+      Integer :version, null: false
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -382,7 +382,8 @@ CREATE TABLE audits (
     auditable_type text NOT NULL,
     action text NOT NULL,
     changes json NOT NULL,
-    version integer NOT NULL
+    version integer NOT NULL,
+    created_at timestamp without time zone NOT NULL
 );
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -381,7 +381,7 @@ CREATE TABLE audits (
     auditable_id integer NOT NULL,
     auditable_type text NOT NULL,
     action text NOT NULL,
-    changes text NOT NULL,
+    changes json NOT NULL,
     version integer NOT NULL
 );
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -373,6 +373,39 @@ ALTER SEQUENCE additional_codes_oid_seq OWNED BY additional_codes_oplog.oid;
 
 
 --
+-- Name: audits; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE audits (
+    id integer NOT NULL,
+    auditable_id integer NOT NULL,
+    auditable_type text NOT NULL,
+    action text NOT NULL,
+    changes text NOT NULL,
+    version integer NOT NULL
+);
+
+
+--
+-- Name: audits_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE audits_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: audits_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE audits_id_seq OWNED BY audits.id;
+
+
+--
 -- Name: base_regulations_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -6267,6 +6300,13 @@ ALTER TABLE ONLY additional_codes_oplog ALTER COLUMN oid SET DEFAULT nextval('ad
 
 
 --
+-- Name: audits id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY audits ALTER COLUMN id SET DEFAULT nextval('audits_id_seq'::regclass);
+
+
+--
 -- Name: base_regulations_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -7033,6 +7073,14 @@ ALTER TABLE ONLY additional_code_types_oplog
 
 ALTER TABLE ONLY additional_codes_oplog
     ADD CONSTRAINT additional_codes_pkey PRIMARY KEY (oid);
+
+
+--
+-- Name: audits audits_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY audits
+    ADD CONSTRAINT audits_pkey PRIMARY KEY (id);
 
 
 --
@@ -9961,3 +10009,4 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20150507133620_add_organis
 INSERT INTO "schema_migrations" ("filename") VALUES ('20151214224024_add_model_views_reloaded.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20151214230831_quota_critical_events_view_reloaded.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20161209195324_alter_footnotes_foonote_id_lenght.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20170117212158_create_audits.rb');

--- a/lib/sequel/plugins/auditable.rb
+++ b/lib/sequel/plugins/auditable.rb
@@ -1,0 +1,15 @@
+# Keeps a record of the changes after create/update/destroy
+module Sequel
+  module Plugins
+    module Auditable
+
+      def self.configure(model, options = {})
+        # Associations
+        model.one_to_many :audits, key: :auditable_id, reciprocal: :auditable, conditions: {auditable_type: model.to_s},
+                                   adder: proc{|asset| asset.update(auditable_id: model.primary_key, auditable_type: model.to_s)},
+                                   remover: proc{|asset| asset.update(auditable_id: nil, auditable_type: nil)},
+                                   clearer: proc{assets_dataset.update(auditable_id: nil, auditable_type: nil)}
+      end
+    end
+  end
+end

--- a/lib/sequel/plugins/auditable.rb
+++ b/lib/sequel/plugins/auditable.rb
@@ -1,14 +1,25 @@
-# Keeps a record of the changes after create/update/destroy
+# Keeps a record of the changes after update
 module Sequel
   module Plugins
     module Auditable
 
       def self.configure(model, options = {})
+
+        model.plugin :dirty
+
         # Associations
         model.one_to_many :audits, key: :auditable_id, reciprocal: :auditable, conditions: {auditable_type: model.to_s},
                                    adder: proc{|asset| asset.update(auditable_id: model.primary_key, auditable_type: model.to_s)},
                                    remover: proc{|asset| asset.update(auditable_id: nil, auditable_type: nil)},
                                    clearer: proc{assets_dataset.update(auditable_id: nil, auditable_type: nil)}
+      end
+
+      module InstanceMethods
+
+        def before_update
+          Audit.create(action: "update", changes: Sequel.pg_json(column_changes), auditable: self)
+          super
+        end
       end
     end
   end

--- a/spec/unit/sequel/plugins/auditable_spec.rb
+++ b/spec/unit/sequel/plugins/auditable_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+describe "Auditable sequel plugin" do
+  let(:model_with_plugin) { create :section_note, content: "first content" }
+
+  describe "Model hooks" do
+    it "creates an audit record when updated" do
+      expect {
+        model_with_plugin.update(content: "test")
+      }.to change { Audit.count }.by(1)
+    end
+
+    it "the new audit record created keeps the record of the changes" do
+      model_with_plugin.update(content: "second content")
+      result = JSON.parse(model_with_plugin.audits.last.changes)
+      
+      expect(result["content"][0]).to eq("first content")
+      expect(result["content"][1]).to eq("second content")
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a new custom plugin for `Sequel` which creates a model `Audit` and a polymorphic association to the models of interest.

If we want a model to have a audit records we have to add the `plugin :auditable` line.

Keep in mind that this plugin expects simple primary keys ( not compound ) for the polymorphic association.

The changes are stored in json format.

![audits](https://cloud.githubusercontent.com/assets/1143421/22045467/6b822440-dce8-11e6-99f7-f1c3b1d9afbc.gif)
