### PR TITLE
separately preload geo areas

### DIFF
--- a/app/controllers/api/v1/commodities_controller.rb
+++ b/app/controllers/api/v1/commodities_controller.rb
@@ -34,6 +34,9 @@ module Api
           ).all, @commodity
         ).validate!
 
+        @geographical_areas = GeographicalArea.actual.where("geographical_area_sid IN ?", @measures.map(&:geographical_area_sid)).
+            eager(:geographical_area_descriptions, { contained_geographical_areas: :geographical_area_descriptions }).all
+
         @commodity_cache_key = "commodity-#{@commodity.goods_nomenclature_sid}-#{actual_date}"
         respond_with @commodity
       end

--- a/app/views/api/v1/commodities/show.json.rabl
+++ b/app/views/api/v1/commodities/show.json.rabl
@@ -5,7 +5,7 @@ attributes :producline_suffix, :description, :number_indents,
            :goods_nomenclature_item_id, :bti_url, :formatted_description,
            :description_plain, :consigned, :consigned_from, :basic_duty_rate
 
-extends "api/v1/declarables/declarable", object: @commodity, locals: { measures: @measures }
+extends "api/v1/declarables/declarable", object: @commodity, locals: { measures: @measures, geo_areas: @geographical_areas }
 
 child @commodity.heading do
   attributes :goods_nomenclature_item_id, :description, :formatted_description,

--- a/app/views/api/v1/declarables/_declarable.json.rabl
+++ b/app/views/api/v1/declarables/_declarable.json.rabl
@@ -24,12 +24,12 @@ end
 
 node(:import_measures) { |declarable|
   locals[:measures].select(&:import).map do |import_measure|
-    partial "api/v1/measures/measure", object: import_measure, locals: { declarable: declarable }
+    partial "api/v1/measures/measure", object: import_measure, locals: { declarable: declarable, geo_areas: locals[:geo_areas] }
   end
 }
 
 node(:export_measures) { |declarable|
   locals[:measures].select(&:export).map do |export_measure|
-    partial "api/v1/measures/_measure", object: export_measure, locals: { declarable: declarable }
+    partial "api/v1/measures/_measure", object: export_measure, locals: { declarable: declarable, geo_areas: locals[:geo_areas] }
   end
 }

--- a/app/views/api/v1/measures/_measure.json.rabl
+++ b/app/views/api/v1/measures/_measure.json.rabl
@@ -41,11 +41,21 @@ child(:measure_conditions) do
   attributes :condition, :document_code, :requirement, :action, :duty_expression
 end
 
-child(:geographical_area) do
-  attributes :id, :description
-
-  child(contained_geographical_areas: :children_geographical_areas) do
+if locals[:geo_areas]
+  node(:geographical_area) do |measure|
+    {
+      id: locals[:geo_areas].select{ |g| g.geographical_area_sid == measure.geographical_area_sid }.last.id,
+      description: locals[:geo_areas].select{ |g| g.geographical_area_sid == measure.geographical_area_sid }.last.description,
+      children_geographical_areas: locals[:geo_areas].select{ |g| g.geographical_area_sid == measure.geographical_area_sid }.last.contained_geographical_areas.map{|c| {id: c.id, description: c.description} }
+    }
+  end
+else
+  child(:geographical_area) do
     attributes :id, :description
+
+    child(contained_geographical_areas: :children_geographical_areas) do
+      attributes :id, :description
+    end
   end
 end
 


### PR DESCRIPTION
As we removed geographical_area from measures eager loading to fix an issue with data not loading properly, now to improve the performance we are pre-loading them separately.