### PR TITLE
After Rails upgrade

### DIFF
--- a/lib/tariff_synchronizer.rb
+++ b/lib/tariff_synchronizer.rb
@@ -13,6 +13,7 @@ require 'tariff_synchronizer/logger'
 require 'tariff_synchronizer/taric_file_name_generator'
 require 'tariff_synchronizer/taric_update_downloader'
 require 'tariff_synchronizer/tariff_downloader'
+require 'tariff_synchronizer/tariff_updates_requester'
 
 # How TariffSynchronizer works
 #


### PR DESCRIPTION
fix NameError: uninitialized constant TariffSynchronizer::TariffUpdatesRequester