### PR TITLE
After Rails upgrade 4

### DIFF
--- a/lib/tariff_synchronizer.rb
+++ b/lib/tariff_synchronizer.rb
@@ -1,6 +1,7 @@
 require 'date'
 require 'logger'
 require 'fileutils'
+require 'ring_buffer'
 require 'redis_lock'
 require 'active_support/notifications'
 require 'active_support/log_subscriber'


### PR DESCRIPTION
fixing uninitialized constant TariffSynchronizer::BaseUpdateImporter::RingBuffer