### PR TITLE
After Rails upgrade 6

### DIFF
--- a/lib/tariff_synchronizer.rb
+++ b/lib/tariff_synchronizer.rb
@@ -8,6 +8,8 @@ require 'active_support/log_subscriber'
 
 require 'bank_holidays'
 require 'taric_importer'
+require 'chief_importer'
+require 'chief_transformer'
 require 'tariff_synchronizer/base_update'
 require 'tariff_synchronizer/base_update_importer'
 require 'tariff_synchronizer/chief_file_name_generator'


### PR DESCRIPTION
fixing uninitialized constant TariffSynchronizer::TaricUpdate::ChiefImporter