### PR TITLE
Measures logger

### DIFF
--- a/lib/chief_transformer.rb
+++ b/lib/chief_transformer.rb
@@ -60,13 +60,13 @@ class ChiefTransformer
     end
 
     # Before run:
-    # deleting local version of logs
-    ChiefTransformer::MeasuresLogger.delete_tmp_file(chief.try(:filename))
+    # deleting local and S3 version of logs
+    ChiefTransformer::MeasuresLogger.delete_logs(chief.try(:filename))
 
     processor.process
 
     # After run:
-    # re-uploading logs to S3 after each processor run
+    # upload logs to S3 after each processor run
     ChiefTransformer::MeasuresLogger.upload_to_s3(chief.try(:filename))
   end
 end

--- a/lib/chief_transformer/candidate_measure.rb
+++ b/lib/chief_transformer/candidate_measure.rb
@@ -71,7 +71,7 @@ class ChiefTransformer
       # needs to throw errors about invalid goods nomenclature item found
       # we should check previous months in case CHIEF changes come before TARIC
       gono_sid = nil
-      [0, 1, 2, 3].each do |num|
+      [0, 1, 2, 3, 4].each do |num|
         gono_sid = GoodsNomenclature.where(goods_nomenclature_item_id: goods_nomenclature_item_id)
                                     .where("validity_start_date <= ? AND (validity_end_date >= ? OR validity_end_date IS NULL)",
                                            validity_start_date ? validity_start_date + num.month : validity_start_date,

--- a/lib/chief_transformer/measures_logger.rb
+++ b/lib/chief_transformer/measures_logger.rb
@@ -39,11 +39,16 @@ class ChiefTransformer
         end
       end
 
-      def delete_tmp_file(origin)
+      def delete_logs(origin)
         return if origin.nil?
 
         LOG_TYPES.each do |type|
+          # delete local version
           FileUtils.rm_f(tmp_file_path(origin, type))
+          # delete from S3
+          TariffSynchronizer::FileService.delete_file(
+            file_path(origin, type)
+          )
         end
       end
 

--- a/lib/tariff_synchronizer.rb
+++ b/lib/tariff_synchronizer.rb
@@ -171,6 +171,9 @@ module TariffSynchronizer
 
               chief_update.mark_as_pending
               chief_update.clear_applied_at
+
+              # need to delete measure logs
+              ChiefTransformer::MeasuresLogger.delete_logs(chief_update.filename)
             end
           else
             TariffSynchronizer::TaricUpdate.where { issue_date > date }.delete
@@ -180,6 +183,9 @@ module TariffSynchronizer
               end
 
               chief_update.delete
+
+              # need to delete measure logs
+              ChiefTransformer::MeasuresLogger.delete_logs(chief_update.filename)
             end
           end
         end

--- a/lib/tariff_synchronizer/file_service.rb
+++ b/lib/tariff_synchronizer/file_service.rb
@@ -8,6 +8,13 @@ module TariffSynchronizer
         end
       end
 
+      # Deletes file by path
+      def delete_file(file_path)
+        if Rails.env.production? && file_exists?(file_path)
+          bucket.object(file_path).delete
+        end
+      end
+
       def write_file(file_path, body)
         if Rails.env.production?
           bucket.object(file_path).put(body: body)


### PR DESCRIPTION
delete measure logs after rollback, extend candidate measure validation to 4 month