### PR TITLE
[DATA MIGRATION] add missing Import VAT measures for list of commodity codes

### DIFF
--- a/db/data_migrations/20180116140502_add_missing_vat_measures.rb
+++ b/db/data_migrations/20180116140502_add_missing_vat_measures.rb
@@ -1,0 +1,197 @@
+TradeTariffBackend::DataMigrator.migration do
+  name 'Add missing VAT measures'
+
+  MISSING_VAT_MEASURES = [
+    [ "20079939 03", "VT Z", "01.10.2014" ],
+    [ "39071000 90", "VT S", "01.07.2016" ],
+    [ "72142000 10", "VT S", "01.01.2016" ],
+    [ "72254012 20", "VT S", "01.02.2017" ],
+    [ "72254012 95", "VT S", "01.01.2017" ],
+    [ "72254015 20", "VT S", "01.02.2017" ],
+    [ "72254015 95", "VT S", "01.02.2017" ],
+    [ "72262000 20", "VT S", "01.02.2017" ],
+    [ "72262000 95", "VT S", "01.02.2017" ],
+    [ "72283020 10", "VT S", "01.01.2016" ],
+    [ "72283020 90", "VT S", "01.01.2016" ],
+    [ "72283041 10", "VT S", "01.01.2016" ],
+    [ "72283041 90", "VT S", "01.01.2016" ],
+    [ "72283049 10", "VT S", "01.01.2016" ],
+    [ "72283049 90", "VT S", "01.01.2016" ],
+    [ "72283061 10", "VT S", "01.01.2016" ],
+    [ "72283061 90", "VT S", "01.01.2016" ],
+    [ "72283069 10", "VT S", "01.01.2016" ],
+    [ "72283069 90", "VT S", "01.01.2016" ],
+    [ "72283070 10", "VT S", "01.01.2016" ],
+    [ "72283070 90", "VT S", "01.01.2016" ],
+    [ "72283089 10", "VT S", "01.01.2016" ],
+    [ "72283089 90", "VT S", "01.01.2016" ]
+  ]
+
+  up do
+    applicable {
+      MISSING_VAT_MEASURES.any? do |measure_candidate_ops|
+        find_measure_by(measure_candidate_ops).blank?
+      end
+    }
+
+    apply {
+      #
+      # Examples of 'MFCM' records in /data/chief/*.txt:
+      #
+      # "MFCM","01/07/2012:00:00:00","I","VT","S","B00",null,null,null,"21/06/2012:09:01:00","38123080 65","N","N","N"
+      #
+      # "MFCM","01/07/2012:00:00:00","I","VT","Z","B00",null,null,null,"21/06/2012:09:01:00","03054410 00","Y","N","N"
+      #
+      # "MFCM","01/01/2018:00:00:00","I","VT","Z","B00",null,null,null,"21/12/2017:08:31:00","03021180 90","Y","N","N"
+      #
+      # Adding of measures will be modifying primary key (fe_tsmp - aka validity_start_date)
+      # so unrestricting it for Chief::Mfcm.
+      #
+      Chief::Mfcm.unrestrict_primary_key
+
+      added_list = []
+      skipped_list = []
+      candidate_measures = []
+
+      MISSING_VAT_MEASURES.map do |measure_candidate_ops|
+        existing_record = find_measure_by(measure_candidate_ops)
+
+        if existing_record.present?
+          debug_it("[#{measure_candidate_ops}] measure already in system! Skipping...")
+
+          skipped_list << measure_candidate_ops[0]
+        else
+          debug_it("[#{measure_candidate_ops}] measure is missing! Adding...")
+
+          mfcm = Chief::Mfcm.new(
+            mfcm_ops(measure_candidate_ops)
+          )
+
+          candidate_measures << ChiefTransformer::CandidateMeasure.new(
+            mfcm: mfcm,
+            tame: mfcm.tame,
+            operation: :create,
+            operation_date: Date.today
+          )
+
+          added_list << measure_candidate_ops[0]
+        end
+      end
+
+      if candidate_measures.present?
+        candidates = ChiefTransformer::CandidateMeasure::Collection.new(candidate_measures)
+        debug_it("#{candidate_measures.count} candidate measures detected!")
+
+        candidates.validate
+        debug_it("#{candidate_measures.count} candidate measures passed validation!")
+
+        candidates.persist
+        debug_it("#{candidate_measures.count} candidate measures persisted!")
+
+        debug_it("Script completed!")
+
+        added_list.map do |item|
+          debug_it("  https://www.trade-tariff.service.gov.uk/trade-tariff/commodities/#{clean_up_whitespaces(item)}")
+        end
+
+        debug_it("  - skipped: #{skipped_list.join(', ')}")
+      else
+        debug_it("No any measure candidates found!")
+      end
+
+      #
+      # Restricting it for Chief::Mfcm back.
+      #
+      Chief::Mfcm.restrict_primary_key
+    }
+  end
+
+  down do
+    applicable {
+      MISSING_VAT_MEASURES.any? do |measure_candidate_ops|
+        find_measure_by(measure_candidate_ops).present?
+      end
+    }
+
+    apply {
+      deleted_list = []
+
+      MISSING_VAT_MEASURES.map do |measure_candidate_ops|
+        existing_record = find_measure_by(measure_candidate_ops)
+
+        if existing_record.present?
+          debug_it("[#{measure_candidate_ops}] measure detected! Removing...")
+
+          existing_record.destroy
+          deleted_list << measure_candidate_ops[0]
+
+          debug_it("[#{measure_candidate_ops}] measure detected! Removing...")
+        else
+          debug_it("[#{measure_candidate_ops}] measure is missing! Skipping...")
+        end
+      end
+
+      debug_it("Script completed!")
+      debug_it("  - deleted_list: #{deleted_list.join(', ')}")
+    }
+  end
+
+  def mfcm_ops(measure_candidate_ops)
+    commodity_code = measure_candidate_ops[0]
+    msrgp_code, msr_type = measure_candidate_ops[1].split(" ")
+    validity_start_date = measure_candidate_ops[2].to_datetime
+
+    ops = {
+      fe_tsmp: validity_start_date,
+      amend_indicator: "I",
+      msrgp_code: msrgp_code,
+      msr_type: msr_type,
+      tty_code: "B00",
+      tar_msr_no: nil,
+      le_tsmp: nil,
+      audit_tsmp: nil,
+      cmdty_code: commodity_code,
+      cmdty_msr_xhdg: (msr_type == "Z" ? "Y" : "N"),
+      null_tri_rqd: "N",
+      exports_use_ind: "N"
+    }
+
+    debug_it("[#{commodity_code} - '#{msrgp_code}#{msr_type}'] options: #{ops.inspect}")
+
+    #
+    # Other options will be assigned by default:
+    #
+    #   geographical_area_id: "1011" # "ERGA OMNES"
+    #   generating_regulation_code: "I9999/YY 31/12/1971 1971-12-31"
+    #   measure_generating_regulation_id: "IYY99990"
+    #   generating_regulation_code: "I9999/YY"
+    #
+    # and footnotes:
+    #
+    #   VTS: "03020 UK VAT standard rate"
+    #
+    #   VTZ: "03026 UK VAT zero rate"
+    #
+
+    ops
+  end
+
+  def find_measure_by(measure_candidate_ops)
+    Measure.find(
+      goods_nomenclature_item_id: clean_up_whitespaces(measure_candidate_ops[0]),
+      measure_type_id: clean_up_whitespaces(measure_candidate_ops[1])
+    )
+  end
+
+  def clean_up_whitespaces(v)
+    v.gsub(" ", "")
+  end
+
+  def debug_it(message)
+    puts ""
+    puts "-" * 100
+    puts " #{message}"
+    puts "-" * 100
+    puts ""
+  end
+end


### PR DESCRIPTION
*THIS PR DOES:*

Adds data migration script, which populate missing Import VAT measures for following commodity codes:

```
 "20079939 03", "VT Z", "01.10.2014"
 "39071000 90", "VT S", "01.07.2016"
 "72142000 10", "VT S", "01.01.2016"
 "72254012 20", "VT S", "01.02.2017"
 "72254012 95", "VT S", "01.01.2017"
 "72254015 20", "VT S", "01.02.2017"
 "72254015 95", "VT S", "01.02.2017"
 "72262000 20", "VT S", "01.02.2017"
 "72262000 95", "VT S", "01.02.2017"
 "72283020 10", "VT S", "01.01.2016"
 "72283020 90", "VT S", "01.01.2016"
 "72283041 10", "VT S", "01.01.2016"
 "72283041 90", "VT S", "01.01.2016"
 "72283049 10", "VT S", "01.01.2016"
 "72283049 90", "VT S", "01.01.2016"
 "72283061 10", "VT S", "01.01.2016"
 "72283061 90", "VT S", "01.01.2016"
 "72283069 10", "VT S", "01.01.2016"
 "72283069 90", "VT S", "01.01.2016"
 "72283070 10", "VT S", "01.01.2016"
 "72283070 90", "VT S", "01.01.2016"
 "72283089 10", "VT S", "01.01.2016"
 "72283089 90", "VT S", "01.01.2016"
```

*DETAILS:*

As part of our audit of which VAT measures are missing, the following com codes were missing vat measures - we need to manually create them using the data attached.
The country group should be erga omnes, the legislation should be the default, the footnote should match the measure type (standard or 0% vat).

[TRELLO CARD](https://trello.com/c/meFyMWaN/469-tariff17-import-missing-vat-measures-manually)