### PR TITLE
[MEASURE] Council Regulation - URL generation improvements

### DIFF
--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -298,17 +298,32 @@ class Measure < Sequel::Model
     "#{regulation_code.first}#{regulation_code[3..6]}/#{regulation_code[1..2]}"
   end
 
-  def generating_regulation_url(regulation_code = measure_generating_regulation_id)
-    year = regulation_code[1..2]
-    # When we get to 2071 assume that we don't care about the 1900's
-    # or the EU has a better way to search
-    if year.to_i > 70
-      full_year = "19#{year}"
+  def generating_regulation_url(for_suspending_regulation=false)
+    target_regulation = for_suspending_regulation ? suspending_regulation : generating_regulation
+
+    oj_seria, oj_number = target_regulation.officialjournal_number
+                                           .split(" ")
+
+    oj_page = target_regulation.officialjournal_page
+                               .to_s
+                               .rjust(4, "0")
+
+    url_ops = if target_regulation.is_a?(MeasurePartialTemporaryStop)
+      #
+      # If MeasurePartialTemporaryStop, we do not pass year into the search params
+      # as there are no published_date for partial stop
+      #
+      "whOJ=NO_OJ%3D#{oj_number},PAGE_FIRST%3D#{oj_page}&DB_COLL_OJ=oj-#{oj_seria.downcase}&type=advanced&lang=en"
     else
-      full_year = "20#{year}"
+      #
+      # If general regulation or FullTemporaryStopRegulation, then
+      # we are providing 'published_date' year to the search parameters
+      #
+      oj_year = target_regulation.published_date.year
+      "whOJ=NO_OJ%3D#{oj_number},YEAR_OJ%3D#{oj_year},PAGE_FIRST%3D#{oj_page}&DB_COLL_OJ=oj-#{oj_seria.downcase}&type=advanced&lang=en"
     end
-    code = "3#{full_year}#{regulation_code.first}#{regulation_code[3..6]}"
-    "http://eur-lex.europa.eu/search.html?instInvStatus=ALL&or0=DN%3D#{code}*,DN-old%3D#{code}*&DTC=false&type=advanced"
+
+    "http://eur-lex.europa.eu/search.html?#{url_ops}"
   end
 
   def origin

--- a/app/models/measure_partial_temporary_stop.rb
+++ b/app/models/measure_partial_temporary_stop.rb
@@ -6,6 +6,9 @@ class MeasurePartialTemporaryStop < Sequel::Model
 
   set_primary_key [:measure_sid, :partial_temporary_stop_regulation_id]
 
+  alias_attribute :officialjournal_number, :partial_temporary_stop_regulation_officialjournal_number
+  alias_attribute :officialjournal_page, :partial_temporary_stop_regulation_officialjournal_page
+
   def regulation_id
     partial_temporary_stop_regulation_id
   end

--- a/app/views/api/v1/measures/_measure.json.rabl
+++ b/app/views/api/v1/measures/_measure.json.rabl
@@ -36,7 +36,7 @@ end
 node(:suspension_legal_act, if: ->(measure) { !measure.national && measure.suspended? }) do |measure|
   {
     generating_regulation_code: measure.generating_regulation_code(measure.suspending_regulation.regulation_id),
-    url: measure.generating_regulation_url(measure.suspending_regulation.regulation_id),
+    url: measure.generating_regulation_url(true),
     validity_end_date: measure.suspending_regulation.effective_end_date,
     validity_start_date: measure.suspending_regulation.effective_start_date
   }

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -947,25 +947,121 @@ describe Measure do
   end
 
   describe '#generating_regulation_url' do
-    context 'when regulation was created between year 1970 and 2000' do
-      let(:measure) {
-        build :measure,
-        measure_generating_regulation_id: '7734567'
-      }
+    context "for base_regulation" do
+      context "for Official Journal - C (Information and Notices) seria" do
+        let!(:base_regulation) do
+          create(:base_regulation, base_regulation_id: "I1703530",
+                                   base_regulation_role: 1,
+                                   published_date: Date.new(2017, 10, 20),
+                                   officialjournal_number: "C 353",
+                                   officialjournal_page: 19)
+        end
 
-      it 'returns link to eur-lex with relevant year' do
-        expect(measure.generating_regulation_url).to include '3197374567'
+        let!(:measure) do
+          create(:measure, goods_nomenclature_item_id: "8711601000",
+                           measure_generating_regulation_id: "I1703530",
+                           base_regulation: base_regulation)
+        end
+
+        before do
+          measure.reload
+        end
+
+        it "should generate council regulation url" do
+          expect(measure.generating_regulation_url).to be_eql("http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D353,YEAR_OJ%3D2017,PAGE_FIRST%3D0019&DB_COLL_OJ=oj-c&type=advanced&lang=en")
+        end
+      end
+
+      context "for Official Journal - L (Legislation) seria" do
+        let!(:base_regulation) do
+          create(:base_regulation, base_regulation_id: "R1708920",
+                                   base_regulation_role: 1,
+                                   published_date: Date.new(2017, 05, 25),
+                                   officialjournal_number: "L 138",
+                                   officialjournal_page: 57)
+        end
+
+        let!(:measure) do
+          create(:measure, goods_nomenclature_item_id: "0808108000",
+                           measure_generating_regulation_id: "R1708920",
+                           base_regulation: base_regulation)
+        end
+
+        before do
+          measure.reload
+        end
+
+        it "should generate council regulation url" do
+          expect(measure.generating_regulation_url).to be_eql("http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D138,YEAR_OJ%3D2017,PAGE_FIRST%3D0057&DB_COLL_OJ=oj-l&type=advanced&lang=en")
+        end
       end
     end
 
-    context 'when regulation was created after year 2000' do
-      let(:measure) {
-        build :measure,
-        measure_generating_regulation_id: '7014567'
-      }
+    context "for suspending_regulation" do
+      context "for FullTemporaryStopRegulation" do
+        let!(:fts_regulation) do
+          create(:fts_regulation, full_temporary_stop_regulation_id: "R9528150",
+                                  full_temporary_stop_regulation_role: 8,
+                                  published_date: Date.new(1995, 12, 9),
+                                  officialjournal_number: "L 297",
+                                  officialjournal_page: 1)
+        end
 
-      it 'returns link to eur-lex with relevant year' do
-        expect(measure.generating_regulation_url).to include '3200174567'
+        let!(:measure) do
+          create(:measure, goods_nomenclature_item_id: "0100000000",
+                           measure_generating_regulation_id: "R9309900")
+        end
+
+        let!(:fts_regulation_action) do
+          create(:fts_regulation_action, fts_regulation_role: 8,
+                                         fts_regulation_id: "R9528150",
+                                         stopped_regulation_role: 1,
+                                         stopped_regulation_id: "R9309900")
+        end
+
+        before do
+          measure.reload
+        end
+
+        it "should generate council regulation url" do
+          expect(measure.generating_regulation_url(true)).to be_eql(
+            "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D297,YEAR_OJ%3D1995,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-l&type=advanced&lang=en"
+          )
+        end
+      end
+
+      context "for MeasurePartialTemporaryStop" do
+        let!(:base_regulation) do
+          create(:base_regulation, base_regulation_id: "R0912150",
+                                   base_regulation_role: 1,
+                                   published_date: Date.new(2009, 12, 15),
+                                   officialjournal_number: "L 328",
+                                   officialjournal_page: 1)
+        end
+
+        let!(:measure) do
+          create(:measure, goods_nomenclature_item_id: "2823000000",
+                           measure_generating_regulation_id: "R0912150",
+                           base_regulation: base_regulation)
+        end
+
+        let!(:measure_partial_temporary_stop) do
+          create(:measure_partial_temporary_stop, measure_sid: measure.measure_sid,
+                                                  partial_temporary_stop_regulation_id: "R0912150",
+                                                  validity_start_date: DateTime.parse("2010-01-04T00:00:00.000Z"),
+                                                  officialjournal_number: "L 328",
+                                                  officialjournal_page: 6)
+        end
+
+        before do
+          measure.reload
+        end
+
+        it "should generate council regulation url" do
+          expect(measure.generating_regulation_url(true)).to be_eql(
+            "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D328,PAGE_FIRST%3D0006&DB_COLL_OJ=oj-l&type=advanced&lang=en"
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
**DESCRIPTION:**

We need to update the URL so that it finds the correct url, attached screenshots show one format and this is another from the client with an example:

https://www.trade-tariff.service.gov.uk/trade-tariff/commodities/8711601000?country=CN#import

The hyperlink on the pages above to 1053/17 does not work, I think it should go to I0353/17

[TRELLO CARD](https://trello.com/c/J4Ddzqgr/453-tariff17-improve-lookup-of-legal-notices)