### PR TITLE
[FOR NATIONAL MEASURES] do not show 'Council Regulation (EEC)' link

### DIFF
--- a/app/controllers/api/v1/commodities_controller.rb
+++ b/app/controllers/api/v1/commodities_controller.rb
@@ -28,11 +28,10 @@ module Api
             },
             { quota_order_number: :quota_definition },
             { excluded_geographical_areas: :geographical_area_descriptions },
+            { geographical_area: :geographical_area_descriptions },
             :additional_code,
             :full_temporary_stop_regulations,
             :measure_partial_temporary_stops
-          ).join_table(
-            :inner, :geographical_areas, geographical_areas__geographical_area_sid: :measures__geographical_area_sid
           ).order(
             Sequel.asc(:measures__national, nulls: :last), Sequel.asc(:measures__geographical_area_id)
           ).all, @commodity

--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -299,6 +299,8 @@ class Measure < Sequel::Model
   end
 
   def generating_regulation_url(for_suspending_regulation=false)
+    return false if national?
+
     target_regulation = for_suspending_regulation ? suspending_regulation : generating_regulation
 
     oj_seria, oj_number = target_regulation.officialjournal_number


### PR DESCRIPTION
*CARD DESCRIPTION:*

It's a placeholder code from CHIEF, not a real valid code, so do not display anything on the frontend for it.
If national do not show the 'Council Regulation (EEC)' link.

*WHAT THIS PR DOES:*

As we found 'join_table' used in `app/controllers/api/v1/commodities_controller.rb`:
```
join_table(
   :inner, :geographical_areas, geographical_areas__geographical_area_sid: :measures__geographical_area_sid
)
```
lead to issue with `national` boolean field of 'Measure' object at commodity details page.
So that we are replacing it with advanced condition for `@commodity.measures_dataset.eager`:
```
{ geographical_area: :geographical_area_descriptions }
```

[TRELLO CARD](https://trello.com/c/2qNKK1NT/466-tariff17-hide-i9999-yy-from-the-regulations-on-the-tariff-frontend)