### PR TITLE
[MEASURE] Council Regulation - URL generation improvements

### DIFF
--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -301,31 +301,9 @@ class Measure < Sequel::Model
   def generating_regulation_url(for_suspending_regulation=false)
     return false if national?
 
-    target_regulation = for_suspending_regulation ? suspending_regulation : generating_regulation
-
-    oj_seria, oj_number = target_regulation.officialjournal_number
-                                           .split(" ")
-
-    oj_page = target_regulation.officialjournal_page
-                               .to_s
-                               .rjust(4, "0")
-
-    url_ops = if target_regulation.is_a?(MeasurePartialTemporaryStop)
-      #
-      # If MeasurePartialTemporaryStop, we do not pass year into the search params
-      # as there are no published_date for partial stop
-      #
-      "whOJ=NO_OJ%3D#{oj_number},PAGE_FIRST%3D#{oj_page}&DB_COLL_OJ=oj-#{oj_seria.downcase}&type=advanced&lang=en"
-    else
-      #
-      # If general regulation or FullTemporaryStopRegulation, then
-      # we are providing 'published_date' year to the search parameters
-      #
-      oj_year = target_regulation.published_date.year
-      "whOJ=NO_OJ%3D#{oj_number},YEAR_OJ%3D#{oj_year},PAGE_FIRST%3D#{oj_page}&DB_COLL_OJ=oj-#{oj_seria.downcase}&type=advanced&lang=en"
-    end
-
-    "http://eur-lex.europa.eu/search.html?#{url_ops}"
+    MeasureService::CouncilRegulationUrlGenerator.new(
+      for_suspending_regulation ? suspending_regulation : generating_regulation
+    ).generate
   end
 
   def origin

--- a/app/services/measure_service/council_regulation_url_generator.rb
+++ b/app/services/measure_service/council_regulation_url_generator.rb
@@ -1,0 +1,85 @@
+#
+# This service generates search url for http://eur-lex.europa.eu service
+#
+# We are using 2 approaches of search for regulation details:
+#
+# APPROACH 1: If regulation have official journal page
+#             then we are using seach by Official Journal parameters
+#
+# APPROACH 2: If regulation doens't have official joirnal page
+#             then we are using search by celex number
+#
+
+module MeasureService
+  class CouncilRegulationUrlGenerator
+
+    attr_accessor :target_regulation
+
+    def initialize(target_regulation)
+      @target_regulation = target_regulation
+    end
+
+    def generate
+      if target_regulation.officialjournal_page.present?
+        published_journal_search_type_url
+      else
+        celex_number_search_type_url
+      end
+    end
+
+    private
+
+      def published_journal_search_type_url
+        oj_seria, oj_number = target_regulation.officialjournal_number
+                                               .split(" ")
+
+        oj_page = target_regulation.officialjournal_page
+                                   .to_s
+                                   .rjust(4, "0")
+
+        url_ops = if target_regulation.is_a?(MeasurePartialTemporaryStop)
+          #
+          # If MeasurePartialTemporaryStop, we do not pass year into the search params
+          # as there are no published_date for partial stop
+          #
+          "whOJ=NO_OJ%3D#{oj_number},PAGE_FIRST%3D#{oj_page}&DB_COLL_OJ=oj-#{oj_seria.downcase}&type=advanced&lang=en"
+        else
+          #
+          # If general regulation or FullTemporaryStopRegulation, then
+          # we are providing 'published_date' year to the search parameters
+          #
+          oj_year = target_regulation.published_date.year
+          "whOJ=NO_OJ%3D#{oj_number},YEAR_OJ%3D#{oj_year},PAGE_FIRST%3D#{oj_page}&DB_COLL_OJ=oj-#{oj_seria.downcase}&type=advanced&lang=en"
+        end
+
+        "http://eur-lex.europa.eu/search.html?#{url_ops}"
+      end
+
+      def celex_number_search_type_url
+        regulation_code = target_regulation.public_send(regulation_id)
+
+        year = regulation_code[1..2]
+        # When we get to 2071 assume that we don't care about the 1900's
+        # or the EU has a better way to search
+        if year.to_i > 70
+          full_year = "19#{year}"
+        else
+          full_year = "20#{year}"
+        end
+
+        code = "3#{full_year}#{regulation_code.first}#{regulation_code[3..6]}"
+        "http://eur-lex.europa.eu/search.html?instInvStatus=ALL&or0=DN%3D#{code}*,DN-old%3D#{code}*&DTC=false&type=advanced"
+      end
+
+      def regulation_id
+        case target_regulation.class
+        when MeasurePartialTemporaryStop
+          :partial_temporary_stop_regulation_id
+        when FullTemporaryStopRegulation
+          :full_temporary_stop_regulation_id
+        else
+          :base_regulation_id
+        end
+      end
+  end
+end


### PR DESCRIPTION
**WHAT THIS PR DOES:**

We are introducing conditional council regulation URL generation.
Previously, we used just CELEX number way to generate URL, but
as we noted it doesn't work for all measures.

So that we introduced previously alternative way of URL generation
by Official journal parameters (OJ Seria, OJ number, OJ page and Year).

But after testing we noted that this way doesn't work for old regulations.
For example: R2840/72 and R2658/87
Because they have no official page number.

So in this PR we are using 2 approaches of search for regulation details:

APPROACH 1: If regulation have official journal page
            then we are using seach by Official Journal parameters

APPROACH 2: If regulation doens't have official joirnal page
            then we are using search by celex number

[TRELLO CARD](https://trello.com/c/J4Ddzqgr/453-tariff17-improve-lookup-of-legal-notices)