### PR TITLE
[MISSING VAT MEASURES] data migration for '3802 9000 11', '3824 9992 35', '7225 9900 40'

### DIFF
--- a/db/data_migrations/20180116140502_add_missing_vat_measures.rb
+++ b/db/data_migrations/20180116140502_add_missing_vat_measures.rb
@@ -29,167 +29,25 @@ TradeTariffBackend::DataMigrator.migration do
 
   up do
     applicable {
-      MISSING_VAT_MEASURES.any? do |measure_candidate_ops|
-        find_measure_by(measure_candidate_ops).blank?
-      end
+      helper_klass.up_applicable?(MISSING_VAT_MEASURES)
     }
 
     apply {
-      #
-      # Examples of 'MFCM' records in /data/chief/*.txt:
-      #
-      # "MFCM","01/07/2012:00:00:00","I","VT","S","B00",null,null,null,"21/06/2012:09:01:00","38123080 65","N","N","N"
-      #
-      # "MFCM","01/07/2012:00:00:00","I","VT","Z","B00",null,null,null,"21/06/2012:09:01:00","03054410 00","Y","N","N"
-      #
-      # "MFCM","01/01/2018:00:00:00","I","VT","Z","B00",null,null,null,"21/12/2017:08:31:00","03021180 90","Y","N","N"
-      #
-      # Adding of measures will be modifying primary key (fe_tsmp - aka validity_start_date)
-      # so unrestricting it for Chief::Mfcm.
-      #
-      Chief::Mfcm.unrestrict_primary_key
-
-      added_list = []
-      skipped_list = []
-      candidate_measures = []
-
-      MISSING_VAT_MEASURES.map do |measure_candidate_ops|
-        existing_record = find_measure_by(measure_candidate_ops)
-
-        if existing_record.present?
-          debug_it("[#{measure_candidate_ops}] measure already in system! Skipping...")
-
-          skipped_list << measure_candidate_ops[0]
-        else
-          debug_it("[#{measure_candidate_ops}] measure is missing! Adding...")
-
-          mfcm = Chief::Mfcm.new(
-            mfcm_ops(measure_candidate_ops)
-          )
-
-          candidate_measures << ChiefTransformer::CandidateMeasure.new(
-            mfcm: mfcm,
-            tame: mfcm.tame,
-            operation: :create,
-            operation_date: Date.today
-          )
-
-          added_list << measure_candidate_ops[0]
-        end
-      end
-
-      if candidate_measures.present?
-        candidates = ChiefTransformer::CandidateMeasure::Collection.new(candidate_measures)
-        debug_it("#{candidate_measures.count} candidate measures detected!")
-
-        candidates.validate
-        debug_it("#{candidate_measures.count} candidate measures passed validation!")
-
-        candidates.persist
-        debug_it("#{candidate_measures.count} candidate measures persisted!")
-
-        debug_it("Script completed!")
-
-        added_list.map do |item|
-          debug_it("  https://www.trade-tariff.service.gov.uk/trade-tariff/commodities/#{clean_up_whitespaces(item)}")
-        end
-
-        debug_it("  - skipped (#{skipped_list.size}): #{skipped_list.join(', ')}")
-      else
-        debug_it("No any measure candidates found!")
-      end
-
-      #
-      # Restricting it for Chief::Mfcm back.
-      #
-      Chief::Mfcm.restrict_primary_key
+      helper_klass.up_apply(MISSING_VAT_MEASURES)
     }
   end
 
   down do
     applicable {
-      MISSING_VAT_MEASURES.any? do |measure_candidate_ops|
-        find_measure_by(measure_candidate_ops).present?
-      end
+      helper_klass.down_applicable?(MISSING_VAT_MEASURES)
     }
 
     apply {
-      deleted_list = []
-
-      MISSING_VAT_MEASURES.map do |measure_candidate_ops|
-        existing_record = find_measure_by(measure_candidate_ops)
-
-        if existing_record.present?
-          debug_it("[#{measure_candidate_ops}] measure detected! Removing...")
-
-          existing_record.destroy
-          deleted_list << measure_candidate_ops[0]
-        else
-          debug_it("[#{measure_candidate_ops}] measure is missing! Skipping...")
-        end
-      end
-
-      debug_it("Script completed!")
-      debug_it("  - deleted_list (#{deleted_list.size}): #{deleted_list.join(', ')}")
+      helper_klass.down_apply(MISSING_VAT_MEASURES)
     }
   end
 
-  def mfcm_ops(measure_candidate_ops)
-    commodity_code = measure_candidate_ops[0]
-    msrgp_code, msr_type = measure_candidate_ops[1].split(" ")
-    validity_start_date = measure_candidate_ops[2].to_datetime
-
-    ops = {
-      fe_tsmp: validity_start_date,
-      amend_indicator: "I",
-      msrgp_code: msrgp_code,
-      msr_type: msr_type,
-      tty_code: "B00",
-      tar_msr_no: nil,
-      le_tsmp: nil,
-      audit_tsmp: nil,
-      cmdty_code: commodity_code,
-      cmdty_msr_xhdg: (msr_type == "Z" ? "Y" : "N"),
-      null_tri_rqd: "N",
-      exports_use_ind: "N"
-    }
-
-    debug_it("[#{commodity_code} - '#{msrgp_code}#{msr_type}'] options: #{ops.inspect}")
-
-    #
-    # Other options will be assigned by default:
-    #
-    #   geographical_area_id: "1011" # "ERGA OMNES"
-    #   generating_regulation_code: "I9999/YY 31/12/1971 1971-12-31"
-    #   measure_generating_regulation_id: "IYY99990"
-    #   generating_regulation_code: "I9999/YY"
-    #
-    # and footnotes:
-    #
-    #   VTS: "03020 UK VAT standard rate"
-    #
-    #   VTZ: "03026 UK VAT zero rate"
-    #
-
-    ops
-  end
-
-  def find_measure_by(measure_candidate_ops)
-    Measure.find(
-      goods_nomenclature_item_id: measure_candidate_ops[0],
-      measure_type_id: clean_up_whitespaces(measure_candidate_ops[1])
-    )
-  end
-
-  def clean_up_whitespaces(v)
-    v.gsub(" ", "")
-  end
-
-  def debug_it(message)
-    puts ""
-    puts "-" * 100
-    puts " #{message}"
-    puts "-" * 100
-    puts ""
+  def helper_klass
+    ::TradeTariffBackend::DataMigration::Helpers::VatMeasures::ManualAddition
   end
 end

--- a/db/data_migrations/20180130085145_add_missing_vts_to_some_commodities.rb
+++ b/db/data_migrations/20180130085145_add_missing_vts_to_some_commodities.rb
@@ -1,0 +1,33 @@
+TradeTariffBackend::DataMigrator.migration do
+  name "Add missing VAT measures for commodities '3802 9000 11', '3824 9992 35', '7225 9900 40'"
+
+  MISSING_VAT_MEASURES = [
+    [ "3802900011", "VT S", "30.01.2018" ],
+    [ "3824999235", "VT S", "30.01.2018" ],
+    [ "7225990040", "VT S", "30.01.2018" ]
+  ]
+
+  up do
+    applicable {
+      helper_klass.up_applicable?(MISSING_VAT_MEASURES)
+    }
+
+    apply {
+      helper_klass.up_apply(MISSING_VAT_MEASURES)
+    }
+  end
+
+  down do
+    applicable {
+      helper_klass.down_applicable?(MISSING_VAT_MEASURES)
+    }
+
+    apply {
+      helper_klass.down_apply(MISSING_VAT_MEASURES)
+    }
+  end
+
+  def helper_klass
+    ::TradeTariffBackend::DataMigration::Helpers::VatMeasures::ManualAddition
+  end
+end

--- a/lib/trade_tariff_backend/data_migration/helpers/vat_measures/manual_addition.rb
+++ b/lib/trade_tariff_backend/data_migration/helpers/vat_measures/manual_addition.rb
@@ -1,0 +1,174 @@
+module TradeTariffBackend
+  class DataMigration
+    module Helpers
+      module VatMeasures
+        class ManualAddition
+          class << self
+            def down_apply(list)
+              deleted_list = []
+
+              list.map do |measure_candidate_ops|
+                existing_record = find_measure_by(measure_candidate_ops)
+
+                if existing_record.present?
+                  debug_it("[#{measure_candidate_ops}] measure detected! Removing...")
+
+                  existing_record.destroy
+                  deleted_list << measure_candidate_ops[0]
+                else
+                  debug_it("[#{measure_candidate_ops}] measure is missing! Skipping...")
+                end
+              end
+
+              debug_it("Script completed!")
+              debug_it("  - deleted_list (#{deleted_list.size}): #{deleted_list.join(', ')}")
+            end
+
+            def up_applicable?(list)
+              list.any? do |measure_candidate_ops|
+                find_measure_by(measure_candidate_ops).blank?
+              end
+            end
+
+            def down_applicable?(list)
+              list.any? do |measure_candidate_ops|
+                find_measure_by(measure_candidate_ops).present?
+              end
+            end
+
+            def mfcm_ops(measure_candidate_ops)
+              commodity_code = measure_candidate_ops[0]
+              msrgp_code, msr_type = measure_candidate_ops[1].split(" ")
+              validity_start_date = measure_candidate_ops[2].to_datetime
+
+              ops = {
+                fe_tsmp: validity_start_date,
+                amend_indicator: "I",
+                msrgp_code: msrgp_code,
+                msr_type: msr_type,
+                tty_code: "B00",
+                tar_msr_no: nil,
+                le_tsmp: nil,
+                audit_tsmp: nil,
+                cmdty_code: commodity_code,
+                cmdty_msr_xhdg: (msr_type == "Z" ? "Y" : "N"),
+                null_tri_rqd: "N",
+                exports_use_ind: "N"
+              }
+
+              debug_it("[#{commodity_code} - '#{msrgp_code}#{msr_type}'] options: #{ops.inspect}")
+
+              #
+              # Other options will be assigned by default:
+              #
+              #   geographical_area_id: "1011" # "ERGA OMNES"
+              #   generating_regulation_code: "I9999/YY 31/12/1971 1971-12-31"
+              #   measure_generating_regulation_id: "IYY99990"
+              #   generating_regulation_code: "I9999/YY"
+              #
+              # and footnotes:
+              #
+              #   VTS: "03020 UK VAT standard rate"
+              #
+              #   VTZ: "03026 UK VAT zero rate"
+              #
+
+              ops
+            end
+
+            def find_measure_by(measure_candidate_ops)
+              Measure.find(
+                goods_nomenclature_item_id: measure_candidate_ops[0],
+                measure_type_id: clean_up_whitespaces(measure_candidate_ops[1]),
+                operation: "C"
+              )
+            end
+
+            def clean_up_whitespaces(v)
+              v.gsub(" ", "")
+            end
+
+            def debug_it(message)
+              puts ""
+              puts "-" * 100
+              puts " #{message}"
+              puts "-" * 100
+              puts ""
+            end
+
+            def up_apply(list)
+              #
+              # Examples of 'MFCM' records in /data/chief/*.txt:
+              #
+              # "MFCM","01/07/2012:00:00:00","I","VT","S","B00",null,null,null,"21/06/2012:09:01:00","38123080 65","N","N","N"
+              #
+              # "MFCM","01/07/2012:00:00:00","I","VT","Z","B00",null,null,null,"21/06/2012:09:01:00","03054410 00","Y","N","N"
+              #
+              # "MFCM","01/01/2018:00:00:00","I","VT","Z","B00",null,null,null,"21/12/2017:08:31:00","03021180 90","Y","N","N"
+              #
+              # Adding of measures will be modifying primary key (fe_tsmp - aka validity_start_date)
+              # so unrestricting it for Chief::Mfcm.
+              #
+              Chief::Mfcm.unrestrict_primary_key
+
+              added_list = []
+              skipped_list = []
+              candidate_measures = []
+
+              list.map do |measure_candidate_ops|
+                existing_record = find_measure_by(measure_candidate_ops)
+
+                if existing_record.present?
+                  debug_it("[#{measure_candidate_ops}] measure already in system! Skipping...")
+
+                  skipped_list << measure_candidate_ops[0]
+                else
+                  debug_it("[#{measure_candidate_ops}] measure is missing! Adding...")
+
+                  mfcm = Chief::Mfcm.new(
+                    mfcm_ops(measure_candidate_ops)
+                  )
+
+                  candidate_measures << ChiefTransformer::CandidateMeasure.new(
+                    mfcm: mfcm,
+                    tame: mfcm.tame,
+                    operation: :create,
+                    operation_date: Date.today
+                  )
+
+                  added_list << measure_candidate_ops[0]
+                end
+              end
+
+              if candidate_measures.present?
+                candidates = ChiefTransformer::CandidateMeasure::Collection.new(candidate_measures)
+                debug_it("#{candidate_measures.count} candidate measures detected!")
+
+                candidates.validate
+                debug_it("#{candidate_measures.count} candidate measures passed validation!")
+
+                candidates.persist
+                debug_it("#{candidate_measures.count} candidate measures persisted!")
+
+                debug_it("Script completed!")
+
+                added_list.map do |item|
+                  debug_it("  https://www.trade-tariff.service.gov.uk/trade-tariff/commodities/#{clean_up_whitespaces(item)}")
+                end
+
+                debug_it("  - skipped (#{skipped_list.size}): #{skipped_list.join(', ')}")
+              else
+                debug_it("No any measure candidates found!")
+              end
+
+              #
+              # Restricting it for Chief::Mfcm back.
+              #
+              Chief::Mfcm.restrict_primary_key
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Following commodities doesn't have VTS Standart VAT now.
So we added data migration to populate them.
As we already similar code for adding of missing VAT in data migration
`20180116140502_add_missing_vat_measures.rb`

So that I decided to move this code to separated class in `lib/trade_tariff_backend/data_migration/helpers`

*1) 3824 9992 35*
https://www.trade-tariff.service.gov.uk/trade-tariff/commodities/3824999235

IN LIVE DB:
`3824999235: VTS validity_start_date: 2017-01-01 00:00:00 UTC - validity_end_date: 2018-01-01 00:00:00 UTC, operation: update, operation_date: 2018-01-02`

IN LOCAL DB:
`3824999235: VTS validity_start_date: 2017-01-01 00:00:00 UTC - validity_end_date: no date, operation: create, operation_date: 2017-01-02`

IN CHIEF UPDATE FILES we have related actions:

create at *2017-01-02_KBT009(17002).txt*:
`20235: "MFCM","01/01/2017:00:00:00","I","VT","S","B00",null,null,null,"21/12/2016:08:10:00","38249992 35","N","N","N"`

then update at *2017-03-02_KBT009(17061).txt* :
`39357: "MFCM","01/03/2017:00:00:00","U","VT","S","B00",null,null,null,"24/02/2017:09:16:00","38249992 35","N","N","N"`

update at *2017-06-02_KBT009(17153).txt*:
`45620: "MFCM","01/06/2017:00:00:00","U","VT","S","B00",null,null,null,"30/05/2017:08:49:00","38249992 35","N","N","N"`

and then delete at *2018-01-02_KBT009(18002).txt*:
`12023: "MFCM","01/01/2018:00:00:00","X","VT","S","B00",null,null,null,"21/12/2017:08:32:00","38249992 35","N","N","N"`

*Summary:* VTS measure was removed for `3824999235` at *2018-01-02_KBT009(18002).txt*,
           that's why we no longer see it at https://www.trade-tariff.service.gov.uk/trade-tariff/commodities/3824999235#import

*2) 3802 9000 11*
https://www.trade-tariff.service.gov.uk/trade-tariff/commodities/3802900011#import

IN LIVE DB:
`3802900011: VTS validity_start_date: 2013-01-10 15:12:00 UTC - validity_end_date: 2018-01-01 00:00:00 UTC, operation: update, operation_date: 2018-01-02`

IN LOCAL DB:
`3802900011: VTS validity_start_date: 2013-01-10 15:12:00 UTC - validity_end_date: no date, operation: create, operation_date: 2013-01-11`

IN CHIEF UPDATE FILES we have related actions:

create at *2013-01-11_KBT009(13011).txt*:
`370: "MFCM","10/01/2013:15:12:00","I","VT","S","B00",null,null,null,"10/01/2013:15:10:00","38029000 11","N","N","N"`

update at *2013-02-02_KBT009(13033).txt*:
`5638: "MFCM","01/02/2013:00:00:00","U","VT","S","B00",null,null,null,"24/01/2013:07:45:00","38029000 11","N","N","N"`

update at *2013-04-02_KBT009(13092).txt*:
`20260: "MFCM       ","01/04/2013:00:00:00","U","VT","S","B00",null,null,null,"25/03/2013:07:57:00","38029000 11","N","N","N"`

then a lot of similar updates with changing of `validity_end_date`

and then delete at *2018-01-02_KBT009(18002).txt*:
` 19911: "MFCM","01/01/2018:00:00:00","X","VT","S","B00",null,null,null,"21/12/2017:08:32:00","38029000 11","N","N","N"`

*Summary:* VTS measure was removed for `3802900011` at *2018-01-02_KBT009(18002).txt*,
that's why we no longer see it at https://www.trade-tariff.service.gov.uk/trade-tariff/commodities/3802900011#import

*3) 7225 9900 40*
https://www.trade-tariff.service.gov.uk/trade-tariff/commodities/7225990040#import

IN LIVE DB:
```7225990040: VTS validity_start_date: 2016-12-15 11:42:00 UTC - validity_end_date: 2016-12-15 15:04:00 UTC, geo area: ERGA OMNES, operation: update, operation_date: 2016-12-16
7225990040: VTS validity_start_date: 2016-12-15 15:04:00 UTC - validity_end_date: no date, geo area: ERGA OMNES, operation: update, operation_date: 2016-12-16
7225990040: VTS validity_start_date: 2017-01-01 00:00:00 UTC - validity_end_date: no date, geo area: ERGA OMNES, operation: update, operation_date: 2017-01-02
7225990040: VTS validity_start_date: 2017-04-01 00:00:00 UTC - validity_end_date: no date, geo area: ERGA OMNES, operation: update, operation_date: 2017-04-02
```

IN LOCAL DB:
```7225990040: VTS validity_start_date: 2016-12-15 11:42:00 UTC - validity_end_date: 2016-12-15 15:04:00 UTC, geo area: ERGA OMNES, operation: update, operation_date: 2016-12-16
7225990040: VTS validity_start_date: 2016-12-15 15:04:00 UTC - validity_end_date: no date, geo area: ERGA OMNES, operation: update, operation_date: 2016-12-16
7225990040: VTS validity_start_date: 2017-01-01 00:00:00 UTC - validity_end_date: no date, geo area: ERGA OMNES, operation: update, operation_date: 2017-01-02
7225990040: VTS validity_start_date: 2017-04-01 00:00:00 UTC - validity_end_date: no date, geo area: ERGA OMNES, operation: update, operation_date: 2017-04-02
```

IN CHIEF UPDATE FILES we have related actions:

create at *2016-12-16_KBT009(16351).txt*:
`103: "MFCM","15/12/2016:15:04:00","U","VT","S","B00",null,null,null,"15/12/2016:15:02:00","72259900 40","N","N","N"`
`104: "MFCM","15/12/2016:11:42:00","I","VT","S","B00",null,"15/12/2016:15:04:00",null,"15/12/2016:11:40:00","72259900 40","N","N","N"`

update at *2017-01-02_KBT009(17002).txt*:
`52237: "MFCM","01/01/2017:00:00:00","U","VT","S","B00",null,null,null,"21/12/2016:08:11:00","72259900 40","N","N","N"`

update at *2017-04-02_KBT009(17092).txt*:
`18128: "MFCM","01/04/2017:00:00:00","U","VT","S","B00",null,null,null,"28/03/2017:08:00:00","72259900 40","N","N","N"`

*Summary:* There are no any VTS measure in DB with validity_end_date in future for `7225990040` ,
that's why we no longer see it at https://www.trade-tariff.service.gov.uk/trade-tariff/commodities/7225990040#import
as validity_end_date expired at `28/03/2017:08:00:00`

[TRELLO CARD](https://trello.com/c/sGTRQBh4/457-tariff17-vat-is-missing-from-some-commodity-codes)