### PR TITLE
[COMMODITY] Fix for issue with wrong detection of 'children' in tree

### DIFF
--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -83,37 +83,27 @@ class Commodity < GoodsNomenclature
   end
 
   def children
-    next_sibling = heading.commodities_dataset
-      .join(:goods_nomenclature_indents, goods_nomenclature_sid: :goods_nomenclature_sid)
-      .where("goods_nomenclature_indents.number_indents = ?", goods_nomenclature_indent.number_indents)
-      .where("goods_nomenclatures.goods_nomenclature_sid != ?", goods_nomenclature_sid)
-      .where("goods_nomenclatures.goods_nomenclature_item_id > ?", goods_nomenclature_item_id)
-      .where("goods_nomenclature_indents.validity_start_date <= ? AND (goods_nomenclature_indents.validity_end_date >= ? OR goods_nomenclature_indents.validity_end_date IS NULL)", point_in_time, point_in_time)
-      .order(:goods_nomenclatures__goods_nomenclature_item_id)
-      .first
+    func = Proc.new {
+      GoodsNomenclatureMapper.new(
+        heading.commodities_dataset.
+                eager(:goods_nomenclature_indents, :goods_nomenclature_descriptions).
+                all
+      ).all.
+        detect do |item|
+        item.goods_nomenclature_sid == goods_nomenclature_sid
+      end.try(:children) || []
+    }
 
-    if next_sibling.present?
-      heading.commodities_dataset
-             .join(:goods_nomenclature_indents, goods_nomenclature_sid: :goods_nomenclature_sid)
-             .where("goods_nomenclature_indents.number_indents > ?", goods_nomenclature_indent.number_indents)
-             .where("goods_nomenclatures.goods_nomenclature_sid != ?", goods_nomenclature_sid)
-             .where("goods_nomenclatures.producline_suffix >= ?", producline_suffix)
-             .where("goods_nomenclature_indents.validity_start_date <= ? AND (goods_nomenclature_indents.validity_end_date >= ? OR goods_nomenclature_indents.validity_end_date IS NULL)", point_in_time, point_in_time)
-             .where("goods_nomenclatures.goods_nomenclature_item_id >= ? AND goods_nomenclatures.goods_nomenclature_item_id < ?", goods_nomenclature_item_id, next_sibling.goods_nomenclature_item_id)
-             .order(nil)
-             .all
+    if Rails.env.test? || Rails.env.development?
+      # Do not cache it in Test and Development environments.
+      #
+      func.call
     else
-      # commodity is last in the list, check if there are any commodities
-      # under it
-
-      heading.commodities_dataset
-             .join(:goods_nomenclature_indents, goods_nomenclature_sid: :goods_nomenclature_sid)
-             .where("goods_nomenclature_indents.number_indents >= ?", goods_nomenclature_indent.number_indents + 1)
-             .where("goods_nomenclatures.goods_nomenclature_sid != ?", goods_nomenclature_sid)
-             .where("goods_nomenclature_indents.validity_start_date <= ? AND (goods_nomenclature_indents.validity_end_date >= ? OR goods_nomenclature_indents.validity_end_date IS NULL)", point_in_time, point_in_time)
-             .where("goods_nomenclatures.goods_nomenclature_item_id >= ?", goods_nomenclature_item_id)
-             .order(nil)
-             .all
+      # Cache for 3 hours
+      #
+      Rails.cache.fetch("commodity_#{goods_nomenclature_sid}_children", expires_in: 3.hours) do
+        func.call
+      end
     end
   end
 


### PR DESCRIPTION
*ORIGINAL ISSUE DESCRIPTION:*

Original issue was caused on '8536501100'.
Issue was in 'next_sibling' detection.
First fix attempt was done in [PR#194](https://github.com/bitzesty/trade-tariff-backend/pull/194)
But, unfortunatelly this fix caused issue on 'children' detection for other commodities.
So that we had to revert this fix in [PR#226](https://github.com/bitzesty/trade-tariff-backend/pull/226)

*WHAT'S WE DONE IN THIS PR:*

Instead of trying to make complex SQL for Commodity#children method we are going by another way.
I noted that we already have good commodity tree discover class GoodsNomenclatureMapper.

We made benchmark on production of how fast would it take to use GoodsNomenclatureMapper
for fetching 'children' tree for defined Commodity and here are results:

```
Benchmark.measure { GoodsNomenclatureMapper.new(heading.commodities_dataset.eager(:goods_nomenclature_indents, :goods_nomenclature_descriptions).all).all }
=> 0.610000   0.160000   0.770000 (  1.833092)
```

So, average value is `1.5` seconds, which is not much more than previously used complex SQL did.
Another good point of using this way is that we will have children fetching code in one place `GoodsNomenclatureMapper`.

[TRELLO STORY](https://trello.com/c/VOrEAwts/441-tariff17-duplicate-commodity-codes-in-search-box-and-non-declarable-commodity-clickable-searchable)