### PR TITLE
[MISSING VTS MEASURE] data migration for '7225 9900 40'

### DIFF
--- a/db/data_migrations/20180116140502_add_missing_vat_measures.rb
+++ b/db/data_migrations/20180116140502_add_missing_vat_measures.rb
@@ -1,195 +1,55 @@
 TradeTariffBackend::DataMigrator.migration do
   name 'Add missing VAT measures'
 
-  MISSING_VAT_MEASURES = [
-    [ "2007993903", "VT Z", "01.10.2014" ],
-    [ "3907100090", "VT S", "01.07.2016" ],
-    [ "7214200010", "VT S", "01.01.2016" ],
-    [ "7225401220", "VT S", "01.02.2017" ],
-    [ "7225401295", "VT S", "01.01.2017" ],
-    [ "7225401520", "VT S", "01.02.2017" ],
-    [ "7225401595", "VT S", "01.02.2017" ],
-    [ "7226200020", "VT S", "01.02.2017" ],
-    [ "7226200095", "VT S", "01.02.2017" ],
-    [ "7228302010", "VT S", "01.01.2016" ],
-    [ "7228302090", "VT S", "01.01.2016" ],
-    [ "7228304110", "VT S", "01.01.2016" ],
-    [ "7228304190", "VT S", "01.01.2016" ],
-    [ "7228304910", "VT S", "01.01.2016" ],
-    [ "7228304990", "VT S", "01.01.2016" ],
-    [ "7228306110", "VT S", "01.01.2016" ],
-    [ "7228306190", "VT S", "01.01.2016" ],
-    [ "7228306910", "VT S", "01.01.2016" ],
-    [ "7228306990", "VT S", "01.01.2016" ],
-    [ "7228307010", "VT S", "01.01.2016" ],
-    [ "7228307090", "VT S", "01.01.2016" ],
-    [ "7228308910", "VT S", "01.01.2016" ],
-    [ "7228308990", "VT S", "01.01.2016" ]
-  ]
+  def missing_vat_measures
+    [
+      [ "2007993903", "VT Z", "01.10.2014" ],
+      [ "3907100090", "VT S", "01.07.2016" ],
+      [ "7214200010", "VT S", "01.01.2016" ],
+      [ "7225401220", "VT S", "01.02.2017" ],
+      [ "7225401295", "VT S", "01.01.2017" ],
+      [ "7225401520", "VT S", "01.02.2017" ],
+      [ "7225401595", "VT S", "01.02.2017" ],
+      [ "7226200020", "VT S", "01.02.2017" ],
+      [ "7226200095", "VT S", "01.02.2017" ],
+      [ "7228302010", "VT S", "01.01.2016" ],
+      [ "7228302090", "VT S", "01.01.2016" ],
+      [ "7228304110", "VT S", "01.01.2016" ],
+      [ "7228304190", "VT S", "01.01.2016" ],
+      [ "7228304910", "VT S", "01.01.2016" ],
+      [ "7228304990", "VT S", "01.01.2016" ],
+      [ "7228306110", "VT S", "01.01.2016" ],
+      [ "7228306190", "VT S", "01.01.2016" ],
+      [ "7228306910", "VT S", "01.01.2016" ],
+      [ "7228306990", "VT S", "01.01.2016" ],
+      [ "7228307010", "VT S", "01.01.2016" ],
+      [ "7228307090", "VT S", "01.01.2016" ],
+      [ "7228308910", "VT S", "01.01.2016" ],
+      [ "7228308990", "VT S", "01.01.2016" ]
+    ]
+  end
 
   up do
     applicable {
-      MISSING_VAT_MEASURES.any? do |measure_candidate_ops|
-        find_measure_by(measure_candidate_ops).blank?
-      end
+      helper_klass.up_applicable?(missing_vat_measures)
     }
 
     apply {
-      #
-      # Examples of 'MFCM' records in /data/chief/*.txt:
-      #
-      # "MFCM","01/07/2012:00:00:00","I","VT","S","B00",null,null,null,"21/06/2012:09:01:00","38123080 65","N","N","N"
-      #
-      # "MFCM","01/07/2012:00:00:00","I","VT","Z","B00",null,null,null,"21/06/2012:09:01:00","03054410 00","Y","N","N"
-      #
-      # "MFCM","01/01/2018:00:00:00","I","VT","Z","B00",null,null,null,"21/12/2017:08:31:00","03021180 90","Y","N","N"
-      #
-      # Adding of measures will be modifying primary key (fe_tsmp - aka validity_start_date)
-      # so unrestricting it for Chief::Mfcm.
-      #
-      Chief::Mfcm.unrestrict_primary_key
-
-      added_list = []
-      skipped_list = []
-      candidate_measures = []
-
-      MISSING_VAT_MEASURES.map do |measure_candidate_ops|
-        existing_record = find_measure_by(measure_candidate_ops)
-
-        if existing_record.present?
-          debug_it("[#{measure_candidate_ops}] measure already in system! Skipping...")
-
-          skipped_list << measure_candidate_ops[0]
-        else
-          debug_it("[#{measure_candidate_ops}] measure is missing! Adding...")
-
-          mfcm = Chief::Mfcm.new(
-            mfcm_ops(measure_candidate_ops)
-          )
-
-          candidate_measures << ChiefTransformer::CandidateMeasure.new(
-            mfcm: mfcm,
-            tame: mfcm.tame,
-            operation: :create,
-            operation_date: Date.today
-          )
-
-          added_list << measure_candidate_ops[0]
-        end
-      end
-
-      if candidate_measures.present?
-        candidates = ChiefTransformer::CandidateMeasure::Collection.new(candidate_measures)
-        debug_it("#{candidate_measures.count} candidate measures detected!")
-
-        candidates.validate
-        debug_it("#{candidate_measures.count} candidate measures passed validation!")
-
-        candidates.persist
-        debug_it("#{candidate_measures.count} candidate measures persisted!")
-
-        debug_it("Script completed!")
-
-        added_list.map do |item|
-          debug_it("  https://www.trade-tariff.service.gov.uk/trade-tariff/commodities/#{clean_up_whitespaces(item)}")
-        end
-
-        debug_it("  - skipped (#{skipped_list.size}): #{skipped_list.join(', ')}")
-      else
-        debug_it("No any measure candidates found!")
-      end
-
-      #
-      # Restricting it for Chief::Mfcm back.
-      #
-      Chief::Mfcm.restrict_primary_key
+      helper_klass.up_apply(missing_vat_measures)
     }
   end
 
   down do
     applicable {
-      MISSING_VAT_MEASURES.any? do |measure_candidate_ops|
-        find_measure_by(measure_candidate_ops).present?
-      end
+      helper_klass.down_applicable?(missing_vat_measures)
     }
 
     apply {
-      deleted_list = []
-
-      MISSING_VAT_MEASURES.map do |measure_candidate_ops|
-        existing_record = find_measure_by(measure_candidate_ops)
-
-        if existing_record.present?
-          debug_it("[#{measure_candidate_ops}] measure detected! Removing...")
-
-          existing_record.destroy
-          deleted_list << measure_candidate_ops[0]
-        else
-          debug_it("[#{measure_candidate_ops}] measure is missing! Skipping...")
-        end
-      end
-
-      debug_it("Script completed!")
-      debug_it("  - deleted_list (#{deleted_list.size}): #{deleted_list.join(', ')}")
+      helper_klass.down_apply(missing_vat_measures)
     }
   end
 
-  def mfcm_ops(measure_candidate_ops)
-    commodity_code = measure_candidate_ops[0]
-    msrgp_code, msr_type = measure_candidate_ops[1].split(" ")
-    validity_start_date = measure_candidate_ops[2].to_datetime
-
-    ops = {
-      fe_tsmp: validity_start_date,
-      amend_indicator: "I",
-      msrgp_code: msrgp_code,
-      msr_type: msr_type,
-      tty_code: "B00",
-      tar_msr_no: nil,
-      le_tsmp: nil,
-      audit_tsmp: nil,
-      cmdty_code: commodity_code,
-      cmdty_msr_xhdg: (msr_type == "Z" ? "Y" : "N"),
-      null_tri_rqd: "N",
-      exports_use_ind: "N"
-    }
-
-    debug_it("[#{commodity_code} - '#{msrgp_code}#{msr_type}'] options: #{ops.inspect}")
-
-    #
-    # Other options will be assigned by default:
-    #
-    #   geographical_area_id: "1011" # "ERGA OMNES"
-    #   generating_regulation_code: "I9999/YY 31/12/1971 1971-12-31"
-    #   measure_generating_regulation_id: "IYY99990"
-    #   generating_regulation_code: "I9999/YY"
-    #
-    # and footnotes:
-    #
-    #   VTS: "03020 UK VAT standard rate"
-    #
-    #   VTZ: "03026 UK VAT zero rate"
-    #
-
-    ops
-  end
-
-  def find_measure_by(measure_candidate_ops)
-    Measure.find(
-      goods_nomenclature_item_id: measure_candidate_ops[0],
-      measure_type_id: clean_up_whitespaces(measure_candidate_ops[1])
-    )
-  end
-
-  def clean_up_whitespaces(v)
-    v.gsub(" ", "")
-  end
-
-  def debug_it(message)
-    puts ""
-    puts "-" * 100
-    puts " #{message}"
-    puts "-" * 100
-    puts ""
+  def helper_klass
+    ::TradeTariffBackend::DataMigration::Helpers::VatMeasures::ManualAddition
   end
 end

--- a/db/data_migrations/20180130085145_add_missing_vts_to_commodity.rb
+++ b/db/data_migrations/20180130085145_add_missing_vts_to_commodity.rb
@@ -1,0 +1,40 @@
+TradeTariffBackend::DataMigrator.migration do
+  name "Add missing VTS measure for commodity '7225 9900 40'"
+
+  def apply_at
+    TariffSynchronizer::BaseUpdate.latest_applied_of_both_kinds
+                                  .first
+                                  .applied_at
+                                  .strftime("%d.%m.%Y")
+  end
+
+  def missing_vat_measures
+    [
+      [ "7225990040", "VT S", apply_at ]
+    ]
+  end
+
+  up do
+    applicable {
+      helper_klass.up_applicable?(missing_vat_measures)
+    }
+
+    apply {
+      helper_klass.up_apply(missing_vat_measures)
+    }
+  end
+
+  down do
+    applicable {
+      helper_klass.down_applicable?(missing_vat_measures)
+    }
+
+    apply {
+      helper_klass.down_apply(missing_vat_measures)
+    }
+  end
+
+  def helper_klass
+    ::TradeTariffBackend::DataMigration::Helpers::VatMeasures::ManualAddition
+  end
+end

--- a/lib/trade_tariff_backend/data_migration/helpers/vat_measures/manual_addition.rb
+++ b/lib/trade_tariff_backend/data_migration/helpers/vat_measures/manual_addition.rb
@@ -1,0 +1,174 @@
+module TradeTariffBackend
+  class DataMigration
+    module Helpers
+      module VatMeasures
+        class ManualAddition
+          class << self
+            def down_apply(list)
+              deleted_list = []
+
+              list.map do |measure_candidate_ops|
+                existing_record = find_measure_by(measure_candidate_ops)
+
+                if existing_record.present?
+                  debug_it("[#{measure_candidate_ops}] measure detected! Removing...")
+
+                  existing_record.destroy
+                  deleted_list << measure_candidate_ops[0]
+                else
+                  debug_it("[#{measure_candidate_ops}] measure is missing! Skipping...")
+                end
+              end
+
+              debug_it("Script completed!")
+              debug_it("  - deleted_list (#{deleted_list.size}): #{deleted_list.join(', ')}")
+            end
+
+            def up_applicable?(list)
+              list.any? do |measure_candidate_ops|
+                find_measure_by(measure_candidate_ops).blank?
+              end
+            end
+
+            def down_applicable?(list)
+              list.any? do |measure_candidate_ops|
+                find_measure_by(measure_candidate_ops).present?
+              end
+            end
+
+            def mfcm_ops(measure_candidate_ops)
+              commodity_code = measure_candidate_ops[0]
+              msrgp_code, msr_type = measure_candidate_ops[1].split(" ")
+              validity_start_date = measure_candidate_ops[2].to_datetime
+
+              ops = {
+                fe_tsmp: validity_start_date,
+                amend_indicator: "I",
+                msrgp_code: msrgp_code,
+                msr_type: msr_type,
+                tty_code: "B00",
+                tar_msr_no: nil,
+                le_tsmp: nil,
+                audit_tsmp: nil,
+                cmdty_code: commodity_code,
+                cmdty_msr_xhdg: (msr_type == "Z" ? "Y" : "N"),
+                null_tri_rqd: "N",
+                exports_use_ind: "N"
+              }
+
+              debug_it("[#{commodity_code} - '#{msrgp_code}#{msr_type}'] options: #{ops.inspect}")
+
+              #
+              # Other options will be assigned by default:
+              #
+              #   geographical_area_id: "1011" # "ERGA OMNES"
+              #   generating_regulation_code: "I9999/YY 31/12/1971 1971-12-31"
+              #   measure_generating_regulation_id: "IYY99990"
+              #   generating_regulation_code: "I9999/YY"
+              #
+              # and footnotes:
+              #
+              #   VTS: "03020 UK VAT standard rate"
+              #
+              #   VTZ: "03026 UK VAT zero rate"
+              #
+
+              ops
+            end
+
+            def find_measure_by(measure_candidate_ops)
+              Measure.find(
+                goods_nomenclature_item_id: measure_candidate_ops[0],
+                measure_type_id: clean_up_whitespaces(measure_candidate_ops[1]),
+                operation: "C"
+              )
+            end
+
+            def clean_up_whitespaces(v)
+              v.gsub(" ", "")
+            end
+
+            def debug_it(message)
+              puts ""
+              puts "-" * 100
+              puts " #{message}"
+              puts "-" * 100
+              puts ""
+            end
+
+            def up_apply(list)
+              #
+              # Examples of 'MFCM' records in /data/chief/*.txt:
+              #
+              # "MFCM","01/07/2012:00:00:00","I","VT","S","B00",null,null,null,"21/06/2012:09:01:00","38123080 65","N","N","N"
+              #
+              # "MFCM","01/07/2012:00:00:00","I","VT","Z","B00",null,null,null,"21/06/2012:09:01:00","03054410 00","Y","N","N"
+              #
+              # "MFCM","01/01/2018:00:00:00","I","VT","Z","B00",null,null,null,"21/12/2017:08:31:00","03021180 90","Y","N","N"
+              #
+              # Adding of measures will be modifying primary key (fe_tsmp - aka validity_start_date)
+              # so unrestricting it for Chief::Mfcm.
+              #
+              Chief::Mfcm.unrestrict_primary_key
+
+              added_list = []
+              skipped_list = []
+              candidate_measures = []
+
+              list.map do |measure_candidate_ops|
+                existing_record = find_measure_by(measure_candidate_ops)
+
+                if existing_record.present?
+                  debug_it("[#{measure_candidate_ops}] measure already in system! Skipping...")
+
+                  skipped_list << measure_candidate_ops[0]
+                else
+                  debug_it("[#{measure_candidate_ops}] measure is missing! Adding...")
+
+                  mfcm = Chief::Mfcm.new(
+                    mfcm_ops(measure_candidate_ops)
+                  )
+
+                  candidate_measures << ChiefTransformer::CandidateMeasure.new(
+                    mfcm: mfcm,
+                    tame: mfcm.tame,
+                    operation: :create,
+                    operation_date: Date.today
+                  )
+
+                  added_list << measure_candidate_ops[0]
+                end
+              end
+
+              if candidate_measures.present?
+                candidates = ChiefTransformer::CandidateMeasure::Collection.new(candidate_measures)
+                debug_it("#{candidate_measures.count} candidate measures detected!")
+
+                candidates.validate
+                debug_it("#{candidate_measures.count} candidate measures passed validation!")
+
+                candidates.persist
+                debug_it("#{candidate_measures.count} candidate measures persisted!")
+
+                debug_it("Script completed!")
+
+                added_list.map do |item|
+                  debug_it("  https://www.trade-tariff.service.gov.uk/trade-tariff/commodities/#{clean_up_whitespaces(item)}")
+                end
+
+                debug_it("  - skipped (#{skipped_list.size}): #{skipped_list.join(', ')}")
+              else
+                debug_it("No any measure candidates found!")
+              end
+
+              #
+              # Restricting it for Chief::Mfcm back.
+              #
+              Chief::Mfcm.restrict_primary_key
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://www.trade-tariff.service.gov.uk/trade-tariff/commodities/7225990040#import

    IN LIVE DB:
    ```7225990040: VTS validity_start_date: 2016-12-15 11:42:00 UTC - validity_end_date: 2016-12-15 15:04:00 UTC, geo area: ERGA OMNES, operation: update, operation_date: 2016-12-16
    7225990040: VTS validity_start_date: 2016-12-15 15:04:00 UTC - validity_end_date: no date, geo area: ERGA OMNES, operation: update, operation_date: 2016-12-16
    7225990040: VTS validity_start_date: 2017-01-01 00:00:00 UTC - validity_end_date: no date, geo area: ERGA OMNES, operation: update, operation_date: 2017-01-02
    7225990040: VTS validity_start_date: 2017-04-01 00:00:00 UTC - validity_end_date: no date, geo area: ERGA OMNES, operation: update, operation_date: 2017-04-02
    ```

    IN LOCAL DB:
    ```7225990040: VTS validity_start_date: 2016-12-15 11:42:00 UTC - validity_end_date: 2016-12-15 15:04:00 UTC, geo area: ERGA OMNES, operation: update, operation_date: 2016-12-16
    7225990040: VTS validity_start_date: 2016-12-15 15:04:00 UTC - validity_end_date: no date, geo area: ERGA OMNES, operation: update, operation_date: 2016-12-16
    7225990040: VTS validity_start_date: 2017-01-01 00:00:00 UTC - validity_end_date: no date, geo area: ERGA OMNES, operation: update, operation_date: 2017-01-02
    7225990040: VTS validity_start_date: 2017-04-01 00:00:00 UTC - validity_end_date: no date, geo area: ERGA OMNES, operation: update, operation_date: 2017-04-02
    ```

    IN CHIEF UPDATE FILES we have related actions:

    create at *2016-12-16_KBT009(16351).txt*:
    `103: "MFCM","15/12/2016:15:04:00","U","VT","S","B00",null,null,null,"15/12/2016:15:02:00","72259900 40","N","N","N"`
    `104: "MFCM","15/12/2016:11:42:00","I","VT","S","B00",null,"15/12/2016:15:04:00",null,"15/12/2016:11:40:00","72259900 40","N","N","N"`

    update at *2017-01-02_KBT009(17002).txt*:
    `52237: "MFCM","01/01/2017:00:00:00","U","VT","S","B00",null,null,null,"21/12/2016:08:11:00","72259900 40","N","N","N"`

    update at *2017-04-02_KBT009(17092).txt*:
    `18128: "MFCM","01/04/2017:00:00:00","U","VT","S","B00",null,null,null,"28/03/2017:08:00:00","72259900 40","N","N","N"`

    *Summary:* There are no any VTS measure in DB with validity_end_date in future for `7225990040` ,
    that's why we no longer see it at https://www.trade-tariff.service.gov.uk/trade-tariff/commodities/7225990040#import
    as validity_end_date expired at `28/03/2017:08:00:00`

    [TRELLO STORY](https://trello.com/c/sGTRQBh4/457-tariff17-vat-is-missing-from-some-commodity-codes)