### PR TITLE
Use loose ruby version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
-ruby "2.5.0"
+ruby "~> 2.5.0"
 
 gem "rails", "5.1.3"
 


### PR DESCRIPTION
Use loose ruby version [TRELLO CARD](https://trello.com/c/VBBidWSL/485-tariff17-use-loose-ruby-versions-in-our-gemfiles-for-all-apps)