### PR TITLE
Association ECO footnotes to the headings and commodities

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -8,5 +8,5 @@ ignore:
         expires: '2017-06-21T12:12:22.642Z'
     - '* > nokogiri@1.8.2':
         reason: None given
-        expires: '2018-03-14T12:12:22.642Z'
+        expires: '2018-04-14T12:12:22.642Z'
 patch: {}

--- a/app/models/footnote_association_goods_nomenclature.rb
+++ b/app/models/footnote_association_goods_nomenclature.rb
@@ -6,6 +6,18 @@ class FootnoteAssociationGoodsNomenclature < Sequel::Model
   plugin :conformance_validator
 
   set_primary_key [:footnote_id, :footnote_type, :goods_nomenclature_sid]
+
+  def self.associate_footnote_with_goods_nomenclature(goods_nomenclature, footnote)
+    f = FootnoteAssociationGoodsNomenclature.new
+    f.values[:goods_nomenclature_sid] = goods_nomenclature.values[:goods_nomenclature_sid]
+    f.values[:goods_nomenclature_item_id] = goods_nomenclature.values[:goods_nomenclature_item_id]
+    f.values[:productline_suffix] = goods_nomenclature.values[:producline_suffix]
+    f.values[:validity_start_date] = goods_nomenclature.values[:validity_start_date]
+    f.values[:validity_end_date] = goods_nomenclature.values[:validity_end_date]
+    f.values[:operation] = goods_nomenclature.values[:operation]
+    f.values[:footnote_id] = footnote.values[:footnote_id]
+    f.values[:footnote_type] = footnote.values[:footnote_type_id]
+    f.values[:national] = footnote.values[:national]
+    f.save
+  end
 end
-
-

--- a/app/views/api/v1/commodities/show.json.rabl
+++ b/app/views/api/v1/commodities/show.json.rabl
@@ -5,6 +5,13 @@ attributes :producline_suffix, :description, :number_indents,
            :goods_nomenclature_item_id, :bti_url, :formatted_description,
            :description_plain, :consigned, :consigned_from, :basic_duty_rate
 
+  footnotes = (@commodity.footnotes + @commodity.heading.footnotes).uniq
+  if footnotes.any?
+    child(footnotes) {
+    attributes :code, :description, :formatted_description
+  }
+end
+
 extends "api/v1/declarables/declarable", object: @commodity, locals: { measures: @measures, geo_areas: @geographical_areas }
 
 child @commodity.heading do

--- a/app/views/api/v1/declarables/_declarable.json.rabl
+++ b/app/views/api/v1/declarables/_declarable.json.rabl
@@ -18,10 +18,6 @@ child :chapter do
   end
 end
 
-child :footnote do
-  attributes :code, :description, :formatted_description
-end
-
 node(:import_measures) { |declarable|
   locals[:measures].select(&:import).map do |import_measure|
     partial "api/v1/measures/measure", object: import_measure, locals: { declarable: declarable, geo_areas: locals[:geo_areas] }

--- a/app/views/api/v1/headings/show.json.rabl
+++ b/app/views/api/v1/headings/show.json.rabl
@@ -4,17 +4,18 @@ cache @heading_cache_key, expires_at: actual_date.end_of_day
 attributes :goods_nomenclature_item_id, :description, :bti_url,
            :formatted_description
 
-if @heading.declarable?
-  attributes :basic_duty_rate
-
-  extends "api/v1/declarables/declarable", object: @heading, locals: { measures: @measures }
-else
   footnotes = @heading.footnotes
   if footnotes.any?
     child(footnotes) {
       attributes :code, :description, :formatted_description
     }
   end
+
+if @heading.declarable?
+  attributes :basic_duty_rate
+
+  extends "api/v1/declarables/declarable", object: @heading, locals: { measures: @measures }
+else
   child :chapter do
     attributes :goods_nomenclature_item_id, :description, :formatted_description
     node(:chapter_note, if: lambda {|chapter| chapter.chapter_note.present? }) do |chapter|

--- a/app/views/api/v1/headings/show.json.rabl
+++ b/app/views/api/v1/headings/show.json.rabl
@@ -4,17 +4,17 @@ cache @heading_cache_key, expires_at: actual_date.end_of_day
 attributes :goods_nomenclature_item_id, :description, :bti_url,
            :formatted_description
 
-unless @heading.footnote.nil?
-  child(@heading.footnotes) {
-    attributes :code, :description, :formatted_description
-  }
-end
-
 if @heading.declarable?
   attributes :basic_duty_rate
 
   extends "api/v1/declarables/declarable", object: @heading, locals: { measures: @measures }
 else
+  footnotes = @heading.footnotes
+  if footnotes.any?
+    child(footnotes) {
+      attributes :code, :description, :formatted_description
+    }
+  end
   child :chapter do
     attributes :goods_nomenclature_item_id, :description, :formatted_description
     node(:chapter_note, if: lambda {|chapter| chapter.chapter_note.present? }) do |chapter|

--- a/app/views/api/v1/headings/show.json.rabl
+++ b/app/views/api/v1/headings/show.json.rabl
@@ -5,10 +5,10 @@ attributes :goods_nomenclature_item_id, :description, :bti_url,
            :formatted_description
 
 unless @heading.footnote.nil?
-  child :footnote do
+  child(@heading.footnotes) {
     attributes :code, :description, :formatted_description
-  end           
-end  
+  }
+end
 
 if @heading.declarable?
   attributes :basic_duty_rate

--- a/db/data_migrations/20180323145947_add_footnote_to_headings_and_commodities.rb
+++ b/db/data_migrations/20180323145947_add_footnote_to_headings_and_commodities.rb
@@ -1,9 +1,13 @@
-Sequel.migration do
-  # Assign footnote_id/footnote_type_id to list of heading ids and their comodities. Id is 10 digits.
-  # Seperate heading ids with spaces.
-  # ex: rake tariff:assign_footnote_id_to_headings['002','05','8702000000 8705000000']
+TradeTariffBackend::DataMigrator.migration do
+  name 'Assign footnote_id/footnote_type_id 002 05 ECO to list of heading ids and their comodities'
 
   up do
+    applicable {
+      # The apply block is idempotent
+      true
+    }
+    apply {
+      
     # Eco footnote
     footnote = Footnote.where(footnote_id: '002', footnote_type_id: '05').first
     heading_ids = ['8702000000', '8705000000', '8710000000', '8802000000', '8803000000', '8805000000', '8906000000', '9301000000', '9302000000', '9303000000', '9304000000', '9305000000', '9306000000', '9307000000']
@@ -18,5 +22,16 @@ Sequel.migration do
         puts "Associating footnote #{footnote.inspect} with Commodity #{commodity.inspect}"
       end
     end
+
+    }
+  end
+
+  down do
+    applicable {
+      false
+    }
+    apply {
+      # noop
+    }
   end
 end

--- a/db/data_migrations/20180323145947_add_footnote_to_headings_and_commodities.rb
+++ b/db/data_migrations/20180323145947_add_footnote_to_headings_and_commodities.rb
@@ -16,11 +16,6 @@ TradeTariffBackend::DataMigrator.migration do
       next if heading.footnotes.include?(footnote)
       puts "Associating footnote #{footnote.inspect} with heading #{heading.inspect}"
       FootnoteAssociationGoodsNomenclature.associate_footnote_with_goods_nomenclature(heading, footnote)
-
-      heading.commodities.each do |commodity|
-        FootnoteAssociationGoodsNomenclature.associate_footnote_with_goods_nomenclature(commodity, footnote)
-        puts "Associating footnote #{footnote.inspect} with Commodity #{commodity.inspect}"
-      end
     end
 
     }

--- a/db/migrate/20180323145947_add_footnote_to_headings_and_commodities.rb
+++ b/db/migrate/20180323145947_add_footnote_to_headings_and_commodities.rb
@@ -1,0 +1,22 @@
+Sequel.migration do
+  # Assign footnote_id/footnote_type_id to list of heading ids and their comodities. Id is 10 digits.
+  # Seperate heading ids with spaces.
+  # ex: rake tariff:assign_footnote_id_to_headings['002','05','8702000000 8705000000']
+
+  up do
+    # Eco footnote
+    footnote = Footnote.where(footnote_id: '002', footnote_type_id: '05').first
+    heading_ids = ['8702000000', '8705000000', '8710000000', '8802000000', '8803000000', '8805000000', '8906000000', '9301000000', '9302000000', '9303000000', '9304000000', '9305000000', '9306000000', '9307000000']
+
+    Heading.where(goods_nomenclatures__goods_nomenclature_item_id: heading_ids).each do |heading|
+      next if heading.footnotes.include?(footnote)
+      puts "Associating footnote #{footnote.inspect} with heading #{heading.inspect}"
+      associate_footnote_with_goods_nomenclature(heading, footnote)
+
+      heading.commodities.each do |commodity|
+        associate_footnote_with_goods_nomenclature(commodity, footnote)
+        puts "Associating footnote #{footnote.inspect} with Commodity #{commodity.inspect}"
+      end
+    end
+  end
+end

--- a/db/migrate/20180323145947_add_footnote_to_headings_and_commodities.rb
+++ b/db/migrate/20180323145947_add_footnote_to_headings_and_commodities.rb
@@ -11,10 +11,10 @@ Sequel.migration do
     Heading.where(goods_nomenclatures__goods_nomenclature_item_id: heading_ids).each do |heading|
       next if heading.footnotes.include?(footnote)
       puts "Associating footnote #{footnote.inspect} with heading #{heading.inspect}"
-      associate_footnote_with_goods_nomenclature(heading, footnote)
+      FootnoteAssociationGoodsNomenclature.associate_footnote_with_goods_nomenclature(heading, footnote)
 
       heading.commodities.each do |commodity|
-        associate_footnote_with_goods_nomenclature(commodity, footnote)
+        FootnoteAssociationGoodsNomenclature.associate_footnote_with_goods_nomenclature(commodity, footnote)
         puts "Associating footnote #{footnote.inspect} with Commodity #{commodity.inspect}"
       end
     end

--- a/lib/tasks/tariff.rake
+++ b/lib/tasks/tariff.rake
@@ -12,32 +12,6 @@ namespace :tariff do
     TradeTariffBackend.reindex
   end
 
-
-  task :assign_footnote_id_to_headings, [:footnote_id, :footnote_type_id, :heading_ids] => :environment do |t, args|
-    footnote_id = args[:footnote_id]
-    footnote_type_id = args[:footnote_type_id]
-    heading_ids = args[:heading_ids].split(' ')
-    puts "Arguments: "
-    puts "Footnote id #{footnote_id}"
-    puts "Footnote type id #{footnote_type_id}"
-    puts "Heading ids #{heading_ids.join(', ')}"
-
-    footnote = Footnote.where(footnote_id: footnote_id, footnote_type_id: footnote_type_id).first
-
-    Heading.where(goods_nomenclatures__goods_nomenclature_item_id: heading_ids).each do |heading|
-      next if heading.footnotes.include?(footnote)
-      puts "Associating footnote #{footnote.inspect} with heading #{heading.inspect}"
-      associate_footnote_with_goods_nomenclature(heading, footnote)
-
-      heading.commodities.each do |commodity|
-        associate_footnote_with_goods_nomenclature(commodity, footnote)
-        puts "Associating footnote #{footnote.inspect} with Commodity #{commodity.inspect}"
-      end
-    end
-
-    puts "SUCCESS"
-  end
-
   desc 'Add commodity footnotes for ECO licences where these is an export restriction'
   task add_missing_commodity_footnote: :environment do
     measure_type_id = MeasureType.all.detect { |mt| mt.description == 'Export authorization (Dual use)' }.values[:measure_type_id]

--- a/lib/tasks/tariff.rake
+++ b/lib/tasks/tariff.rake
@@ -64,20 +64,6 @@ namespace :tariff do
     end
   end
 
-  def associate_footnote_with_goods_nomenclature(source, footnote)
-    f = FootnoteAssociationGoodsNomenclature.new
-    f.values[:goods_nomenclature_sid] = source.values[:goods_nomenclature_sid]
-    f.values[:goods_nomenclature_item_id] = source.values[:goods_nomenclature_item_id]
-    f.values[:productline_suffix] = source.values[:producline_suffix]
-    f.values[:validity_start_date] = source.values[:validity_start_date]
-    f.values[:validity_end_date] = source.values[:validity_end_date]
-    f.values[:operation] = source.values[:operation]
-    f.values[:footnote_id] = footnote.values[:footnote_id]
-    f.values[:footnote_type] = footnote.values[:footnote_type_id]
-    f.values[:national] = footnote.values[:national]
-    f.save
-  end
-
   desc 'Download and apply Taric and CHIEF data'
   task sync: %w[environment sync:apply]
 

--- a/lib/tasks/tariff.rake
+++ b/lib/tasks/tariff.rake
@@ -12,11 +12,7 @@ namespace :tariff do
     TradeTariffBackend.reindex
   end
 
-  desc %{
-    Assign footnote_id/footnote_type_id to list of heading ids and their comodities. Id is 10 digits.
-    Seperate heading ids with spaces.
-    ex: rake tariff:assign_footnote_id_to_headings['002','05','8702000000 8705000000']
-  }
+
   task :assign_footnote_id_to_headings, [:footnote_id, :footnote_type_id, :heading_ids] => :environment do |t, args|
     footnote_id = args[:footnote_id]
     footnote_type_id = args[:footnote_type_id]
@@ -63,7 +59,7 @@ namespace :tariff do
     }
     GoodsNomenclature.fetch(sql).all.each do |c|
       if c.footnote != footnote
-        associate_footnote_with_goods_nomenclature(c, footnote)
+        FootnoteAssociationGoodsNomenclature.associate_footnote_with_goods_nomenclature(c, footnote)
       end
     end
   end
@@ -381,4 +377,3 @@ namespace :tariff do
     end
   end
 end
-


### PR DESCRIPTION
Per [Trello Card](https://trello.com/c/cpAzDs5e/2165-tariff17-update-copy-for-eco-notice) requesting some heading codes and all headings in the chapter 93 to be associated to ECO footnotes and to propagate down the tree.

@matthewford 
Initially I fell for a classic trap or trying to solve multiple issues at one time, and ended up having one thing work but bunch of others not work. So to actually finish the task in the trello card unfortunately I decided at the end to go the least preferred way as discussed on slack. Here are couple of issues I encountered :

1) API does returns just one footnote for a heading, but should be returning many
2) The front-end only renders one
3) There are existing rules around rendering a footnote, like checking if code is present and what not
4) Not a problem, but was unclear whether we 'delegate' all non declarable heading footnotes to it's child commodities or just certain ones like ECO footnote.

Once we have all these items above resolved, I can easily un-associate the commodities we've associated the footnotes to, and do it the right way and just leave the footnotes at heading level. 

Also I made the task bit more generic as this is not the first time we're updating the footnotes.

This is how I ran the rake task including all the headings from the trello card and the ones from chapter 93 :

```
bundle exec rake tariff:assign_footnote_id_to_headings['002','05','8702000000 8705000000 8710000000 8802000000 8803000000 8805000000 8906000000 9301000000 9302000000 9303000000 9304000000 9305000000 9306000000 9307000000']
```

**Per conversation with Matt on slack**

- [x] Convert rake task to db migration
- [x] Api to return more than one footnote
Before :
<img width="946" alt="screen shot 2018-03-23 at 5 10 00 pm" src="https://user-images.githubusercontent.com/36192669/37853641-f07f456a-2ebd-11e8-8dbe-6309462c1cb7.png">
After:
<img width="883" alt="screen shot 2018-03-23 at 5 11 35 pm" src="https://user-images.githubusercontent.com/36192669/37853649-f44f5540-2ebd-11e8-8073-c7cf2d0bcffd.png">

And for commodity too:

<img width="1022" alt="screen shot 2018-03-23 at 6 32 48 pm" src="https://user-images.githubusercontent.com/36192669/37856050-ad7fedfe-2ec8-11e8-9012-f2e9ce9b9179.png">


- [x] Front end to render more than one
https://github.com/bitzesty/trade-tariff-frontend/pull/190
- [x] Propagate heading footnotes to commodity level

Now when we save footnotes at heading level it will propagate over to the commodity level. OR we can save one at commodity level. In fact we can put both commodity at both levels and the only one of the two level will show up. We can also have some footnotes on commodity and some on heading. The ones on the heading would propagate down to commodity

- [x] Modify migration to add footnotes only to heading level

Making the original request without having to set footnote at the individual commodity level but rather at heading level will work now too