### PR TITLE
Format duty expressions in GBP

### DIFF
--- a/app/formatters/duty_expression_formatter.rb
+++ b/app/formatters/duty_expression_formatter.rb
@@ -25,6 +25,7 @@ class DutyExpressionFormatter
         if monetary_unit == "EUR" && duty_amount.present?
           period = MonetaryExchangePeriod.actual.last(parent_monetary_unit_code: "EUR")
           gbp = MonetaryExchangeRate.last(monetary_exchange_period_sid: period.monetary_exchange_period_sid, child_monetary_unit_code: "GBP")
+          eur_duty_amount = duty_amount
           duty_amount = (gbp.exchange_rate * duty_amount.to_d).to_f
           monetary_unit = "GBP"
         end
@@ -51,7 +52,11 @@ class DutyExpressionFormatter
           output << duty_expression_description
         end
         if duty_amount.present?
-          output << prettify(duty_amount).to_s
+          if opts[:formatted]
+            output << "<span title='#{eur_duty_amount} EUR'>#{prettify(duty_amount).to_s}</span>"
+          else
+            output << prettify(duty_amount).to_s
+          end
         end
         if monetary_unit.present?
           output << monetary_unit
@@ -67,7 +72,11 @@ class DutyExpressionFormatter
         end
       else
         if duty_amount.present?
-          output << prettify(duty_amount).to_s
+          if opts[:formatted]
+            output << "<span title='#{eur_duty_amount} EUR'>#{prettify(duty_amount).to_s}</span>"
+          else
+            output << prettify(duty_amount).to_s
+          end
         end
         if duty_expression_abbreviation.present? && !monetary_unit.present?
           output << duty_expression_abbreviation

--- a/app/formatters/duty_expression_formatter.rb
+++ b/app/formatters/duty_expression_formatter.rb
@@ -20,6 +20,16 @@ class DutyExpressionFormatter
       measurement_unit_abbreviation = measurement_unit.try :abbreviation,
                                                            measurement_unit_qualifier: measurement_unit_qualifier
 
+
+      if opts[:convert_currency].present?
+        if monetary_unit == "EUR" && duty_amount.present?
+          period = MonetaryExchangePeriod.actual.last(parent_monetary_unit_code: "EUR")
+          gbp = MonetaryExchangeRate.last(monetary_exchange_period_sid: period.monetary_exchange_period_sid, child_monetary_unit_code: "GBP")
+          duty_amount = (gbp.exchange_rate * duty_amount.to_d).to_f
+          monetary_unit = "GBP"
+        end
+      end
+
       output = []
       case duty_expression_id
       when "99"

--- a/app/formatters/requirement_duty_expression_formatter.rb
+++ b/app/formatters/requirement_duty_expression_formatter.rb
@@ -15,6 +15,16 @@ class RequirementDutyExpressionFormatter
       measurement_unit = opts[:measurement_unit]
       measurement_unit_qualifier = opts[:formatted_measurement_unit_qualifier]
 
+      if opts[:convert_currency].present?
+        if monetary_unit == "EUR" && duty_amount.present?
+          period = MonetaryExchangePeriod.actual.last(parent_monetary_unit_code: "EUR")
+          gbp = MonetaryExchangeRate.last(monetary_exchange_period_sid: period.monetary_exchange_period_sid, child_monetary_unit_code: "GBP")
+          eur_duty_amount = duty_amount
+          duty_amount = (gbp.exchange_rate * duty_amount.to_d).to_f
+          monetary_unit = "GBP"
+        end
+      end
+
       output = []
 
       if duty_amount.present?

--- a/app/models/measure_component.rb
+++ b/app/models/measure_component.rb
@@ -56,6 +56,8 @@ class MeasureComponent < Sequel::Model
       monetary_unit: monetary_unit_code,
       monetary_unit_abbreviation: monetary_unit_abbreviation,
       measurement_unit: measurement_unit,
-      measurement_unit_qualifier: measurement_unit_qualifier }
+      measurement_unit_qualifier: measurement_unit_qualifier,
+      convert_currency: TradeTariffBackend.gbp?
+     }
   end
 end

--- a/app/models/measure_condition.rb
+++ b/app/models/measure_condition.rb
@@ -86,7 +86,7 @@ class MeasureCondition < Sequel::Model
       monetary_unit_abbreviation: monetary_unit_abbreviation,
       measurement_unit: measurement_unit_description,
       formatted_measurement_unit_qualifier: formatted_measurement_unit_qualifier
-    })
+    }) 
   end
 
   def action

--- a/app/models/measure_condition.rb
+++ b/app/models/measure_condition.rb
@@ -85,8 +85,9 @@ class MeasureCondition < Sequel::Model
       monetary_unit: condition_monetary_unit_code,
       monetary_unit_abbreviation: monetary_unit_abbreviation,
       measurement_unit: measurement_unit_description,
-      formatted_measurement_unit_qualifier: formatted_measurement_unit_qualifier
-    }) 
+      formatted_measurement_unit_qualifier: formatted_measurement_unit_qualifier,
+      convert_currency: TradeTariffBackend.gbp?
+    })
   end
 
   def action

--- a/app/models/monetary_exchange_period.rb
+++ b/app/models/monetary_exchange_period.rb
@@ -1,9 +1,8 @@
 class MonetaryExchangePeriod < Sequel::Model
+  plugin :time_machine
   plugin :oplog, primary_key: [:monetary_exchange_period_sid,
                                :parent_monetary_unit_code]
   plugin :conformance_validator
 
   set_primary_key  [:monetary_exchange_period_sid, :parent_monetary_unit_code]
 end
-
-

--- a/app/models/monetary_unit.rb
+++ b/app/models/monetary_unit.rb
@@ -1,6 +1,6 @@
 class MonetaryUnit < Sequel::Model
-  plugin :oplog, primary_key: :monetary_unit_code
   plugin :time_machine
+  plugin :oplog, primary_key: :monetary_unit_code
   plugin :conformance_validator
 
   set_primary_key [:monetary_unit_code]
@@ -14,5 +14,3 @@ class MonetaryUnit < Sequel::Model
     monetary_unit_code
   end
 end
-
-

--- a/lib/trade_tariff_backend.rb
+++ b/lib/trade_tariff_backend.rb
@@ -51,6 +51,10 @@ module TradeTariffBackend
       ENV["GOVUK_APP_DOMAIN"] == "tariff-backend-production.cloudapps.digital"
     end
 
+    def gbp?
+      ENV["CURRENCY"] == "GBP"
+    end
+
     def data_migration_path
       File.join(Rails.root, 'db', 'data_migrations')
     end


### PR DESCRIPTION
Display the duty expression amount and currency in GBP.

![screen shot 2018-03-29 at 16 11 39](https://user-images.githubusercontent.com/215/38096921-f9d0e47c-336b-11e8-836c-e903639a370e.png)

**VS**

![screen shot 2018-03-29 at 16 11 46](https://user-images.githubusercontent.com/215/38096930-fd1aeb50-336b-11e8-81d2-e83b63adcf26.png)

Uses the currency exchange period for that month from TARIC3

https://tariff-frontend-dev.cloudapps.digital/trade-tariff/commodities/1902110020?day=28&month=3&year=2018#import