### PR TITLE
Unable access commodity

### DIFF
--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -94,7 +94,6 @@ class Commodity < GoodsNomenclature
       end.try(:children) || []
     }
 
-
     if Rails.env.test? || Rails.env.development?
       # Do not cache it in Test and Development environments.
       #

--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -94,6 +94,7 @@ class Commodity < GoodsNomenclature
       end.try(:children) || []
     }
 
+
     if Rails.env.test? || Rails.env.development?
       # Do not cache it in Test and Development environments.
       #
@@ -101,7 +102,8 @@ class Commodity < GoodsNomenclature
     else
       # Cache for 3 hours
       #
-      Rails.cache.fetch("commodity_#{goods_nomenclature_sid}_children", expires_in: 3.hours) do
+      time_machine_key = Thread.current[:time_machine_now].strftime("%Y-%m-%d")
+      Rails.cache.fetch("commodity_#{goods_nomenclature_sid}_#{time_machine_key}_children", expires_in: 3.hours) do
         func.call
       end
     end


### PR DESCRIPTION
Added a time machine parameter to a cache key that was generating issues fetching data from the backend. Note that the "as_of" query string parameter is only accesible in controller code. So being this cache query in a model, the time machine date had to be fetch from Thread.current.