### PR TITLE
[DB] Fixed Footnote related database tables issue with wrong column char limit

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -359,7 +359,6 @@ DEPENDENCIES
   simplecov (~> 0.14.1)
   simplecov-rcov!
   sinatra (~> 2.0.2)
-  sprockets (~> 3.7.2)
   tilt
   webmock (~> 3.0.1)
   yajl-ruby (~> 1.3.1)

--- a/db/migrate/20180724155759_fix_footnote_id_characters_limit_in_associations.rb
+++ b/db/migrate/20180724155759_fix_footnote_id_characters_limit_in_associations.rb
@@ -1,0 +1,126 @@
+Sequel.migration do
+  change do
+    #
+    # Footnote, FootnoteDescription, FootnoteDescriptionPeriod
+    # in current db having:
+    #
+    #   footnote_id character varying(5)
+    #
+    # but in FootnoteAssociationMeasure
+    #
+    #   footnote_id character varying(3)
+    #
+    # This is wrong and break saving of FootnoteAssociationMeasure
+    # if footnote_id is longer than 3 symbols
+    #
+    # This migration fixes this issue.
+
+    tables_to_change = [
+      :footnote_association_measures_oplog,
+      :footnote_association_additional_codes_oplog,
+      :footnote_association_erns_oplog,
+      :footnote_association_goods_nomenclatures_oplog,
+      :footnote_association_meursing_headings_oplog
+    ]
+
+    tables_to_change.map do |view_name|
+      run "DROP VIEW public.#{view_name.to_s.gsub('_oplog', '')};"
+    end
+
+    tables_to_change.map do |table_name|
+      alter_table table_name do
+        set_column_type :footnote_id, String, size: 5
+      end
+    end
+
+    run %Q{
+      CREATE VIEW public.footnote_association_measures AS
+       SELECT footnote_association_measures1.measure_sid,
+          footnote_association_measures1.footnote_type_id,
+          footnote_association_measures1.footnote_id,
+          footnote_association_measures1."national",
+          footnote_association_measures1.oid,
+          footnote_association_measures1.operation,
+          footnote_association_measures1.operation_date
+         FROM public.footnote_association_measures_oplog footnote_association_measures1
+        WHERE ((footnote_association_measures1.oid IN ( SELECT max(footnote_association_measures2.oid) AS max
+                 FROM public.footnote_association_measures_oplog footnote_association_measures2
+                WHERE ((footnote_association_measures1.measure_sid = footnote_association_measures2.measure_sid) AND ((footnote_association_measures1.footnote_id)::text = (footnote_association_measures2.footnote_id)::text) AND ((footnote_association_measures1.footnote_type_id)::text = (footnote_association_measures2.footnote_type_id)::text)))) AND ((footnote_association_measures1.operation)::text <> 'D'::text));
+    }
+
+    run %Q{
+      CREATE VIEW public.footnote_association_additional_codes AS
+       SELECT footnote_association_additional_codes1.additional_code_sid,
+          footnote_association_additional_codes1.footnote_type_id,
+          footnote_association_additional_codes1.footnote_id,
+          footnote_association_additional_codes1.validity_start_date,
+          footnote_association_additional_codes1.validity_end_date,
+          footnote_association_additional_codes1.additional_code_type_id,
+          footnote_association_additional_codes1.additional_code,
+          footnote_association_additional_codes1.oid,
+          footnote_association_additional_codes1.operation,
+          footnote_association_additional_codes1.operation_date
+         FROM public.footnote_association_additional_codes_oplog footnote_association_additional_codes1
+        WHERE ((footnote_association_additional_codes1.oid IN ( SELECT max(footnote_association_additional_codes2.oid) AS max
+                 FROM public.footnote_association_additional_codes_oplog footnote_association_additional_codes2
+                WHERE (((footnote_association_additional_codes1.footnote_id)::text = (footnote_association_additional_codes2.footnote_id)::text) AND ((footnote_association_additional_codes1.footnote_type_id)::text = (footnote_association_additional_codes2.footnote_type_id)::text) AND (footnote_association_additional_codes1.additional_code_sid = footnote_association_additional_codes2.additional_code_sid)))) AND ((footnote_association_additional_codes1.operation)::text <> 'D'::text));
+    }
+
+    run %Q{
+      CREATE VIEW public.footnote_association_erns AS
+       SELECT footnote_association_erns1.export_refund_nomenclature_sid,
+          footnote_association_erns1.footnote_type,
+          footnote_association_erns1.footnote_id,
+          footnote_association_erns1.validity_start_date,
+          footnote_association_erns1.validity_end_date,
+          footnote_association_erns1.goods_nomenclature_item_id,
+          footnote_association_erns1.additional_code_type,
+          footnote_association_erns1.export_refund_code,
+          footnote_association_erns1.productline_suffix,
+          footnote_association_erns1.oid,
+          footnote_association_erns1.operation,
+          footnote_association_erns1.operation_date
+         FROM public.footnote_association_erns_oplog footnote_association_erns1
+        WHERE ((footnote_association_erns1.oid IN ( SELECT max(footnote_association_erns2.oid) AS max
+                 FROM public.footnote_association_erns_oplog footnote_association_erns2
+                WHERE ((footnote_association_erns1.export_refund_nomenclature_sid = footnote_association_erns2.export_refund_nomenclature_sid) AND ((footnote_association_erns1.footnote_id)::text = (footnote_association_erns2.footnote_id)::text) AND ((footnote_association_erns1.footnote_type)::text = (footnote_association_erns2.footnote_type)::text) AND (footnote_association_erns1.validity_start_date = footnote_association_erns2.validity_start_date)))) AND ((footnote_association_erns1.operation)::text <> 'D'::text));
+    }
+
+    run %Q{
+      CREATE VIEW public.footnote_association_goods_nomenclatures AS
+       SELECT footnote_association_goods_nomenclatures1.goods_nomenclature_sid,
+          footnote_association_goods_nomenclatures1.footnote_type,
+          footnote_association_goods_nomenclatures1.footnote_id,
+          footnote_association_goods_nomenclatures1.validity_start_date,
+          footnote_association_goods_nomenclatures1.validity_end_date,
+          footnote_association_goods_nomenclatures1.goods_nomenclature_item_id,
+          footnote_association_goods_nomenclatures1.productline_suffix,
+          footnote_association_goods_nomenclatures1."national",
+          footnote_association_goods_nomenclatures1.oid,
+          footnote_association_goods_nomenclatures1.operation,
+          footnote_association_goods_nomenclatures1.operation_date
+         FROM public.footnote_association_goods_nomenclatures_oplog footnote_association_goods_nomenclatures1
+        WHERE ((footnote_association_goods_nomenclatures1.oid IN ( SELECT max(footnote_association_goods_nomenclatures2.oid) AS max
+                 FROM public.footnote_association_goods_nomenclatures_oplog footnote_association_goods_nomenclatures2
+                WHERE (((footnote_association_goods_nomenclatures1.footnote_id)::text = (footnote_association_goods_nomenclatures2.footnote_id)::text) AND ((footnote_association_goods_nomenclatures1.footnote_type)::text = (footnote_association_goods_nomenclatures2.footnote_type)::text) AND (footnote_association_goods_nomenclatures1.goods_nomenclature_sid = footnote_association_goods_nomenclatures2.goods_nomenclature_sid)))) AND ((footnote_association_goods_nomenclatures1.operation)::text <> 'D'::text));
+    }
+
+    run %Q{
+      CREATE VIEW public.footnote_association_meursing_headings AS
+       SELECT footnote_association_meursing_headings1.meursing_table_plan_id,
+          footnote_association_meursing_headings1.meursing_heading_number,
+          footnote_association_meursing_headings1.row_column_code,
+          footnote_association_meursing_headings1.footnote_type,
+          footnote_association_meursing_headings1.footnote_id,
+          footnote_association_meursing_headings1.validity_start_date,
+          footnote_association_meursing_headings1.validity_end_date,
+          footnote_association_meursing_headings1.oid,
+          footnote_association_meursing_headings1.operation,
+          footnote_association_meursing_headings1.operation_date
+         FROM public.footnote_association_meursing_headings_oplog footnote_association_meursing_headings1
+        WHERE ((footnote_association_meursing_headings1.oid IN ( SELECT max(footnote_association_meursing_headings2.oid) AS max
+                 FROM public.footnote_association_meursing_headings_oplog footnote_association_meursing_headings2
+                WHERE (((footnote_association_meursing_headings1.footnote_id)::text = (footnote_association_meursing_headings2.footnote_id)::text) AND ((footnote_association_meursing_headings1.meursing_table_plan_id)::text = (footnote_association_meursing_headings2.meursing_table_plan_id)::text)))) AND ((footnote_association_meursing_headings1.operation)::text <> 'D'::text));
+    }
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,14 +2,15 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.6.1
--- Dumped by pg_dump version 9.6.1
+-- Dumped from database version 9.6.9
+-- Dumped by pg_dump version 9.6.9
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
 SET client_min_messages = warning;
 SET row_security = off;
@@ -28,7 +29,48 @@ CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
 COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
 
 
-SET search_path = public, pg_catalog;
+--
+-- Name: uuid-ossp; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp" WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION "uuid-ossp"; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON EXTENSION "uuid-ossp" IS 'generate universally unique identifiers (UUIDs)';
+
+
+--
+-- Name: reassign_owned(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.reassign_owned() RETURNS event_trigger
+    LANGUAGE plpgsql
+    AS $$
+	begin
+		-- do not execute if member of rds_superuser
+		IF EXISTS (select 1 from pg_catalog.pg_roles where rolname = 'rds_superuser')
+		AND pg_has_role(current_user, 'rds_superuser', 'member') THEN
+			RETURN;
+		END IF;
+
+		-- do not execute if not member of manager role
+		IF NOT pg_has_role(current_user, 'rdsbroker_266a9334_2e5d_4234_b2bf_5f5ebf7d973d_manager', 'member') THEN
+			RETURN;
+		END IF;
+
+		-- do not execute if superuser
+		IF EXISTS (SELECT 1 FROM pg_user WHERE usename = current_user and usesuper = true) THEN
+			RETURN;
+		END IF;
+
+		EXECUTE 'reassign owned by "' || current_user || '" to "rdsbroker_266a9334_2e5d_4234_b2bf_5f5ebf7d973d_manager"';
+	end
+	$$;
+
 
 SET default_tablespace = '';
 
@@ -38,7 +80,7 @@ SET default_with_oids = false;
 -- Name: additional_code_description_periods_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE additional_code_description_periods_oplog (
+CREATE TABLE public.additional_code_description_periods_oplog (
     additional_code_description_period_sid integer,
     additional_code_sid integer,
     additional_code_type_id character varying(1),
@@ -56,7 +98,7 @@ CREATE TABLE additional_code_description_periods_oplog (
 -- Name: additional_code_description_periods; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW additional_code_description_periods AS
+CREATE VIEW public.additional_code_description_periods AS
  SELECT additional_code_description_periods1.additional_code_description_period_sid,
     additional_code_description_periods1.additional_code_sid,
     additional_code_description_periods1.additional_code_type_id,
@@ -66,9 +108,9 @@ CREATE VIEW additional_code_description_periods AS
     additional_code_description_periods1.oid,
     additional_code_description_periods1.operation,
     additional_code_description_periods1.operation_date
-   FROM additional_code_description_periods_oplog additional_code_description_periods1
+   FROM public.additional_code_description_periods_oplog additional_code_description_periods1
   WHERE ((additional_code_description_periods1.oid IN ( SELECT max(additional_code_description_periods2.oid) AS max
-           FROM additional_code_description_periods_oplog additional_code_description_periods2
+           FROM public.additional_code_description_periods_oplog additional_code_description_periods2
           WHERE ((additional_code_description_periods1.additional_code_description_period_sid = additional_code_description_periods2.additional_code_description_period_sid) AND (additional_code_description_periods1.additional_code_sid = additional_code_description_periods2.additional_code_sid) AND ((additional_code_description_periods1.additional_code_type_id)::text = (additional_code_description_periods2.additional_code_type_id)::text)))) AND ((additional_code_description_periods1.operation)::text <> 'D'::text));
 
 
@@ -76,7 +118,7 @@ CREATE VIEW additional_code_description_periods AS
 -- Name: additional_code_description_periods_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE additional_code_description_periods_oid_seq
+CREATE SEQUENCE public.additional_code_description_periods_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -88,14 +130,14 @@ CREATE SEQUENCE additional_code_description_periods_oid_seq
 -- Name: additional_code_description_periods_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE additional_code_description_periods_oid_seq OWNED BY additional_code_description_periods_oplog.oid;
+ALTER SEQUENCE public.additional_code_description_periods_oid_seq OWNED BY public.additional_code_description_periods_oplog.oid;
 
 
 --
 -- Name: additional_code_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE additional_code_descriptions_oplog (
+CREATE TABLE public.additional_code_descriptions_oplog (
     additional_code_description_period_sid integer,
     language_id character varying(5),
     additional_code_sid integer,
@@ -114,7 +156,7 @@ CREATE TABLE additional_code_descriptions_oplog (
 -- Name: additional_code_descriptions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW additional_code_descriptions AS
+CREATE VIEW public.additional_code_descriptions AS
  SELECT additional_code_descriptions1.additional_code_description_period_sid,
     additional_code_descriptions1.language_id,
     additional_code_descriptions1.additional_code_sid,
@@ -125,9 +167,9 @@ CREATE VIEW additional_code_descriptions AS
     additional_code_descriptions1.oid,
     additional_code_descriptions1.operation,
     additional_code_descriptions1.operation_date
-   FROM additional_code_descriptions_oplog additional_code_descriptions1
+   FROM public.additional_code_descriptions_oplog additional_code_descriptions1
   WHERE ((additional_code_descriptions1.oid IN ( SELECT max(additional_code_descriptions2.oid) AS max
-           FROM additional_code_descriptions_oplog additional_code_descriptions2
+           FROM public.additional_code_descriptions_oplog additional_code_descriptions2
           WHERE ((additional_code_descriptions1.additional_code_description_period_sid = additional_code_descriptions2.additional_code_description_period_sid) AND (additional_code_descriptions1.additional_code_sid = additional_code_descriptions2.additional_code_sid)))) AND ((additional_code_descriptions1.operation)::text <> 'D'::text));
 
 
@@ -135,7 +177,7 @@ CREATE VIEW additional_code_descriptions AS
 -- Name: additional_code_descriptions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE additional_code_descriptions_oid_seq
+CREATE SEQUENCE public.additional_code_descriptions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -147,14 +189,14 @@ CREATE SEQUENCE additional_code_descriptions_oid_seq
 -- Name: additional_code_descriptions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE additional_code_descriptions_oid_seq OWNED BY additional_code_descriptions_oplog.oid;
+ALTER SEQUENCE public.additional_code_descriptions_oid_seq OWNED BY public.additional_code_descriptions_oplog.oid;
 
 
 --
 -- Name: additional_code_type_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE additional_code_type_descriptions_oplog (
+CREATE TABLE public.additional_code_type_descriptions_oplog (
     additional_code_type_id character varying(1),
     language_id character varying(5),
     description text,
@@ -170,7 +212,7 @@ CREATE TABLE additional_code_type_descriptions_oplog (
 -- Name: additional_code_type_descriptions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW additional_code_type_descriptions AS
+CREATE VIEW public.additional_code_type_descriptions AS
  SELECT additional_code_type_descriptions1.additional_code_type_id,
     additional_code_type_descriptions1.language_id,
     additional_code_type_descriptions1.description,
@@ -178,9 +220,9 @@ CREATE VIEW additional_code_type_descriptions AS
     additional_code_type_descriptions1.oid,
     additional_code_type_descriptions1.operation,
     additional_code_type_descriptions1.operation_date
-   FROM additional_code_type_descriptions_oplog additional_code_type_descriptions1
+   FROM public.additional_code_type_descriptions_oplog additional_code_type_descriptions1
   WHERE ((additional_code_type_descriptions1.oid IN ( SELECT max(additional_code_type_descriptions2.oid) AS max
-           FROM additional_code_type_descriptions_oplog additional_code_type_descriptions2
+           FROM public.additional_code_type_descriptions_oplog additional_code_type_descriptions2
           WHERE ((additional_code_type_descriptions1.additional_code_type_id)::text = (additional_code_type_descriptions2.additional_code_type_id)::text))) AND ((additional_code_type_descriptions1.operation)::text <> 'D'::text));
 
 
@@ -188,7 +230,7 @@ CREATE VIEW additional_code_type_descriptions AS
 -- Name: additional_code_type_descriptions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE additional_code_type_descriptions_oid_seq
+CREATE SEQUENCE public.additional_code_type_descriptions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -200,14 +242,14 @@ CREATE SEQUENCE additional_code_type_descriptions_oid_seq
 -- Name: additional_code_type_descriptions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE additional_code_type_descriptions_oid_seq OWNED BY additional_code_type_descriptions_oplog.oid;
+ALTER SEQUENCE public.additional_code_type_descriptions_oid_seq OWNED BY public.additional_code_type_descriptions_oplog.oid;
 
 
 --
 -- Name: additional_code_type_measure_types_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE additional_code_type_measure_types_oplog (
+CREATE TABLE public.additional_code_type_measure_types_oplog (
     measure_type_id character varying(3),
     additional_code_type_id character varying(1),
     validity_start_date timestamp without time zone,
@@ -224,7 +266,7 @@ CREATE TABLE additional_code_type_measure_types_oplog (
 -- Name: additional_code_type_measure_types; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW additional_code_type_measure_types AS
+CREATE VIEW public.additional_code_type_measure_types AS
  SELECT additional_code_type_measure_types1.measure_type_id,
     additional_code_type_measure_types1.additional_code_type_id,
     additional_code_type_measure_types1.validity_start_date,
@@ -233,9 +275,9 @@ CREATE VIEW additional_code_type_measure_types AS
     additional_code_type_measure_types1.oid,
     additional_code_type_measure_types1.operation,
     additional_code_type_measure_types1.operation_date
-   FROM additional_code_type_measure_types_oplog additional_code_type_measure_types1
+   FROM public.additional_code_type_measure_types_oplog additional_code_type_measure_types1
   WHERE ((additional_code_type_measure_types1.oid IN ( SELECT max(additional_code_type_measure_types2.oid) AS max
-           FROM additional_code_type_measure_types_oplog additional_code_type_measure_types2
+           FROM public.additional_code_type_measure_types_oplog additional_code_type_measure_types2
           WHERE (((additional_code_type_measure_types1.measure_type_id)::text = (additional_code_type_measure_types2.measure_type_id)::text) AND ((additional_code_type_measure_types1.additional_code_type_id)::text = (additional_code_type_measure_types2.additional_code_type_id)::text)))) AND ((additional_code_type_measure_types1.operation)::text <> 'D'::text));
 
 
@@ -243,7 +285,7 @@ CREATE VIEW additional_code_type_measure_types AS
 -- Name: additional_code_type_measure_types_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE additional_code_type_measure_types_oid_seq
+CREATE SEQUENCE public.additional_code_type_measure_types_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -255,14 +297,14 @@ CREATE SEQUENCE additional_code_type_measure_types_oid_seq
 -- Name: additional_code_type_measure_types_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE additional_code_type_measure_types_oid_seq OWNED BY additional_code_type_measure_types_oplog.oid;
+ALTER SEQUENCE public.additional_code_type_measure_types_oid_seq OWNED BY public.additional_code_type_measure_types_oplog.oid;
 
 
 --
 -- Name: additional_code_types_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE additional_code_types_oplog (
+CREATE TABLE public.additional_code_types_oplog (
     additional_code_type_id character varying(1),
     validity_start_date timestamp without time zone,
     validity_end_date timestamp without time zone,
@@ -280,7 +322,7 @@ CREATE TABLE additional_code_types_oplog (
 -- Name: additional_code_types; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW additional_code_types AS
+CREATE VIEW public.additional_code_types AS
  SELECT additional_code_types1.additional_code_type_id,
     additional_code_types1.validity_start_date,
     additional_code_types1.validity_end_date,
@@ -290,9 +332,9 @@ CREATE VIEW additional_code_types AS
     additional_code_types1.oid,
     additional_code_types1.operation,
     additional_code_types1.operation_date
-   FROM additional_code_types_oplog additional_code_types1
+   FROM public.additional_code_types_oplog additional_code_types1
   WHERE ((additional_code_types1.oid IN ( SELECT max(additional_code_types2.oid) AS max
-           FROM additional_code_types_oplog additional_code_types2
+           FROM public.additional_code_types_oplog additional_code_types2
           WHERE ((additional_code_types1.additional_code_type_id)::text = (additional_code_types2.additional_code_type_id)::text))) AND ((additional_code_types1.operation)::text <> 'D'::text));
 
 
@@ -300,7 +342,7 @@ CREATE VIEW additional_code_types AS
 -- Name: additional_code_types_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE additional_code_types_oid_seq
+CREATE SEQUENCE public.additional_code_types_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -312,14 +354,14 @@ CREATE SEQUENCE additional_code_types_oid_seq
 -- Name: additional_code_types_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE additional_code_types_oid_seq OWNED BY additional_code_types_oplog.oid;
+ALTER SEQUENCE public.additional_code_types_oid_seq OWNED BY public.additional_code_types_oplog.oid;
 
 
 --
 -- Name: additional_codes_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE additional_codes_oplog (
+CREATE TABLE public.additional_codes_oplog (
     additional_code_sid integer,
     additional_code_type_id character varying(1),
     additional_code character varying(3),
@@ -337,7 +379,7 @@ CREATE TABLE additional_codes_oplog (
 -- Name: additional_codes; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW additional_codes AS
+CREATE VIEW public.additional_codes AS
  SELECT additional_codes1.additional_code_sid,
     additional_codes1.additional_code_type_id,
     additional_codes1.additional_code,
@@ -347,9 +389,9 @@ CREATE VIEW additional_codes AS
     additional_codes1.oid,
     additional_codes1.operation,
     additional_codes1.operation_date
-   FROM additional_codes_oplog additional_codes1
+   FROM public.additional_codes_oplog additional_codes1
   WHERE ((additional_codes1.oid IN ( SELECT max(additional_codes2.oid) AS max
-           FROM additional_codes_oplog additional_codes2
+           FROM public.additional_codes_oplog additional_codes2
           WHERE (additional_codes1.additional_code_sid = additional_codes2.additional_code_sid))) AND ((additional_codes1.operation)::text <> 'D'::text));
 
 
@@ -357,7 +399,7 @@ CREATE VIEW additional_codes AS
 -- Name: additional_codes_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE additional_codes_oid_seq
+CREATE SEQUENCE public.additional_codes_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -369,14 +411,14 @@ CREATE SEQUENCE additional_codes_oid_seq
 -- Name: additional_codes_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE additional_codes_oid_seq OWNED BY additional_codes_oplog.oid;
+ALTER SEQUENCE public.additional_codes_oid_seq OWNED BY public.additional_codes_oplog.oid;
 
 
 --
 -- Name: audits; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE audits (
+CREATE TABLE public.audits (
     id integer NOT NULL,
     auditable_id integer NOT NULL,
     auditable_type text NOT NULL,
@@ -391,7 +433,7 @@ CREATE TABLE audits (
 -- Name: audits_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE audits_id_seq
+CREATE SEQUENCE public.audits_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -403,14 +445,14 @@ CREATE SEQUENCE audits_id_seq
 -- Name: audits_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE audits_id_seq OWNED BY audits.id;
+ALTER SEQUENCE public.audits_id_seq OWNED BY public.audits.id;
 
 
 --
 -- Name: base_regulations_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE base_regulations_oplog (
+CREATE TABLE public.base_regulations_oplog (
     base_regulation_role integer,
     base_regulation_id character varying(255),
     validity_start_date timestamp without time zone,
@@ -443,7 +485,7 @@ CREATE TABLE base_regulations_oplog (
 -- Name: base_regulations; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW base_regulations AS
+CREATE VIEW public.base_regulations AS
  SELECT base_regulations1.base_regulation_role,
     base_regulations1.base_regulation_id,
     base_regulations1.validity_start_date,
@@ -468,9 +510,9 @@ CREATE VIEW base_regulations AS
     base_regulations1.oid,
     base_regulations1.operation,
     base_regulations1.operation_date
-   FROM base_regulations_oplog base_regulations1
+   FROM public.base_regulations_oplog base_regulations1
   WHERE ((base_regulations1.oid IN ( SELECT max(base_regulations2.oid) AS max
-           FROM base_regulations_oplog base_regulations2
+           FROM public.base_regulations_oplog base_regulations2
           WHERE (((base_regulations1.base_regulation_id)::text = (base_regulations2.base_regulation_id)::text) AND (base_regulations1.base_regulation_role = base_regulations2.base_regulation_role)))) AND ((base_regulations1.operation)::text <> 'D'::text));
 
 
@@ -478,7 +520,7 @@ CREATE VIEW base_regulations AS
 -- Name: base_regulations_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE base_regulations_oid_seq
+CREATE SEQUENCE public.base_regulations_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -490,14 +532,14 @@ CREATE SEQUENCE base_regulations_oid_seq
 -- Name: base_regulations_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE base_regulations_oid_seq OWNED BY base_regulations_oplog.oid;
+ALTER SEQUENCE public.base_regulations_oid_seq OWNED BY public.base_regulations_oplog.oid;
 
 
 --
 -- Name: certificate_description_periods_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE certificate_description_periods_oplog (
+CREATE TABLE public.certificate_description_periods_oplog (
     certificate_description_period_sid integer,
     certificate_type_code character varying(1),
     certificate_code character varying(3),
@@ -515,7 +557,7 @@ CREATE TABLE certificate_description_periods_oplog (
 -- Name: certificate_description_periods; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW certificate_description_periods AS
+CREATE VIEW public.certificate_description_periods AS
  SELECT certificate_description_periods1.certificate_description_period_sid,
     certificate_description_periods1.certificate_type_code,
     certificate_description_periods1.certificate_code,
@@ -525,9 +567,9 @@ CREATE VIEW certificate_description_periods AS
     certificate_description_periods1.oid,
     certificate_description_periods1.operation,
     certificate_description_periods1.operation_date
-   FROM certificate_description_periods_oplog certificate_description_periods1
+   FROM public.certificate_description_periods_oplog certificate_description_periods1
   WHERE ((certificate_description_periods1.oid IN ( SELECT max(certificate_description_periods2.oid) AS max
-           FROM certificate_description_periods_oplog certificate_description_periods2
+           FROM public.certificate_description_periods_oplog certificate_description_periods2
           WHERE (certificate_description_periods1.certificate_description_period_sid = certificate_description_periods2.certificate_description_period_sid))) AND ((certificate_description_periods1.operation)::text <> 'D'::text));
 
 
@@ -535,7 +577,7 @@ CREATE VIEW certificate_description_periods AS
 -- Name: certificate_description_periods_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE certificate_description_periods_oid_seq
+CREATE SEQUENCE public.certificate_description_periods_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -547,14 +589,14 @@ CREATE SEQUENCE certificate_description_periods_oid_seq
 -- Name: certificate_description_periods_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE certificate_description_periods_oid_seq OWNED BY certificate_description_periods_oplog.oid;
+ALTER SEQUENCE public.certificate_description_periods_oid_seq OWNED BY public.certificate_description_periods_oplog.oid;
 
 
 --
 -- Name: certificate_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE certificate_descriptions_oplog (
+CREATE TABLE public.certificate_descriptions_oplog (
     certificate_description_period_sid integer,
     language_id character varying(5),
     certificate_type_code character varying(1),
@@ -572,7 +614,7 @@ CREATE TABLE certificate_descriptions_oplog (
 -- Name: certificate_descriptions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW certificate_descriptions AS
+CREATE VIEW public.certificate_descriptions AS
  SELECT certificate_descriptions1.certificate_description_period_sid,
     certificate_descriptions1.language_id,
     certificate_descriptions1.certificate_type_code,
@@ -582,9 +624,9 @@ CREATE VIEW certificate_descriptions AS
     certificate_descriptions1.oid,
     certificate_descriptions1.operation,
     certificate_descriptions1.operation_date
-   FROM certificate_descriptions_oplog certificate_descriptions1
+   FROM public.certificate_descriptions_oplog certificate_descriptions1
   WHERE ((certificate_descriptions1.oid IN ( SELECT max(certificate_descriptions2.oid) AS max
-           FROM certificate_descriptions_oplog certificate_descriptions2
+           FROM public.certificate_descriptions_oplog certificate_descriptions2
           WHERE (certificate_descriptions1.certificate_description_period_sid = certificate_descriptions2.certificate_description_period_sid))) AND ((certificate_descriptions1.operation)::text <> 'D'::text));
 
 
@@ -592,7 +634,7 @@ CREATE VIEW certificate_descriptions AS
 -- Name: certificate_descriptions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE certificate_descriptions_oid_seq
+CREATE SEQUENCE public.certificate_descriptions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -604,14 +646,14 @@ CREATE SEQUENCE certificate_descriptions_oid_seq
 -- Name: certificate_descriptions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE certificate_descriptions_oid_seq OWNED BY certificate_descriptions_oplog.oid;
+ALTER SEQUENCE public.certificate_descriptions_oid_seq OWNED BY public.certificate_descriptions_oplog.oid;
 
 
 --
 -- Name: certificate_type_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE certificate_type_descriptions_oplog (
+CREATE TABLE public.certificate_type_descriptions_oplog (
     certificate_type_code character varying(1),
     language_id character varying(5),
     description text,
@@ -627,7 +669,7 @@ CREATE TABLE certificate_type_descriptions_oplog (
 -- Name: certificate_type_descriptions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW certificate_type_descriptions AS
+CREATE VIEW public.certificate_type_descriptions AS
  SELECT certificate_type_descriptions1.certificate_type_code,
     certificate_type_descriptions1.language_id,
     certificate_type_descriptions1.description,
@@ -635,9 +677,9 @@ CREATE VIEW certificate_type_descriptions AS
     certificate_type_descriptions1.oid,
     certificate_type_descriptions1.operation,
     certificate_type_descriptions1.operation_date
-   FROM certificate_type_descriptions_oplog certificate_type_descriptions1
+   FROM public.certificate_type_descriptions_oplog certificate_type_descriptions1
   WHERE ((certificate_type_descriptions1.oid IN ( SELECT max(certificate_type_descriptions2.oid) AS max
-           FROM certificate_type_descriptions_oplog certificate_type_descriptions2
+           FROM public.certificate_type_descriptions_oplog certificate_type_descriptions2
           WHERE ((certificate_type_descriptions1.certificate_type_code)::text = (certificate_type_descriptions2.certificate_type_code)::text))) AND ((certificate_type_descriptions1.operation)::text <> 'D'::text));
 
 
@@ -645,7 +687,7 @@ CREATE VIEW certificate_type_descriptions AS
 -- Name: certificate_type_descriptions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE certificate_type_descriptions_oid_seq
+CREATE SEQUENCE public.certificate_type_descriptions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -657,14 +699,14 @@ CREATE SEQUENCE certificate_type_descriptions_oid_seq
 -- Name: certificate_type_descriptions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE certificate_type_descriptions_oid_seq OWNED BY certificate_type_descriptions_oplog.oid;
+ALTER SEQUENCE public.certificate_type_descriptions_oid_seq OWNED BY public.certificate_type_descriptions_oplog.oid;
 
 
 --
 -- Name: certificate_types_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE certificate_types_oplog (
+CREATE TABLE public.certificate_types_oplog (
     certificate_type_code character varying(1),
     validity_start_date timestamp without time zone,
     validity_end_date timestamp without time zone,
@@ -680,7 +722,7 @@ CREATE TABLE certificate_types_oplog (
 -- Name: certificate_types; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW certificate_types AS
+CREATE VIEW public.certificate_types AS
  SELECT certificate_types1.certificate_type_code,
     certificate_types1.validity_start_date,
     certificate_types1.validity_end_date,
@@ -688,9 +730,9 @@ CREATE VIEW certificate_types AS
     certificate_types1.oid,
     certificate_types1.operation,
     certificate_types1.operation_date
-   FROM certificate_types_oplog certificate_types1
+   FROM public.certificate_types_oplog certificate_types1
   WHERE ((certificate_types1.oid IN ( SELECT max(certificate_types2.oid) AS max
-           FROM certificate_types_oplog certificate_types2
+           FROM public.certificate_types_oplog certificate_types2
           WHERE ((certificate_types1.certificate_type_code)::text = (certificate_types2.certificate_type_code)::text))) AND ((certificate_types1.operation)::text <> 'D'::text));
 
 
@@ -698,7 +740,7 @@ CREATE VIEW certificate_types AS
 -- Name: certificate_types_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE certificate_types_oid_seq
+CREATE SEQUENCE public.certificate_types_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -710,14 +752,14 @@ CREATE SEQUENCE certificate_types_oid_seq
 -- Name: certificate_types_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE certificate_types_oid_seq OWNED BY certificate_types_oplog.oid;
+ALTER SEQUENCE public.certificate_types_oid_seq OWNED BY public.certificate_types_oplog.oid;
 
 
 --
 -- Name: certificates_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE certificates_oplog (
+CREATE TABLE public.certificates_oplog (
     certificate_type_code character varying(1),
     certificate_code character varying(3),
     validity_start_date timestamp without time zone,
@@ -735,7 +777,7 @@ CREATE TABLE certificates_oplog (
 -- Name: certificates; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW certificates AS
+CREATE VIEW public.certificates AS
  SELECT certificates1.certificate_type_code,
     certificates1.certificate_code,
     certificates1.validity_start_date,
@@ -745,9 +787,9 @@ CREATE VIEW certificates AS
     certificates1.oid,
     certificates1.operation,
     certificates1.operation_date
-   FROM certificates_oplog certificates1
+   FROM public.certificates_oplog certificates1
   WHERE ((certificates1.oid IN ( SELECT max(certificates2.oid) AS max
-           FROM certificates_oplog certificates2
+           FROM public.certificates_oplog certificates2
           WHERE (((certificates1.certificate_code)::text = (certificates2.certificate_code)::text) AND ((certificates1.certificate_type_code)::text = (certificates2.certificate_type_code)::text)))) AND ((certificates1.operation)::text <> 'D'::text));
 
 
@@ -755,7 +797,7 @@ CREATE VIEW certificates AS
 -- Name: certificates_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE certificates_oid_seq
+CREATE SEQUENCE public.certificates_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -767,14 +809,14 @@ CREATE SEQUENCE certificates_oid_seq
 -- Name: certificates_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE certificates_oid_seq OWNED BY certificates_oplog.oid;
+ALTER SEQUENCE public.certificates_oid_seq OWNED BY public.certificates_oplog.oid;
 
 
 --
 -- Name: chapter_notes; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE chapter_notes (
+CREATE TABLE public.chapter_notes (
     id integer NOT NULL,
     section_id integer,
     chapter_id character varying(2),
@@ -786,7 +828,7 @@ CREATE TABLE chapter_notes (
 -- Name: chapter_notes_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE chapter_notes_id_seq
+CREATE SEQUENCE public.chapter_notes_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -798,14 +840,14 @@ CREATE SEQUENCE chapter_notes_id_seq
 -- Name: chapter_notes_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE chapter_notes_id_seq OWNED BY chapter_notes.id;
+ALTER SEQUENCE public.chapter_notes_id_seq OWNED BY public.chapter_notes.id;
 
 
 --
 -- Name: chapters_sections; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE chapters_sections (
+CREATE TABLE public.chapters_sections (
     goods_nomenclature_sid integer,
     section_id integer
 );
@@ -815,7 +857,7 @@ CREATE TABLE chapters_sections (
 -- Name: chief_comm; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE chief_comm (
+CREATE TABLE public.chief_comm (
     fe_tsmp timestamp without time zone,
     amend_indicator character varying(1),
     cmdty_code character varying(12),
@@ -863,7 +905,7 @@ CREATE TABLE chief_comm (
 -- Name: chief_country_code; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE chief_country_code (
+CREATE TABLE public.chief_country_code (
     chief_country_cd character varying(2),
     country_cd character varying(2)
 );
@@ -873,7 +915,7 @@ CREATE TABLE chief_country_code (
 -- Name: chief_country_group; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE chief_country_group (
+CREATE TABLE public.chief_country_group (
     chief_country_grp character varying(4),
     country_grp_region character varying(4),
     country_exclusions character varying(100)
@@ -884,7 +926,7 @@ CREATE TABLE chief_country_group (
 -- Name: chief_duty_expression; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE chief_duty_expression (
+CREATE TABLE public.chief_duty_expression (
     id integer NOT NULL,
     adval1_rate boolean,
     adval2_rate boolean,
@@ -905,7 +947,7 @@ CREATE TABLE chief_duty_expression (
 -- Name: chief_duty_expression_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE chief_duty_expression_id_seq
+CREATE SEQUENCE public.chief_duty_expression_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -917,14 +959,14 @@ CREATE SEQUENCE chief_duty_expression_id_seq
 -- Name: chief_duty_expression_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE chief_duty_expression_id_seq OWNED BY chief_duty_expression.id;
+ALTER SEQUENCE public.chief_duty_expression_id_seq OWNED BY public.chief_duty_expression.id;
 
 
 --
 -- Name: chief_measure_type_adco; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE chief_measure_type_adco (
+CREATE TABLE public.chief_measure_type_adco (
     measure_group_code character varying(2),
     measure_type character varying(3),
     tax_type_code character varying(11),
@@ -939,7 +981,7 @@ CREATE TABLE chief_measure_type_adco (
 -- Name: chief_measure_type_cond; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE chief_measure_type_cond (
+CREATE TABLE public.chief_measure_type_cond (
     measure_group_code character varying(2),
     measure_type character varying(3),
     cond_cd character varying(1),
@@ -954,7 +996,7 @@ CREATE TABLE chief_measure_type_cond (
 -- Name: chief_measure_type_footnote; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE chief_measure_type_footnote (
+CREATE TABLE public.chief_measure_type_footnote (
     id integer NOT NULL,
     measure_type_id character varying(3),
     footn_type_id character varying(2),
@@ -966,7 +1008,7 @@ CREATE TABLE chief_measure_type_footnote (
 -- Name: chief_measure_type_footnote_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE chief_measure_type_footnote_id_seq
+CREATE SEQUENCE public.chief_measure_type_footnote_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -978,14 +1020,14 @@ CREATE SEQUENCE chief_measure_type_footnote_id_seq
 -- Name: chief_measure_type_footnote_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE chief_measure_type_footnote_id_seq OWNED BY chief_measure_type_footnote.id;
+ALTER SEQUENCE public.chief_measure_type_footnote_id_seq OWNED BY public.chief_measure_type_footnote.id;
 
 
 --
 -- Name: chief_measurement_unit; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE chief_measurement_unit (
+CREATE TABLE public.chief_measurement_unit (
     id integer NOT NULL,
     spfc_cmpd_uoq character varying(3),
     spfc_uoq character varying(3),
@@ -998,7 +1040,7 @@ CREATE TABLE chief_measurement_unit (
 -- Name: chief_measurement_unit_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE chief_measurement_unit_id_seq
+CREATE SEQUENCE public.chief_measurement_unit_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1010,14 +1052,14 @@ CREATE SEQUENCE chief_measurement_unit_id_seq
 -- Name: chief_measurement_unit_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE chief_measurement_unit_id_seq OWNED BY chief_measurement_unit.id;
+ALTER SEQUENCE public.chief_measurement_unit_id_seq OWNED BY public.chief_measurement_unit.id;
 
 
 --
 -- Name: chief_mfcm; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE chief_mfcm (
+CREATE TABLE public.chief_mfcm (
     fe_tsmp timestamp without time zone,
     msrgp_code character varying(5),
     msr_type character varying(5),
@@ -1039,7 +1081,7 @@ CREATE TABLE chief_mfcm (
 -- Name: chief_tame; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE chief_tame (
+CREATE TABLE public.chief_tame (
     fe_tsmp timestamp without time zone,
     msrgp_code character varying(5),
     msr_type character varying(5),
@@ -1084,7 +1126,7 @@ CREATE TABLE chief_tame (
 -- Name: chief_tamf; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE chief_tamf (
+CREATE TABLE public.chief_tamf (
     fe_tsmp timestamp without time zone,
     msrgp_code character varying(5),
     msr_type character varying(5),
@@ -1122,7 +1164,7 @@ CREATE TABLE chief_tamf (
 -- Name: chief_tbl9; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE chief_tbl9 (
+CREATE TABLE public.chief_tbl9 (
     fe_tsmp timestamp without time zone,
     amend_indicator character varying(1),
     tbl_type character varying(4),
@@ -1137,7 +1179,7 @@ CREATE TABLE chief_tbl9 (
 -- Name: complete_abrogation_regulations_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE complete_abrogation_regulations_oplog (
+CREATE TABLE public.complete_abrogation_regulations_oplog (
     complete_abrogation_regulation_role integer,
     complete_abrogation_regulation_id character varying(255),
     published_date date,
@@ -1157,7 +1199,7 @@ CREATE TABLE complete_abrogation_regulations_oplog (
 -- Name: complete_abrogation_regulations; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW complete_abrogation_regulations AS
+CREATE VIEW public.complete_abrogation_regulations AS
  SELECT complete_abrogation_regulations1.complete_abrogation_regulation_role,
     complete_abrogation_regulations1.complete_abrogation_regulation_id,
     complete_abrogation_regulations1.published_date,
@@ -1169,9 +1211,9 @@ CREATE VIEW complete_abrogation_regulations AS
     complete_abrogation_regulations1.oid,
     complete_abrogation_regulations1.operation,
     complete_abrogation_regulations1.operation_date
-   FROM complete_abrogation_regulations_oplog complete_abrogation_regulations1
+   FROM public.complete_abrogation_regulations_oplog complete_abrogation_regulations1
   WHERE ((complete_abrogation_regulations1.oid IN ( SELECT max(complete_abrogation_regulations2.oid) AS max
-           FROM complete_abrogation_regulations_oplog complete_abrogation_regulations2
+           FROM public.complete_abrogation_regulations_oplog complete_abrogation_regulations2
           WHERE (((complete_abrogation_regulations1.complete_abrogation_regulation_id)::text = (complete_abrogation_regulations2.complete_abrogation_regulation_id)::text) AND (complete_abrogation_regulations1.complete_abrogation_regulation_role = complete_abrogation_regulations2.complete_abrogation_regulation_role)))) AND ((complete_abrogation_regulations1.operation)::text <> 'D'::text));
 
 
@@ -1179,7 +1221,7 @@ CREATE VIEW complete_abrogation_regulations AS
 -- Name: complete_abrogation_regulations_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE complete_abrogation_regulations_oid_seq
+CREATE SEQUENCE public.complete_abrogation_regulations_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1191,14 +1233,14 @@ CREATE SEQUENCE complete_abrogation_regulations_oid_seq
 -- Name: complete_abrogation_regulations_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE complete_abrogation_regulations_oid_seq OWNED BY complete_abrogation_regulations_oplog.oid;
+ALTER SEQUENCE public.complete_abrogation_regulations_oid_seq OWNED BY public.complete_abrogation_regulations_oplog.oid;
 
 
 --
 -- Name: data_migrations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE data_migrations (
+CREATE TABLE public.data_migrations (
     filename text NOT NULL
 );
 
@@ -1207,7 +1249,7 @@ CREATE TABLE data_migrations (
 -- Name: duty_expression_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE duty_expression_descriptions_oplog (
+CREATE TABLE public.duty_expression_descriptions_oplog (
     duty_expression_id character varying(255),
     language_id character varying(5),
     description text,
@@ -1222,16 +1264,16 @@ CREATE TABLE duty_expression_descriptions_oplog (
 -- Name: duty_expression_descriptions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW duty_expression_descriptions AS
+CREATE VIEW public.duty_expression_descriptions AS
  SELECT duty_expression_descriptions1.duty_expression_id,
     duty_expression_descriptions1.language_id,
     duty_expression_descriptions1.description,
     duty_expression_descriptions1.oid,
     duty_expression_descriptions1.operation,
     duty_expression_descriptions1.operation_date
-   FROM duty_expression_descriptions_oplog duty_expression_descriptions1
+   FROM public.duty_expression_descriptions_oplog duty_expression_descriptions1
   WHERE ((duty_expression_descriptions1.oid IN ( SELECT max(duty_expression_descriptions2.oid) AS max
-           FROM duty_expression_descriptions_oplog duty_expression_descriptions2
+           FROM public.duty_expression_descriptions_oplog duty_expression_descriptions2
           WHERE ((duty_expression_descriptions1.duty_expression_id)::text = (duty_expression_descriptions2.duty_expression_id)::text))) AND ((duty_expression_descriptions1.operation)::text <> 'D'::text));
 
 
@@ -1239,7 +1281,7 @@ CREATE VIEW duty_expression_descriptions AS
 -- Name: duty_expression_descriptions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE duty_expression_descriptions_oid_seq
+CREATE SEQUENCE public.duty_expression_descriptions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1251,14 +1293,14 @@ CREATE SEQUENCE duty_expression_descriptions_oid_seq
 -- Name: duty_expression_descriptions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE duty_expression_descriptions_oid_seq OWNED BY duty_expression_descriptions_oplog.oid;
+ALTER SEQUENCE public.duty_expression_descriptions_oid_seq OWNED BY public.duty_expression_descriptions_oplog.oid;
 
 
 --
 -- Name: duty_expressions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE duty_expressions_oplog (
+CREATE TABLE public.duty_expressions_oplog (
     duty_expression_id character varying(255),
     validity_start_date timestamp without time zone,
     validity_end_date timestamp without time zone,
@@ -1276,7 +1318,7 @@ CREATE TABLE duty_expressions_oplog (
 -- Name: duty_expressions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW duty_expressions AS
+CREATE VIEW public.duty_expressions AS
  SELECT duty_expressions1.duty_expression_id,
     duty_expressions1.validity_start_date,
     duty_expressions1.validity_end_date,
@@ -1286,9 +1328,9 @@ CREATE VIEW duty_expressions AS
     duty_expressions1.oid,
     duty_expressions1.operation,
     duty_expressions1.operation_date
-   FROM duty_expressions_oplog duty_expressions1
+   FROM public.duty_expressions_oplog duty_expressions1
   WHERE ((duty_expressions1.oid IN ( SELECT max(duty_expressions2.oid) AS max
-           FROM duty_expressions_oplog duty_expressions2
+           FROM public.duty_expressions_oplog duty_expressions2
           WHERE ((duty_expressions1.duty_expression_id)::text = (duty_expressions2.duty_expression_id)::text))) AND ((duty_expressions1.operation)::text <> 'D'::text));
 
 
@@ -1296,7 +1338,7 @@ CREATE VIEW duty_expressions AS
 -- Name: duty_expressions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE duty_expressions_oid_seq
+CREATE SEQUENCE public.duty_expressions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1308,14 +1350,14 @@ CREATE SEQUENCE duty_expressions_oid_seq
 -- Name: duty_expressions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE duty_expressions_oid_seq OWNED BY duty_expressions_oplog.oid;
+ALTER SEQUENCE public.duty_expressions_oid_seq OWNED BY public.duty_expressions_oplog.oid;
 
 
 --
 -- Name: explicit_abrogation_regulations_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE explicit_abrogation_regulations_oplog (
+CREATE TABLE public.explicit_abrogation_regulations_oplog (
     explicit_abrogation_regulation_role integer,
     explicit_abrogation_regulation_id character varying(8),
     published_date date,
@@ -1336,7 +1378,7 @@ CREATE TABLE explicit_abrogation_regulations_oplog (
 -- Name: explicit_abrogation_regulations; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW explicit_abrogation_regulations AS
+CREATE VIEW public.explicit_abrogation_regulations AS
  SELECT explicit_abrogation_regulations1.explicit_abrogation_regulation_role,
     explicit_abrogation_regulations1.explicit_abrogation_regulation_id,
     explicit_abrogation_regulations1.published_date,
@@ -1349,9 +1391,9 @@ CREATE VIEW explicit_abrogation_regulations AS
     explicit_abrogation_regulations1.oid,
     explicit_abrogation_regulations1.operation,
     explicit_abrogation_regulations1.operation_date
-   FROM explicit_abrogation_regulations_oplog explicit_abrogation_regulations1
+   FROM public.explicit_abrogation_regulations_oplog explicit_abrogation_regulations1
   WHERE ((explicit_abrogation_regulations1.oid IN ( SELECT max(explicit_abrogation_regulations2.oid) AS max
-           FROM explicit_abrogation_regulations_oplog explicit_abrogation_regulations2
+           FROM public.explicit_abrogation_regulations_oplog explicit_abrogation_regulations2
           WHERE (((explicit_abrogation_regulations1.explicit_abrogation_regulation_id)::text = (explicit_abrogation_regulations2.explicit_abrogation_regulation_id)::text) AND (explicit_abrogation_regulations1.explicit_abrogation_regulation_role = explicit_abrogation_regulations2.explicit_abrogation_regulation_role)))) AND ((explicit_abrogation_regulations1.operation)::text <> 'D'::text));
 
 
@@ -1359,7 +1401,7 @@ CREATE VIEW explicit_abrogation_regulations AS
 -- Name: explicit_abrogation_regulations_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE explicit_abrogation_regulations_oid_seq
+CREATE SEQUENCE public.explicit_abrogation_regulations_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1371,14 +1413,14 @@ CREATE SEQUENCE explicit_abrogation_regulations_oid_seq
 -- Name: explicit_abrogation_regulations_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE explicit_abrogation_regulations_oid_seq OWNED BY explicit_abrogation_regulations_oplog.oid;
+ALTER SEQUENCE public.explicit_abrogation_regulations_oid_seq OWNED BY public.explicit_abrogation_regulations_oplog.oid;
 
 
 --
 -- Name: export_refund_nomenclature_description_periods_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE export_refund_nomenclature_description_periods_oplog (
+CREATE TABLE public.export_refund_nomenclature_description_periods_oplog (
     export_refund_nomenclature_description_period_sid integer,
     export_refund_nomenclature_sid integer,
     validity_start_date timestamp without time zone,
@@ -1398,7 +1440,7 @@ CREATE TABLE export_refund_nomenclature_description_periods_oplog (
 -- Name: export_refund_nomenclature_description_periods; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW export_refund_nomenclature_description_periods AS
+CREATE VIEW public.export_refund_nomenclature_description_periods AS
  SELECT export_refund_nomenclature_description_periods1.export_refund_nomenclature_description_period_sid,
     export_refund_nomenclature_description_periods1.export_refund_nomenclature_sid,
     export_refund_nomenclature_description_periods1.validity_start_date,
@@ -1410,9 +1452,9 @@ CREATE VIEW export_refund_nomenclature_description_periods AS
     export_refund_nomenclature_description_periods1.oid,
     export_refund_nomenclature_description_periods1.operation,
     export_refund_nomenclature_description_periods1.operation_date
-   FROM export_refund_nomenclature_description_periods_oplog export_refund_nomenclature_description_periods1
+   FROM public.export_refund_nomenclature_description_periods_oplog export_refund_nomenclature_description_periods1
   WHERE ((export_refund_nomenclature_description_periods1.oid IN ( SELECT max(export_refund_nomenclature_description_periods2.oid) AS max
-           FROM export_refund_nomenclature_description_periods_oplog export_refund_nomenclature_description_periods2
+           FROM public.export_refund_nomenclature_description_periods_oplog export_refund_nomenclature_description_periods2
           WHERE ((export_refund_nomenclature_description_periods1.export_refund_nomenclature_sid = export_refund_nomenclature_description_periods2.export_refund_nomenclature_sid) AND (export_refund_nomenclature_description_periods1.export_refund_nomenclature_description_period_sid = export_refund_nomenclature_description_periods2.export_refund_nomenclature_description_period_sid)))) AND ((export_refund_nomenclature_description_periods1.operation)::text <> 'D'::text));
 
 
@@ -1420,7 +1462,7 @@ CREATE VIEW export_refund_nomenclature_description_periods AS
 -- Name: export_refund_nomenclature_description_periods_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE export_refund_nomenclature_description_periods_oid_seq
+CREATE SEQUENCE public.export_refund_nomenclature_description_periods_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1432,14 +1474,14 @@ CREATE SEQUENCE export_refund_nomenclature_description_periods_oid_seq
 -- Name: export_refund_nomenclature_description_periods_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE export_refund_nomenclature_description_periods_oid_seq OWNED BY export_refund_nomenclature_description_periods_oplog.oid;
+ALTER SEQUENCE public.export_refund_nomenclature_description_periods_oid_seq OWNED BY public.export_refund_nomenclature_description_periods_oplog.oid;
 
 
 --
 -- Name: export_refund_nomenclature_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE export_refund_nomenclature_descriptions_oplog (
+CREATE TABLE public.export_refund_nomenclature_descriptions_oplog (
     export_refund_nomenclature_description_period_sid integer,
     language_id character varying(5),
     export_refund_nomenclature_sid integer,
@@ -1459,7 +1501,7 @@ CREATE TABLE export_refund_nomenclature_descriptions_oplog (
 -- Name: export_refund_nomenclature_descriptions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW export_refund_nomenclature_descriptions AS
+CREATE VIEW public.export_refund_nomenclature_descriptions AS
  SELECT export_refund_nomenclature_descriptions1.export_refund_nomenclature_description_period_sid,
     export_refund_nomenclature_descriptions1.language_id,
     export_refund_nomenclature_descriptions1.export_refund_nomenclature_sid,
@@ -1471,9 +1513,9 @@ CREATE VIEW export_refund_nomenclature_descriptions AS
     export_refund_nomenclature_descriptions1.oid,
     export_refund_nomenclature_descriptions1.operation,
     export_refund_nomenclature_descriptions1.operation_date
-   FROM export_refund_nomenclature_descriptions_oplog export_refund_nomenclature_descriptions1
+   FROM public.export_refund_nomenclature_descriptions_oplog export_refund_nomenclature_descriptions1
   WHERE ((export_refund_nomenclature_descriptions1.oid IN ( SELECT max(export_refund_nomenclature_descriptions2.oid) AS max
-           FROM export_refund_nomenclature_descriptions_oplog export_refund_nomenclature_descriptions2
+           FROM public.export_refund_nomenclature_descriptions_oplog export_refund_nomenclature_descriptions2
           WHERE (export_refund_nomenclature_descriptions1.export_refund_nomenclature_description_period_sid = export_refund_nomenclature_descriptions2.export_refund_nomenclature_description_period_sid))) AND ((export_refund_nomenclature_descriptions1.operation)::text <> 'D'::text));
 
 
@@ -1481,7 +1523,7 @@ CREATE VIEW export_refund_nomenclature_descriptions AS
 -- Name: export_refund_nomenclature_descriptions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE export_refund_nomenclature_descriptions_oid_seq
+CREATE SEQUENCE public.export_refund_nomenclature_descriptions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1493,14 +1535,14 @@ CREATE SEQUENCE export_refund_nomenclature_descriptions_oid_seq
 -- Name: export_refund_nomenclature_descriptions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE export_refund_nomenclature_descriptions_oid_seq OWNED BY export_refund_nomenclature_descriptions_oplog.oid;
+ALTER SEQUENCE public.export_refund_nomenclature_descriptions_oid_seq OWNED BY public.export_refund_nomenclature_descriptions_oplog.oid;
 
 
 --
 -- Name: export_refund_nomenclature_indents_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE export_refund_nomenclature_indents_oplog (
+CREATE TABLE public.export_refund_nomenclature_indents_oplog (
     export_refund_nomenclature_indents_sid integer,
     export_refund_nomenclature_sid integer,
     validity_start_date timestamp without time zone,
@@ -1521,7 +1563,7 @@ CREATE TABLE export_refund_nomenclature_indents_oplog (
 -- Name: export_refund_nomenclature_indents; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW export_refund_nomenclature_indents AS
+CREATE VIEW public.export_refund_nomenclature_indents AS
  SELECT export_refund_nomenclature_indents1.export_refund_nomenclature_indents_sid,
     export_refund_nomenclature_indents1.export_refund_nomenclature_sid,
     export_refund_nomenclature_indents1.validity_start_date,
@@ -1534,9 +1576,9 @@ CREATE VIEW export_refund_nomenclature_indents AS
     export_refund_nomenclature_indents1.oid,
     export_refund_nomenclature_indents1.operation,
     export_refund_nomenclature_indents1.operation_date
-   FROM export_refund_nomenclature_indents_oplog export_refund_nomenclature_indents1
+   FROM public.export_refund_nomenclature_indents_oplog export_refund_nomenclature_indents1
   WHERE ((export_refund_nomenclature_indents1.oid IN ( SELECT max(export_refund_nomenclature_indents2.oid) AS max
-           FROM export_refund_nomenclature_indents_oplog export_refund_nomenclature_indents2
+           FROM public.export_refund_nomenclature_indents_oplog export_refund_nomenclature_indents2
           WHERE (export_refund_nomenclature_indents1.export_refund_nomenclature_indents_sid = export_refund_nomenclature_indents2.export_refund_nomenclature_indents_sid))) AND ((export_refund_nomenclature_indents1.operation)::text <> 'D'::text));
 
 
@@ -1544,7 +1586,7 @@ CREATE VIEW export_refund_nomenclature_indents AS
 -- Name: export_refund_nomenclature_indents_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE export_refund_nomenclature_indents_oid_seq
+CREATE SEQUENCE public.export_refund_nomenclature_indents_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1556,14 +1598,14 @@ CREATE SEQUENCE export_refund_nomenclature_indents_oid_seq
 -- Name: export_refund_nomenclature_indents_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE export_refund_nomenclature_indents_oid_seq OWNED BY export_refund_nomenclature_indents_oplog.oid;
+ALTER SEQUENCE public.export_refund_nomenclature_indents_oid_seq OWNED BY public.export_refund_nomenclature_indents_oplog.oid;
 
 
 --
 -- Name: export_refund_nomenclatures_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE export_refund_nomenclatures_oplog (
+CREATE TABLE public.export_refund_nomenclatures_oplog (
     export_refund_nomenclature_sid integer,
     goods_nomenclature_item_id character varying(10),
     additional_code_type character varying(1),
@@ -1583,7 +1625,7 @@ CREATE TABLE export_refund_nomenclatures_oplog (
 -- Name: export_refund_nomenclatures; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW export_refund_nomenclatures AS
+CREATE VIEW public.export_refund_nomenclatures AS
  SELECT export_refund_nomenclatures1.export_refund_nomenclature_sid,
     export_refund_nomenclatures1.goods_nomenclature_item_id,
     export_refund_nomenclatures1.additional_code_type,
@@ -1595,9 +1637,9 @@ CREATE VIEW export_refund_nomenclatures AS
     export_refund_nomenclatures1.oid,
     export_refund_nomenclatures1.operation,
     export_refund_nomenclatures1.operation_date
-   FROM export_refund_nomenclatures_oplog export_refund_nomenclatures1
+   FROM public.export_refund_nomenclatures_oplog export_refund_nomenclatures1
   WHERE ((export_refund_nomenclatures1.oid IN ( SELECT max(export_refund_nomenclatures2.oid) AS max
-           FROM export_refund_nomenclatures_oplog export_refund_nomenclatures2
+           FROM public.export_refund_nomenclatures_oplog export_refund_nomenclatures2
           WHERE (export_refund_nomenclatures1.export_refund_nomenclature_sid = export_refund_nomenclatures2.export_refund_nomenclature_sid))) AND ((export_refund_nomenclatures1.operation)::text <> 'D'::text));
 
 
@@ -1605,7 +1647,7 @@ CREATE VIEW export_refund_nomenclatures AS
 -- Name: export_refund_nomenclatures_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE export_refund_nomenclatures_oid_seq
+CREATE SEQUENCE public.export_refund_nomenclatures_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1617,17 +1659,17 @@ CREATE SEQUENCE export_refund_nomenclatures_oid_seq
 -- Name: export_refund_nomenclatures_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE export_refund_nomenclatures_oid_seq OWNED BY export_refund_nomenclatures_oplog.oid;
+ALTER SEQUENCE public.export_refund_nomenclatures_oid_seq OWNED BY public.export_refund_nomenclatures_oplog.oid;
 
 
 --
 -- Name: footnote_association_additional_codes_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE footnote_association_additional_codes_oplog (
+CREATE TABLE public.footnote_association_additional_codes_oplog (
     additional_code_sid integer,
     footnote_type_id character varying(2),
-    footnote_id character varying(3),
+    footnote_id character varying(5),
     validity_start_date timestamp without time zone,
     validity_end_date timestamp without time zone,
     additional_code_type_id text,
@@ -1643,7 +1685,7 @@ CREATE TABLE footnote_association_additional_codes_oplog (
 -- Name: footnote_association_additional_codes; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW footnote_association_additional_codes AS
+CREATE VIEW public.footnote_association_additional_codes AS
  SELECT footnote_association_additional_codes1.additional_code_sid,
     footnote_association_additional_codes1.footnote_type_id,
     footnote_association_additional_codes1.footnote_id,
@@ -1654,9 +1696,9 @@ CREATE VIEW footnote_association_additional_codes AS
     footnote_association_additional_codes1.oid,
     footnote_association_additional_codes1.operation,
     footnote_association_additional_codes1.operation_date
-   FROM footnote_association_additional_codes_oplog footnote_association_additional_codes1
+   FROM public.footnote_association_additional_codes_oplog footnote_association_additional_codes1
   WHERE ((footnote_association_additional_codes1.oid IN ( SELECT max(footnote_association_additional_codes2.oid) AS max
-           FROM footnote_association_additional_codes_oplog footnote_association_additional_codes2
+           FROM public.footnote_association_additional_codes_oplog footnote_association_additional_codes2
           WHERE (((footnote_association_additional_codes1.footnote_id)::text = (footnote_association_additional_codes2.footnote_id)::text) AND ((footnote_association_additional_codes1.footnote_type_id)::text = (footnote_association_additional_codes2.footnote_type_id)::text) AND (footnote_association_additional_codes1.additional_code_sid = footnote_association_additional_codes2.additional_code_sid)))) AND ((footnote_association_additional_codes1.operation)::text <> 'D'::text));
 
 
@@ -1664,7 +1706,7 @@ CREATE VIEW footnote_association_additional_codes AS
 -- Name: footnote_association_additional_codes_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE footnote_association_additional_codes_oid_seq
+CREATE SEQUENCE public.footnote_association_additional_codes_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1676,17 +1718,17 @@ CREATE SEQUENCE footnote_association_additional_codes_oid_seq
 -- Name: footnote_association_additional_codes_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE footnote_association_additional_codes_oid_seq OWNED BY footnote_association_additional_codes_oplog.oid;
+ALTER SEQUENCE public.footnote_association_additional_codes_oid_seq OWNED BY public.footnote_association_additional_codes_oplog.oid;
 
 
 --
 -- Name: footnote_association_erns_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE footnote_association_erns_oplog (
+CREATE TABLE public.footnote_association_erns_oplog (
     export_refund_nomenclature_sid integer,
     footnote_type character varying(2),
-    footnote_id character varying(3),
+    footnote_id character varying(5),
     validity_start_date timestamp without time zone,
     validity_end_date timestamp without time zone,
     goods_nomenclature_item_id character varying(10),
@@ -1704,7 +1746,7 @@ CREATE TABLE footnote_association_erns_oplog (
 -- Name: footnote_association_erns; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW footnote_association_erns AS
+CREATE VIEW public.footnote_association_erns AS
  SELECT footnote_association_erns1.export_refund_nomenclature_sid,
     footnote_association_erns1.footnote_type,
     footnote_association_erns1.footnote_id,
@@ -1717,9 +1759,9 @@ CREATE VIEW footnote_association_erns AS
     footnote_association_erns1.oid,
     footnote_association_erns1.operation,
     footnote_association_erns1.operation_date
-   FROM footnote_association_erns_oplog footnote_association_erns1
+   FROM public.footnote_association_erns_oplog footnote_association_erns1
   WHERE ((footnote_association_erns1.oid IN ( SELECT max(footnote_association_erns2.oid) AS max
-           FROM footnote_association_erns_oplog footnote_association_erns2
+           FROM public.footnote_association_erns_oplog footnote_association_erns2
           WHERE ((footnote_association_erns1.export_refund_nomenclature_sid = footnote_association_erns2.export_refund_nomenclature_sid) AND ((footnote_association_erns1.footnote_id)::text = (footnote_association_erns2.footnote_id)::text) AND ((footnote_association_erns1.footnote_type)::text = (footnote_association_erns2.footnote_type)::text) AND (footnote_association_erns1.validity_start_date = footnote_association_erns2.validity_start_date)))) AND ((footnote_association_erns1.operation)::text <> 'D'::text));
 
 
@@ -1727,7 +1769,7 @@ CREATE VIEW footnote_association_erns AS
 -- Name: footnote_association_erns_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE footnote_association_erns_oid_seq
+CREATE SEQUENCE public.footnote_association_erns_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1739,17 +1781,17 @@ CREATE SEQUENCE footnote_association_erns_oid_seq
 -- Name: footnote_association_erns_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE footnote_association_erns_oid_seq OWNED BY footnote_association_erns_oplog.oid;
+ALTER SEQUENCE public.footnote_association_erns_oid_seq OWNED BY public.footnote_association_erns_oplog.oid;
 
 
 --
 -- Name: footnote_association_goods_nomenclatures_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE footnote_association_goods_nomenclatures_oplog (
+CREATE TABLE public.footnote_association_goods_nomenclatures_oplog (
     goods_nomenclature_sid integer,
     footnote_type character varying(2),
-    footnote_id character varying(3),
+    footnote_id character varying(5),
     validity_start_date timestamp without time zone,
     validity_end_date timestamp without time zone,
     goods_nomenclature_item_id character varying(10),
@@ -1766,7 +1808,7 @@ CREATE TABLE footnote_association_goods_nomenclatures_oplog (
 -- Name: footnote_association_goods_nomenclatures; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW footnote_association_goods_nomenclatures AS
+CREATE VIEW public.footnote_association_goods_nomenclatures AS
  SELECT footnote_association_goods_nomenclatures1.goods_nomenclature_sid,
     footnote_association_goods_nomenclatures1.footnote_type,
     footnote_association_goods_nomenclatures1.footnote_id,
@@ -1778,9 +1820,9 @@ CREATE VIEW footnote_association_goods_nomenclatures AS
     footnote_association_goods_nomenclatures1.oid,
     footnote_association_goods_nomenclatures1.operation,
     footnote_association_goods_nomenclatures1.operation_date
-   FROM footnote_association_goods_nomenclatures_oplog footnote_association_goods_nomenclatures1
+   FROM public.footnote_association_goods_nomenclatures_oplog footnote_association_goods_nomenclatures1
   WHERE ((footnote_association_goods_nomenclatures1.oid IN ( SELECT max(footnote_association_goods_nomenclatures2.oid) AS max
-           FROM footnote_association_goods_nomenclatures_oplog footnote_association_goods_nomenclatures2
+           FROM public.footnote_association_goods_nomenclatures_oplog footnote_association_goods_nomenclatures2
           WHERE (((footnote_association_goods_nomenclatures1.footnote_id)::text = (footnote_association_goods_nomenclatures2.footnote_id)::text) AND ((footnote_association_goods_nomenclatures1.footnote_type)::text = (footnote_association_goods_nomenclatures2.footnote_type)::text) AND (footnote_association_goods_nomenclatures1.goods_nomenclature_sid = footnote_association_goods_nomenclatures2.goods_nomenclature_sid)))) AND ((footnote_association_goods_nomenclatures1.operation)::text <> 'D'::text));
 
 
@@ -1788,7 +1830,7 @@ CREATE VIEW footnote_association_goods_nomenclatures AS
 -- Name: footnote_association_goods_nomenclatures_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE footnote_association_goods_nomenclatures_oid_seq
+CREATE SEQUENCE public.footnote_association_goods_nomenclatures_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1800,17 +1842,17 @@ CREATE SEQUENCE footnote_association_goods_nomenclatures_oid_seq
 -- Name: footnote_association_goods_nomenclatures_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE footnote_association_goods_nomenclatures_oid_seq OWNED BY footnote_association_goods_nomenclatures_oplog.oid;
+ALTER SEQUENCE public.footnote_association_goods_nomenclatures_oid_seq OWNED BY public.footnote_association_goods_nomenclatures_oplog.oid;
 
 
 --
 -- Name: footnote_association_measures_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE footnote_association_measures_oplog (
+CREATE TABLE public.footnote_association_measures_oplog (
     measure_sid integer,
     footnote_type_id character varying(2),
-    footnote_id character varying(3),
+    footnote_id character varying(5),
     created_at timestamp without time zone,
     "national" boolean,
     oid integer NOT NULL,
@@ -1823,7 +1865,7 @@ CREATE TABLE footnote_association_measures_oplog (
 -- Name: footnote_association_measures; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW footnote_association_measures AS
+CREATE VIEW public.footnote_association_measures AS
  SELECT footnote_association_measures1.measure_sid,
     footnote_association_measures1.footnote_type_id,
     footnote_association_measures1.footnote_id,
@@ -1831,9 +1873,9 @@ CREATE VIEW footnote_association_measures AS
     footnote_association_measures1.oid,
     footnote_association_measures1.operation,
     footnote_association_measures1.operation_date
-   FROM footnote_association_measures_oplog footnote_association_measures1
+   FROM public.footnote_association_measures_oplog footnote_association_measures1
   WHERE ((footnote_association_measures1.oid IN ( SELECT max(footnote_association_measures2.oid) AS max
-           FROM footnote_association_measures_oplog footnote_association_measures2
+           FROM public.footnote_association_measures_oplog footnote_association_measures2
           WHERE ((footnote_association_measures1.measure_sid = footnote_association_measures2.measure_sid) AND ((footnote_association_measures1.footnote_id)::text = (footnote_association_measures2.footnote_id)::text) AND ((footnote_association_measures1.footnote_type_id)::text = (footnote_association_measures2.footnote_type_id)::text)))) AND ((footnote_association_measures1.operation)::text <> 'D'::text));
 
 
@@ -1841,7 +1883,7 @@ CREATE VIEW footnote_association_measures AS
 -- Name: footnote_association_measures_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE footnote_association_measures_oid_seq
+CREATE SEQUENCE public.footnote_association_measures_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1853,19 +1895,19 @@ CREATE SEQUENCE footnote_association_measures_oid_seq
 -- Name: footnote_association_measures_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE footnote_association_measures_oid_seq OWNED BY footnote_association_measures_oplog.oid;
+ALTER SEQUENCE public.footnote_association_measures_oid_seq OWNED BY public.footnote_association_measures_oplog.oid;
 
 
 --
 -- Name: footnote_association_meursing_headings_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE footnote_association_meursing_headings_oplog (
+CREATE TABLE public.footnote_association_meursing_headings_oplog (
     meursing_table_plan_id character varying(2),
     meursing_heading_number character varying(255),
     row_column_code integer,
     footnote_type character varying(2),
-    footnote_id character varying(3),
+    footnote_id character varying(5),
     validity_start_date timestamp without time zone,
     validity_end_date timestamp without time zone,
     created_at timestamp without time zone,
@@ -1879,7 +1921,7 @@ CREATE TABLE footnote_association_meursing_headings_oplog (
 -- Name: footnote_association_meursing_headings; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW footnote_association_meursing_headings AS
+CREATE VIEW public.footnote_association_meursing_headings AS
  SELECT footnote_association_meursing_headings1.meursing_table_plan_id,
     footnote_association_meursing_headings1.meursing_heading_number,
     footnote_association_meursing_headings1.row_column_code,
@@ -1890,9 +1932,9 @@ CREATE VIEW footnote_association_meursing_headings AS
     footnote_association_meursing_headings1.oid,
     footnote_association_meursing_headings1.operation,
     footnote_association_meursing_headings1.operation_date
-   FROM footnote_association_meursing_headings_oplog footnote_association_meursing_headings1
+   FROM public.footnote_association_meursing_headings_oplog footnote_association_meursing_headings1
   WHERE ((footnote_association_meursing_headings1.oid IN ( SELECT max(footnote_association_meursing_headings2.oid) AS max
-           FROM footnote_association_meursing_headings_oplog footnote_association_meursing_headings2
+           FROM public.footnote_association_meursing_headings_oplog footnote_association_meursing_headings2
           WHERE (((footnote_association_meursing_headings1.footnote_id)::text = (footnote_association_meursing_headings2.footnote_id)::text) AND ((footnote_association_meursing_headings1.meursing_table_plan_id)::text = (footnote_association_meursing_headings2.meursing_table_plan_id)::text)))) AND ((footnote_association_meursing_headings1.operation)::text <> 'D'::text));
 
 
@@ -1900,7 +1942,7 @@ CREATE VIEW footnote_association_meursing_headings AS
 -- Name: footnote_association_meursing_headings_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE footnote_association_meursing_headings_oid_seq
+CREATE SEQUENCE public.footnote_association_meursing_headings_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1912,14 +1954,14 @@ CREATE SEQUENCE footnote_association_meursing_headings_oid_seq
 -- Name: footnote_association_meursing_headings_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE footnote_association_meursing_headings_oid_seq OWNED BY footnote_association_meursing_headings_oplog.oid;
+ALTER SEQUENCE public.footnote_association_meursing_headings_oid_seq OWNED BY public.footnote_association_meursing_headings_oplog.oid;
 
 
 --
 -- Name: footnote_description_periods_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE footnote_description_periods_oplog (
+CREATE TABLE public.footnote_description_periods_oplog (
     footnote_description_period_sid integer,
     footnote_type_id character varying(2),
     footnote_id character varying(5),
@@ -1937,7 +1979,7 @@ CREATE TABLE footnote_description_periods_oplog (
 -- Name: footnote_description_periods; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW footnote_description_periods AS
+CREATE VIEW public.footnote_description_periods AS
  SELECT footnote_description_periods1.footnote_description_period_sid,
     footnote_description_periods1.footnote_type_id,
     footnote_description_periods1.footnote_id,
@@ -1947,9 +1989,9 @@ CREATE VIEW footnote_description_periods AS
     footnote_description_periods1.oid,
     footnote_description_periods1.operation,
     footnote_description_periods1.operation_date
-   FROM footnote_description_periods_oplog footnote_description_periods1
+   FROM public.footnote_description_periods_oplog footnote_description_periods1
   WHERE ((footnote_description_periods1.oid IN ( SELECT max(footnote_description_periods2.oid) AS max
-           FROM footnote_description_periods_oplog footnote_description_periods2
+           FROM public.footnote_description_periods_oplog footnote_description_periods2
           WHERE (((footnote_description_periods1.footnote_id)::text = (footnote_description_periods2.footnote_id)::text) AND ((footnote_description_periods1.footnote_type_id)::text = (footnote_description_periods2.footnote_type_id)::text) AND (footnote_description_periods1.footnote_description_period_sid = footnote_description_periods2.footnote_description_period_sid)))) AND ((footnote_description_periods1.operation)::text <> 'D'::text));
 
 
@@ -1957,7 +1999,7 @@ CREATE VIEW footnote_description_periods AS
 -- Name: footnote_description_periods_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE footnote_description_periods_oid_seq
+CREATE SEQUENCE public.footnote_description_periods_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1969,14 +2011,14 @@ CREATE SEQUENCE footnote_description_periods_oid_seq
 -- Name: footnote_description_periods_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE footnote_description_periods_oid_seq OWNED BY footnote_description_periods_oplog.oid;
+ALTER SEQUENCE public.footnote_description_periods_oid_seq OWNED BY public.footnote_description_periods_oplog.oid;
 
 
 --
 -- Name: footnote_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE footnote_descriptions_oplog (
+CREATE TABLE public.footnote_descriptions_oplog (
     footnote_description_period_sid integer,
     footnote_type_id character varying(2),
     footnote_id character varying(5),
@@ -1994,7 +2036,7 @@ CREATE TABLE footnote_descriptions_oplog (
 -- Name: footnote_descriptions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW footnote_descriptions AS
+CREATE VIEW public.footnote_descriptions AS
  SELECT footnote_descriptions1.footnote_description_period_sid,
     footnote_descriptions1.footnote_type_id,
     footnote_descriptions1.footnote_id,
@@ -2004,9 +2046,9 @@ CREATE VIEW footnote_descriptions AS
     footnote_descriptions1.oid,
     footnote_descriptions1.operation,
     footnote_descriptions1.operation_date
-   FROM footnote_descriptions_oplog footnote_descriptions1
+   FROM public.footnote_descriptions_oplog footnote_descriptions1
   WHERE ((footnote_descriptions1.oid IN ( SELECT max(footnote_descriptions2.oid) AS max
-           FROM footnote_descriptions_oplog footnote_descriptions2
+           FROM public.footnote_descriptions_oplog footnote_descriptions2
           WHERE ((footnote_descriptions1.footnote_description_period_sid = footnote_descriptions2.footnote_description_period_sid) AND ((footnote_descriptions1.footnote_id)::text = (footnote_descriptions2.footnote_id)::text) AND ((footnote_descriptions1.footnote_type_id)::text = (footnote_descriptions2.footnote_type_id)::text)))) AND ((footnote_descriptions1.operation)::text <> 'D'::text));
 
 
@@ -2014,7 +2056,7 @@ CREATE VIEW footnote_descriptions AS
 -- Name: footnote_descriptions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE footnote_descriptions_oid_seq
+CREATE SEQUENCE public.footnote_descriptions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2026,14 +2068,14 @@ CREATE SEQUENCE footnote_descriptions_oid_seq
 -- Name: footnote_descriptions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE footnote_descriptions_oid_seq OWNED BY footnote_descriptions_oplog.oid;
+ALTER SEQUENCE public.footnote_descriptions_oid_seq OWNED BY public.footnote_descriptions_oplog.oid;
 
 
 --
 -- Name: footnote_type_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE footnote_type_descriptions_oplog (
+CREATE TABLE public.footnote_type_descriptions_oplog (
     footnote_type_id character varying(2),
     language_id character varying(5),
     description text,
@@ -2049,7 +2091,7 @@ CREATE TABLE footnote_type_descriptions_oplog (
 -- Name: footnote_type_descriptions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW footnote_type_descriptions AS
+CREATE VIEW public.footnote_type_descriptions AS
  SELECT footnote_type_descriptions1.footnote_type_id,
     footnote_type_descriptions1.language_id,
     footnote_type_descriptions1.description,
@@ -2057,9 +2099,9 @@ CREATE VIEW footnote_type_descriptions AS
     footnote_type_descriptions1.oid,
     footnote_type_descriptions1.operation,
     footnote_type_descriptions1.operation_date
-   FROM footnote_type_descriptions_oplog footnote_type_descriptions1
+   FROM public.footnote_type_descriptions_oplog footnote_type_descriptions1
   WHERE ((footnote_type_descriptions1.oid IN ( SELECT max(footnote_type_descriptions2.oid) AS max
-           FROM footnote_type_descriptions_oplog footnote_type_descriptions2
+           FROM public.footnote_type_descriptions_oplog footnote_type_descriptions2
           WHERE ((footnote_type_descriptions1.footnote_type_id)::text = (footnote_type_descriptions2.footnote_type_id)::text))) AND ((footnote_type_descriptions1.operation)::text <> 'D'::text));
 
 
@@ -2067,7 +2109,7 @@ CREATE VIEW footnote_type_descriptions AS
 -- Name: footnote_type_descriptions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE footnote_type_descriptions_oid_seq
+CREATE SEQUENCE public.footnote_type_descriptions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2079,14 +2121,14 @@ CREATE SEQUENCE footnote_type_descriptions_oid_seq
 -- Name: footnote_type_descriptions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE footnote_type_descriptions_oid_seq OWNED BY footnote_type_descriptions_oplog.oid;
+ALTER SEQUENCE public.footnote_type_descriptions_oid_seq OWNED BY public.footnote_type_descriptions_oplog.oid;
 
 
 --
 -- Name: footnote_types_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE footnote_types_oplog (
+CREATE TABLE public.footnote_types_oplog (
     footnote_type_id character varying(2),
     application_code integer,
     validity_start_date timestamp without time zone,
@@ -2103,7 +2145,7 @@ CREATE TABLE footnote_types_oplog (
 -- Name: footnote_types; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW footnote_types AS
+CREATE VIEW public.footnote_types AS
  SELECT footnote_types1.footnote_type_id,
     footnote_types1.application_code,
     footnote_types1.validity_start_date,
@@ -2112,9 +2154,9 @@ CREATE VIEW footnote_types AS
     footnote_types1.oid,
     footnote_types1.operation,
     footnote_types1.operation_date
-   FROM footnote_types_oplog footnote_types1
+   FROM public.footnote_types_oplog footnote_types1
   WHERE ((footnote_types1.oid IN ( SELECT max(footnote_types2.oid) AS max
-           FROM footnote_types_oplog footnote_types2
+           FROM public.footnote_types_oplog footnote_types2
           WHERE ((footnote_types1.footnote_type_id)::text = (footnote_types2.footnote_type_id)::text))) AND ((footnote_types1.operation)::text <> 'D'::text));
 
 
@@ -2122,7 +2164,7 @@ CREATE VIEW footnote_types AS
 -- Name: footnote_types_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE footnote_types_oid_seq
+CREATE SEQUENCE public.footnote_types_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2134,14 +2176,14 @@ CREATE SEQUENCE footnote_types_oid_seq
 -- Name: footnote_types_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE footnote_types_oid_seq OWNED BY footnote_types_oplog.oid;
+ALTER SEQUENCE public.footnote_types_oid_seq OWNED BY public.footnote_types_oplog.oid;
 
 
 --
 -- Name: footnotes_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE footnotes_oplog (
+CREATE TABLE public.footnotes_oplog (
     footnote_id character varying(5),
     footnote_type_id character varying(2),
     validity_start_date timestamp without time zone,
@@ -2158,7 +2200,7 @@ CREATE TABLE footnotes_oplog (
 -- Name: footnotes; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW footnotes AS
+CREATE VIEW public.footnotes AS
  SELECT footnotes1.footnote_id,
     footnotes1.footnote_type_id,
     footnotes1.validity_start_date,
@@ -2167,9 +2209,9 @@ CREATE VIEW footnotes AS
     footnotes1.oid,
     footnotes1.operation,
     footnotes1.operation_date
-   FROM footnotes_oplog footnotes1
+   FROM public.footnotes_oplog footnotes1
   WHERE ((footnotes1.oid IN ( SELECT max(footnotes2.oid) AS max
-           FROM footnotes_oplog footnotes2
+           FROM public.footnotes_oplog footnotes2
           WHERE (((footnotes1.footnote_type_id)::text = (footnotes2.footnote_type_id)::text) AND ((footnotes1.footnote_id)::text = (footnotes2.footnote_id)::text)))) AND ((footnotes1.operation)::text <> 'D'::text));
 
 
@@ -2177,7 +2219,7 @@ CREATE VIEW footnotes AS
 -- Name: footnotes_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE footnotes_oid_seq
+CREATE SEQUENCE public.footnotes_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2189,14 +2231,14 @@ CREATE SEQUENCE footnotes_oid_seq
 -- Name: footnotes_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE footnotes_oid_seq OWNED BY footnotes_oplog.oid;
+ALTER SEQUENCE public.footnotes_oid_seq OWNED BY public.footnotes_oplog.oid;
 
 
 --
 -- Name: fts_regulation_actions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE fts_regulation_actions_oplog (
+CREATE TABLE public.fts_regulation_actions_oplog (
     fts_regulation_role integer,
     fts_regulation_id character varying(8),
     stopped_regulation_role integer,
@@ -2212,7 +2254,7 @@ CREATE TABLE fts_regulation_actions_oplog (
 -- Name: fts_regulation_actions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW fts_regulation_actions AS
+CREATE VIEW public.fts_regulation_actions AS
  SELECT fts_regulation_actions1.fts_regulation_role,
     fts_regulation_actions1.fts_regulation_id,
     fts_regulation_actions1.stopped_regulation_role,
@@ -2220,9 +2262,9 @@ CREATE VIEW fts_regulation_actions AS
     fts_regulation_actions1.oid,
     fts_regulation_actions1.operation,
     fts_regulation_actions1.operation_date
-   FROM fts_regulation_actions_oplog fts_regulation_actions1
+   FROM public.fts_regulation_actions_oplog fts_regulation_actions1
   WHERE ((fts_regulation_actions1.oid IN ( SELECT max(fts_regulation_actions2.oid) AS max
-           FROM fts_regulation_actions_oplog fts_regulation_actions2
+           FROM public.fts_regulation_actions_oplog fts_regulation_actions2
           WHERE (((fts_regulation_actions1.fts_regulation_id)::text = (fts_regulation_actions2.fts_regulation_id)::text) AND (fts_regulation_actions1.fts_regulation_role = fts_regulation_actions2.fts_regulation_role) AND ((fts_regulation_actions1.stopped_regulation_id)::text = (fts_regulation_actions2.stopped_regulation_id)::text) AND (fts_regulation_actions1.stopped_regulation_role = fts_regulation_actions2.stopped_regulation_role)))) AND ((fts_regulation_actions1.operation)::text <> 'D'::text));
 
 
@@ -2230,7 +2272,7 @@ CREATE VIEW fts_regulation_actions AS
 -- Name: fts_regulation_actions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE fts_regulation_actions_oid_seq
+CREATE SEQUENCE public.fts_regulation_actions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2242,14 +2284,14 @@ CREATE SEQUENCE fts_regulation_actions_oid_seq
 -- Name: fts_regulation_actions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE fts_regulation_actions_oid_seq OWNED BY fts_regulation_actions_oplog.oid;
+ALTER SEQUENCE public.fts_regulation_actions_oid_seq OWNED BY public.fts_regulation_actions_oplog.oid;
 
 
 --
 -- Name: full_temporary_stop_regulations_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE full_temporary_stop_regulations_oplog (
+CREATE TABLE public.full_temporary_stop_regulations_oplog (
     full_temporary_stop_regulation_role integer,
     full_temporary_stop_regulation_id character varying(8),
     published_date date,
@@ -2274,7 +2316,7 @@ CREATE TABLE full_temporary_stop_regulations_oplog (
 -- Name: full_temporary_stop_regulations; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW full_temporary_stop_regulations AS
+CREATE VIEW public.full_temporary_stop_regulations AS
  SELECT full_temporary_stop_regulations1.full_temporary_stop_regulation_role,
     full_temporary_stop_regulations1.full_temporary_stop_regulation_id,
     full_temporary_stop_regulations1.published_date,
@@ -2291,9 +2333,9 @@ CREATE VIEW full_temporary_stop_regulations AS
     full_temporary_stop_regulations1.oid,
     full_temporary_stop_regulations1.operation,
     full_temporary_stop_regulations1.operation_date
-   FROM full_temporary_stop_regulations_oplog full_temporary_stop_regulations1
+   FROM public.full_temporary_stop_regulations_oplog full_temporary_stop_regulations1
   WHERE ((full_temporary_stop_regulations1.oid IN ( SELECT max(full_temporary_stop_regulations2.oid) AS max
-           FROM full_temporary_stop_regulations_oplog full_temporary_stop_regulations2
+           FROM public.full_temporary_stop_regulations_oplog full_temporary_stop_regulations2
           WHERE (((full_temporary_stop_regulations1.full_temporary_stop_regulation_id)::text = (full_temporary_stop_regulations2.full_temporary_stop_regulation_id)::text) AND (full_temporary_stop_regulations1.full_temporary_stop_regulation_role = full_temporary_stop_regulations2.full_temporary_stop_regulation_role)))) AND ((full_temporary_stop_regulations1.operation)::text <> 'D'::text));
 
 
@@ -2301,7 +2343,7 @@ CREATE VIEW full_temporary_stop_regulations AS
 -- Name: full_temporary_stop_regulations_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE full_temporary_stop_regulations_oid_seq
+CREATE SEQUENCE public.full_temporary_stop_regulations_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2313,14 +2355,14 @@ CREATE SEQUENCE full_temporary_stop_regulations_oid_seq
 -- Name: full_temporary_stop_regulations_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE full_temporary_stop_regulations_oid_seq OWNED BY full_temporary_stop_regulations_oplog.oid;
+ALTER SEQUENCE public.full_temporary_stop_regulations_oid_seq OWNED BY public.full_temporary_stop_regulations_oplog.oid;
 
 
 --
 -- Name: geographical_area_description_periods_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE geographical_area_description_periods_oplog (
+CREATE TABLE public.geographical_area_description_periods_oplog (
     geographical_area_description_period_sid integer,
     geographical_area_sid integer,
     validity_start_date timestamp without time zone,
@@ -2338,7 +2380,7 @@ CREATE TABLE geographical_area_description_periods_oplog (
 -- Name: geographical_area_description_periods; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW geographical_area_description_periods AS
+CREATE VIEW public.geographical_area_description_periods AS
  SELECT geographical_area_description_periods1.geographical_area_description_period_sid,
     geographical_area_description_periods1.geographical_area_sid,
     geographical_area_description_periods1.validity_start_date,
@@ -2348,9 +2390,9 @@ CREATE VIEW geographical_area_description_periods AS
     geographical_area_description_periods1.oid,
     geographical_area_description_periods1.operation,
     geographical_area_description_periods1.operation_date
-   FROM geographical_area_description_periods_oplog geographical_area_description_periods1
+   FROM public.geographical_area_description_periods_oplog geographical_area_description_periods1
   WHERE ((geographical_area_description_periods1.oid IN ( SELECT max(geographical_area_description_periods2.oid) AS max
-           FROM geographical_area_description_periods_oplog geographical_area_description_periods2
+           FROM public.geographical_area_description_periods_oplog geographical_area_description_periods2
           WHERE ((geographical_area_description_periods1.geographical_area_description_period_sid = geographical_area_description_periods2.geographical_area_description_period_sid) AND (geographical_area_description_periods1.geographical_area_sid = geographical_area_description_periods2.geographical_area_sid)))) AND ((geographical_area_description_periods1.operation)::text <> 'D'::text));
 
 
@@ -2358,7 +2400,7 @@ CREATE VIEW geographical_area_description_periods AS
 -- Name: geographical_area_description_periods_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE geographical_area_description_periods_oid_seq
+CREATE SEQUENCE public.geographical_area_description_periods_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2370,14 +2412,14 @@ CREATE SEQUENCE geographical_area_description_periods_oid_seq
 -- Name: geographical_area_description_periods_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE geographical_area_description_periods_oid_seq OWNED BY geographical_area_description_periods_oplog.oid;
+ALTER SEQUENCE public.geographical_area_description_periods_oid_seq OWNED BY public.geographical_area_description_periods_oplog.oid;
 
 
 --
 -- Name: geographical_area_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE geographical_area_descriptions_oplog (
+CREATE TABLE public.geographical_area_descriptions_oplog (
     geographical_area_description_period_sid integer,
     language_id character varying(5),
     geographical_area_sid integer,
@@ -2395,7 +2437,7 @@ CREATE TABLE geographical_area_descriptions_oplog (
 -- Name: geographical_area_descriptions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW geographical_area_descriptions AS
+CREATE VIEW public.geographical_area_descriptions AS
  SELECT geographical_area_descriptions1.geographical_area_description_period_sid,
     geographical_area_descriptions1.language_id,
     geographical_area_descriptions1.geographical_area_sid,
@@ -2405,9 +2447,9 @@ CREATE VIEW geographical_area_descriptions AS
     geographical_area_descriptions1.oid,
     geographical_area_descriptions1.operation,
     geographical_area_descriptions1.operation_date
-   FROM geographical_area_descriptions_oplog geographical_area_descriptions1
+   FROM public.geographical_area_descriptions_oplog geographical_area_descriptions1
   WHERE ((geographical_area_descriptions1.oid IN ( SELECT max(geographical_area_descriptions2.oid) AS max
-           FROM geographical_area_descriptions_oplog geographical_area_descriptions2
+           FROM public.geographical_area_descriptions_oplog geographical_area_descriptions2
           WHERE ((geographical_area_descriptions1.geographical_area_description_period_sid = geographical_area_descriptions2.geographical_area_description_period_sid) AND (geographical_area_descriptions1.geographical_area_sid = geographical_area_descriptions2.geographical_area_sid)))) AND ((geographical_area_descriptions1.operation)::text <> 'D'::text));
 
 
@@ -2415,7 +2457,7 @@ CREATE VIEW geographical_area_descriptions AS
 -- Name: geographical_area_descriptions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE geographical_area_descriptions_oid_seq
+CREATE SEQUENCE public.geographical_area_descriptions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2427,14 +2469,14 @@ CREATE SEQUENCE geographical_area_descriptions_oid_seq
 -- Name: geographical_area_descriptions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE geographical_area_descriptions_oid_seq OWNED BY geographical_area_descriptions_oplog.oid;
+ALTER SEQUENCE public.geographical_area_descriptions_oid_seq OWNED BY public.geographical_area_descriptions_oplog.oid;
 
 
 --
 -- Name: geographical_area_memberships_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE geographical_area_memberships_oplog (
+CREATE TABLE public.geographical_area_memberships_oplog (
     geographical_area_sid integer,
     geographical_area_group_sid integer,
     validity_start_date timestamp without time zone,
@@ -2451,7 +2493,7 @@ CREATE TABLE geographical_area_memberships_oplog (
 -- Name: geographical_area_memberships; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW geographical_area_memberships AS
+CREATE VIEW public.geographical_area_memberships AS
  SELECT geographical_area_memberships1.geographical_area_sid,
     geographical_area_memberships1.geographical_area_group_sid,
     geographical_area_memberships1.validity_start_date,
@@ -2460,9 +2502,9 @@ CREATE VIEW geographical_area_memberships AS
     geographical_area_memberships1.oid,
     geographical_area_memberships1.operation,
     geographical_area_memberships1.operation_date
-   FROM geographical_area_memberships_oplog geographical_area_memberships1
+   FROM public.geographical_area_memberships_oplog geographical_area_memberships1
   WHERE ((geographical_area_memberships1.oid IN ( SELECT max(geographical_area_memberships2.oid) AS max
-           FROM geographical_area_memberships_oplog geographical_area_memberships2
+           FROM public.geographical_area_memberships_oplog geographical_area_memberships2
           WHERE ((geographical_area_memberships1.geographical_area_sid = geographical_area_memberships2.geographical_area_sid) AND (geographical_area_memberships1.geographical_area_group_sid = geographical_area_memberships2.geographical_area_group_sid) AND (geographical_area_memberships1.validity_start_date = geographical_area_memberships2.validity_start_date)))) AND ((geographical_area_memberships1.operation)::text <> 'D'::text));
 
 
@@ -2470,7 +2512,7 @@ CREATE VIEW geographical_area_memberships AS
 -- Name: geographical_area_memberships_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE geographical_area_memberships_oid_seq
+CREATE SEQUENCE public.geographical_area_memberships_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2482,14 +2524,14 @@ CREATE SEQUENCE geographical_area_memberships_oid_seq
 -- Name: geographical_area_memberships_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE geographical_area_memberships_oid_seq OWNED BY geographical_area_memberships_oplog.oid;
+ALTER SEQUENCE public.geographical_area_memberships_oid_seq OWNED BY public.geographical_area_memberships_oplog.oid;
 
 
 --
 -- Name: geographical_areas_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE geographical_areas_oplog (
+CREATE TABLE public.geographical_areas_oplog (
     geographical_area_sid integer,
     parent_geographical_area_group_sid integer,
     validity_start_date timestamp without time zone,
@@ -2508,7 +2550,7 @@ CREATE TABLE geographical_areas_oplog (
 -- Name: geographical_areas; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW geographical_areas AS
+CREATE VIEW public.geographical_areas AS
  SELECT geographical_areas1.geographical_area_sid,
     geographical_areas1.parent_geographical_area_group_sid,
     geographical_areas1.validity_start_date,
@@ -2519,9 +2561,9 @@ CREATE VIEW geographical_areas AS
     geographical_areas1.oid,
     geographical_areas1.operation,
     geographical_areas1.operation_date
-   FROM geographical_areas_oplog geographical_areas1
+   FROM public.geographical_areas_oplog geographical_areas1
   WHERE ((geographical_areas1.oid IN ( SELECT max(geographical_areas2.oid) AS max
-           FROM geographical_areas_oplog geographical_areas2
+           FROM public.geographical_areas_oplog geographical_areas2
           WHERE (geographical_areas1.geographical_area_sid = geographical_areas2.geographical_area_sid))) AND ((geographical_areas1.operation)::text <> 'D'::text));
 
 
@@ -2529,7 +2571,7 @@ CREATE VIEW geographical_areas AS
 -- Name: geographical_areas_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE geographical_areas_oid_seq
+CREATE SEQUENCE public.geographical_areas_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2541,14 +2583,14 @@ CREATE SEQUENCE geographical_areas_oid_seq
 -- Name: geographical_areas_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE geographical_areas_oid_seq OWNED BY geographical_areas_oplog.oid;
+ALTER SEQUENCE public.geographical_areas_oid_seq OWNED BY public.geographical_areas_oplog.oid;
 
 
 --
 -- Name: goods_nomenclature_description_periods_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE goods_nomenclature_description_periods_oplog (
+CREATE TABLE public.goods_nomenclature_description_periods_oplog (
     goods_nomenclature_description_period_sid integer,
     goods_nomenclature_sid integer,
     validity_start_date timestamp without time zone,
@@ -2566,7 +2608,7 @@ CREATE TABLE goods_nomenclature_description_periods_oplog (
 -- Name: goods_nomenclature_description_periods; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW goods_nomenclature_description_periods AS
+CREATE VIEW public.goods_nomenclature_description_periods AS
  SELECT goods_nomenclature_description_periods1.goods_nomenclature_description_period_sid,
     goods_nomenclature_description_periods1.goods_nomenclature_sid,
     goods_nomenclature_description_periods1.validity_start_date,
@@ -2576,9 +2618,9 @@ CREATE VIEW goods_nomenclature_description_periods AS
     goods_nomenclature_description_periods1.oid,
     goods_nomenclature_description_periods1.operation,
     goods_nomenclature_description_periods1.operation_date
-   FROM goods_nomenclature_description_periods_oplog goods_nomenclature_description_periods1
+   FROM public.goods_nomenclature_description_periods_oplog goods_nomenclature_description_periods1
   WHERE ((goods_nomenclature_description_periods1.oid IN ( SELECT max(goods_nomenclature_description_periods2.oid) AS max
-           FROM goods_nomenclature_description_periods_oplog goods_nomenclature_description_periods2
+           FROM public.goods_nomenclature_description_periods_oplog goods_nomenclature_description_periods2
           WHERE (goods_nomenclature_description_periods1.goods_nomenclature_description_period_sid = goods_nomenclature_description_periods2.goods_nomenclature_description_period_sid))) AND ((goods_nomenclature_description_periods1.operation)::text <> 'D'::text));
 
 
@@ -2586,7 +2628,7 @@ CREATE VIEW goods_nomenclature_description_periods AS
 -- Name: goods_nomenclature_description_periods_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE goods_nomenclature_description_periods_oid_seq
+CREATE SEQUENCE public.goods_nomenclature_description_periods_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2598,14 +2640,14 @@ CREATE SEQUENCE goods_nomenclature_description_periods_oid_seq
 -- Name: goods_nomenclature_description_periods_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE goods_nomenclature_description_periods_oid_seq OWNED BY goods_nomenclature_description_periods_oplog.oid;
+ALTER SEQUENCE public.goods_nomenclature_description_periods_oid_seq OWNED BY public.goods_nomenclature_description_periods_oplog.oid;
 
 
 --
 -- Name: goods_nomenclature_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE goods_nomenclature_descriptions_oplog (
+CREATE TABLE public.goods_nomenclature_descriptions_oplog (
     goods_nomenclature_description_period_sid integer,
     language_id character varying(5),
     goods_nomenclature_sid integer,
@@ -2623,7 +2665,7 @@ CREATE TABLE goods_nomenclature_descriptions_oplog (
 -- Name: goods_nomenclature_descriptions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW goods_nomenclature_descriptions AS
+CREATE VIEW public.goods_nomenclature_descriptions AS
  SELECT goods_nomenclature_descriptions1.goods_nomenclature_description_period_sid,
     goods_nomenclature_descriptions1.language_id,
     goods_nomenclature_descriptions1.goods_nomenclature_sid,
@@ -2633,9 +2675,9 @@ CREATE VIEW goods_nomenclature_descriptions AS
     goods_nomenclature_descriptions1.oid,
     goods_nomenclature_descriptions1.operation,
     goods_nomenclature_descriptions1.operation_date
-   FROM goods_nomenclature_descriptions_oplog goods_nomenclature_descriptions1
+   FROM public.goods_nomenclature_descriptions_oplog goods_nomenclature_descriptions1
   WHERE ((goods_nomenclature_descriptions1.oid IN ( SELECT max(goods_nomenclature_descriptions2.oid) AS max
-           FROM goods_nomenclature_descriptions_oplog goods_nomenclature_descriptions2
+           FROM public.goods_nomenclature_descriptions_oplog goods_nomenclature_descriptions2
           WHERE ((goods_nomenclature_descriptions1.goods_nomenclature_sid = goods_nomenclature_descriptions2.goods_nomenclature_sid) AND (goods_nomenclature_descriptions1.goods_nomenclature_description_period_sid = goods_nomenclature_descriptions2.goods_nomenclature_description_period_sid)))) AND ((goods_nomenclature_descriptions1.operation)::text <> 'D'::text));
 
 
@@ -2643,7 +2685,7 @@ CREATE VIEW goods_nomenclature_descriptions AS
 -- Name: goods_nomenclature_descriptions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE goods_nomenclature_descriptions_oid_seq
+CREATE SEQUENCE public.goods_nomenclature_descriptions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2655,14 +2697,14 @@ CREATE SEQUENCE goods_nomenclature_descriptions_oid_seq
 -- Name: goods_nomenclature_descriptions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE goods_nomenclature_descriptions_oid_seq OWNED BY goods_nomenclature_descriptions_oplog.oid;
+ALTER SEQUENCE public.goods_nomenclature_descriptions_oid_seq OWNED BY public.goods_nomenclature_descriptions_oplog.oid;
 
 
 --
 -- Name: goods_nomenclature_group_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE goods_nomenclature_group_descriptions_oplog (
+CREATE TABLE public.goods_nomenclature_group_descriptions_oplog (
     goods_nomenclature_group_type character varying(1),
     goods_nomenclature_group_id character varying(6),
     language_id character varying(5),
@@ -2678,7 +2720,7 @@ CREATE TABLE goods_nomenclature_group_descriptions_oplog (
 -- Name: goods_nomenclature_group_descriptions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW goods_nomenclature_group_descriptions AS
+CREATE VIEW public.goods_nomenclature_group_descriptions AS
  SELECT goods_nomenclature_group_descriptions1.goods_nomenclature_group_type,
     goods_nomenclature_group_descriptions1.goods_nomenclature_group_id,
     goods_nomenclature_group_descriptions1.language_id,
@@ -2686,9 +2728,9 @@ CREATE VIEW goods_nomenclature_group_descriptions AS
     goods_nomenclature_group_descriptions1.oid,
     goods_nomenclature_group_descriptions1.operation,
     goods_nomenclature_group_descriptions1.operation_date
-   FROM goods_nomenclature_group_descriptions_oplog goods_nomenclature_group_descriptions1
+   FROM public.goods_nomenclature_group_descriptions_oplog goods_nomenclature_group_descriptions1
   WHERE ((goods_nomenclature_group_descriptions1.oid IN ( SELECT max(goods_nomenclature_group_descriptions2.oid) AS max
-           FROM goods_nomenclature_group_descriptions_oplog goods_nomenclature_group_descriptions2
+           FROM public.goods_nomenclature_group_descriptions_oplog goods_nomenclature_group_descriptions2
           WHERE (((goods_nomenclature_group_descriptions1.goods_nomenclature_group_id)::text = (goods_nomenclature_group_descriptions2.goods_nomenclature_group_id)::text) AND ((goods_nomenclature_group_descriptions1.goods_nomenclature_group_type)::text = (goods_nomenclature_group_descriptions2.goods_nomenclature_group_type)::text)))) AND ((goods_nomenclature_group_descriptions1.operation)::text <> 'D'::text));
 
 
@@ -2696,7 +2738,7 @@ CREATE VIEW goods_nomenclature_group_descriptions AS
 -- Name: goods_nomenclature_group_descriptions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE goods_nomenclature_group_descriptions_oid_seq
+CREATE SEQUENCE public.goods_nomenclature_group_descriptions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2708,14 +2750,14 @@ CREATE SEQUENCE goods_nomenclature_group_descriptions_oid_seq
 -- Name: goods_nomenclature_group_descriptions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE goods_nomenclature_group_descriptions_oid_seq OWNED BY goods_nomenclature_group_descriptions_oplog.oid;
+ALTER SEQUENCE public.goods_nomenclature_group_descriptions_oid_seq OWNED BY public.goods_nomenclature_group_descriptions_oplog.oid;
 
 
 --
 -- Name: goods_nomenclature_groups_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE goods_nomenclature_groups_oplog (
+CREATE TABLE public.goods_nomenclature_groups_oplog (
     goods_nomenclature_group_type character varying(1),
     goods_nomenclature_group_id character varying(6),
     validity_start_date timestamp without time zone,
@@ -2732,7 +2774,7 @@ CREATE TABLE goods_nomenclature_groups_oplog (
 -- Name: goods_nomenclature_groups; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW goods_nomenclature_groups AS
+CREATE VIEW public.goods_nomenclature_groups AS
  SELECT goods_nomenclature_groups1.goods_nomenclature_group_type,
     goods_nomenclature_groups1.goods_nomenclature_group_id,
     goods_nomenclature_groups1.validity_start_date,
@@ -2741,9 +2783,9 @@ CREATE VIEW goods_nomenclature_groups AS
     goods_nomenclature_groups1.oid,
     goods_nomenclature_groups1.operation,
     goods_nomenclature_groups1.operation_date
-   FROM goods_nomenclature_groups_oplog goods_nomenclature_groups1
+   FROM public.goods_nomenclature_groups_oplog goods_nomenclature_groups1
   WHERE ((goods_nomenclature_groups1.oid IN ( SELECT max(goods_nomenclature_groups2.oid) AS max
-           FROM goods_nomenclature_groups_oplog goods_nomenclature_groups2
+           FROM public.goods_nomenclature_groups_oplog goods_nomenclature_groups2
           WHERE (((goods_nomenclature_groups1.goods_nomenclature_group_id)::text = (goods_nomenclature_groups2.goods_nomenclature_group_id)::text) AND ((goods_nomenclature_groups1.goods_nomenclature_group_type)::text = (goods_nomenclature_groups2.goods_nomenclature_group_type)::text)))) AND ((goods_nomenclature_groups1.operation)::text <> 'D'::text));
 
 
@@ -2751,7 +2793,7 @@ CREATE VIEW goods_nomenclature_groups AS
 -- Name: goods_nomenclature_groups_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE goods_nomenclature_groups_oid_seq
+CREATE SEQUENCE public.goods_nomenclature_groups_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2763,14 +2805,14 @@ CREATE SEQUENCE goods_nomenclature_groups_oid_seq
 -- Name: goods_nomenclature_groups_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE goods_nomenclature_groups_oid_seq OWNED BY goods_nomenclature_groups_oplog.oid;
+ALTER SEQUENCE public.goods_nomenclature_groups_oid_seq OWNED BY public.goods_nomenclature_groups_oplog.oid;
 
 
 --
 -- Name: goods_nomenclature_indents_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE goods_nomenclature_indents_oplog (
+CREATE TABLE public.goods_nomenclature_indents_oplog (
     goods_nomenclature_indent_sid integer,
     goods_nomenclature_sid integer,
     validity_start_date timestamp without time zone,
@@ -2789,7 +2831,7 @@ CREATE TABLE goods_nomenclature_indents_oplog (
 -- Name: goods_nomenclature_indents; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW goods_nomenclature_indents AS
+CREATE VIEW public.goods_nomenclature_indents AS
  SELECT goods_nomenclature_indents1.goods_nomenclature_indent_sid,
     goods_nomenclature_indents1.goods_nomenclature_sid,
     goods_nomenclature_indents1.validity_start_date,
@@ -2800,9 +2842,9 @@ CREATE VIEW goods_nomenclature_indents AS
     goods_nomenclature_indents1.oid,
     goods_nomenclature_indents1.operation,
     goods_nomenclature_indents1.operation_date
-   FROM goods_nomenclature_indents_oplog goods_nomenclature_indents1
+   FROM public.goods_nomenclature_indents_oplog goods_nomenclature_indents1
   WHERE ((goods_nomenclature_indents1.oid IN ( SELECT max(goods_nomenclature_indents2.oid) AS max
-           FROM goods_nomenclature_indents_oplog goods_nomenclature_indents2
+           FROM public.goods_nomenclature_indents_oplog goods_nomenclature_indents2
           WHERE (goods_nomenclature_indents1.goods_nomenclature_indent_sid = goods_nomenclature_indents2.goods_nomenclature_indent_sid))) AND ((goods_nomenclature_indents1.operation)::text <> 'D'::text));
 
 
@@ -2810,7 +2852,7 @@ CREATE VIEW goods_nomenclature_indents AS
 -- Name: goods_nomenclature_indents_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE goods_nomenclature_indents_oid_seq
+CREATE SEQUENCE public.goods_nomenclature_indents_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2822,14 +2864,14 @@ CREATE SEQUENCE goods_nomenclature_indents_oid_seq
 -- Name: goods_nomenclature_indents_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE goods_nomenclature_indents_oid_seq OWNED BY goods_nomenclature_indents_oplog.oid;
+ALTER SEQUENCE public.goods_nomenclature_indents_oid_seq OWNED BY public.goods_nomenclature_indents_oplog.oid;
 
 
 --
 -- Name: goods_nomenclature_origins_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE goods_nomenclature_origins_oplog (
+CREATE TABLE public.goods_nomenclature_origins_oplog (
     goods_nomenclature_sid integer,
     derived_goods_nomenclature_item_id character varying(10),
     derived_productline_suffix character varying(2),
@@ -2846,7 +2888,7 @@ CREATE TABLE goods_nomenclature_origins_oplog (
 -- Name: goods_nomenclature_origins; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW goods_nomenclature_origins AS
+CREATE VIEW public.goods_nomenclature_origins AS
  SELECT goods_nomenclature_origins1.goods_nomenclature_sid,
     goods_nomenclature_origins1.derived_goods_nomenclature_item_id,
     goods_nomenclature_origins1.derived_productline_suffix,
@@ -2855,9 +2897,9 @@ CREATE VIEW goods_nomenclature_origins AS
     goods_nomenclature_origins1.oid,
     goods_nomenclature_origins1.operation,
     goods_nomenclature_origins1.operation_date
-   FROM goods_nomenclature_origins_oplog goods_nomenclature_origins1
+   FROM public.goods_nomenclature_origins_oplog goods_nomenclature_origins1
   WHERE ((goods_nomenclature_origins1.oid IN ( SELECT max(goods_nomenclature_origins2.oid) AS max
-           FROM goods_nomenclature_origins_oplog goods_nomenclature_origins2
+           FROM public.goods_nomenclature_origins_oplog goods_nomenclature_origins2
           WHERE ((goods_nomenclature_origins1.goods_nomenclature_sid = goods_nomenclature_origins2.goods_nomenclature_sid) AND ((goods_nomenclature_origins1.derived_goods_nomenclature_item_id)::text = (goods_nomenclature_origins2.derived_goods_nomenclature_item_id)::text) AND ((goods_nomenclature_origins1.derived_productline_suffix)::text = (goods_nomenclature_origins2.derived_productline_suffix)::text) AND ((goods_nomenclature_origins1.goods_nomenclature_item_id)::text = (goods_nomenclature_origins2.goods_nomenclature_item_id)::text) AND ((goods_nomenclature_origins1.productline_suffix)::text = (goods_nomenclature_origins2.productline_suffix)::text)))) AND ((goods_nomenclature_origins1.operation)::text <> 'D'::text));
 
 
@@ -2865,7 +2907,7 @@ CREATE VIEW goods_nomenclature_origins AS
 -- Name: goods_nomenclature_origins_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE goods_nomenclature_origins_oid_seq
+CREATE SEQUENCE public.goods_nomenclature_origins_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2877,14 +2919,14 @@ CREATE SEQUENCE goods_nomenclature_origins_oid_seq
 -- Name: goods_nomenclature_origins_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE goods_nomenclature_origins_oid_seq OWNED BY goods_nomenclature_origins_oplog.oid;
+ALTER SEQUENCE public.goods_nomenclature_origins_oid_seq OWNED BY public.goods_nomenclature_origins_oplog.oid;
 
 
 --
 -- Name: goods_nomenclature_successors_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE goods_nomenclature_successors_oplog (
+CREATE TABLE public.goods_nomenclature_successors_oplog (
     goods_nomenclature_sid integer,
     absorbed_goods_nomenclature_item_id character varying(10),
     absorbed_productline_suffix character varying(2),
@@ -2901,7 +2943,7 @@ CREATE TABLE goods_nomenclature_successors_oplog (
 -- Name: goods_nomenclature_successors; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW goods_nomenclature_successors AS
+CREATE VIEW public.goods_nomenclature_successors AS
  SELECT goods_nomenclature_successors1.goods_nomenclature_sid,
     goods_nomenclature_successors1.absorbed_goods_nomenclature_item_id,
     goods_nomenclature_successors1.absorbed_productline_suffix,
@@ -2910,9 +2952,9 @@ CREATE VIEW goods_nomenclature_successors AS
     goods_nomenclature_successors1.oid,
     goods_nomenclature_successors1.operation,
     goods_nomenclature_successors1.operation_date
-   FROM goods_nomenclature_successors_oplog goods_nomenclature_successors1
+   FROM public.goods_nomenclature_successors_oplog goods_nomenclature_successors1
   WHERE ((goods_nomenclature_successors1.oid IN ( SELECT max(goods_nomenclature_successors2.oid) AS max
-           FROM goods_nomenclature_successors_oplog goods_nomenclature_successors2
+           FROM public.goods_nomenclature_successors_oplog goods_nomenclature_successors2
           WHERE ((goods_nomenclature_successors1.goods_nomenclature_sid = goods_nomenclature_successors2.goods_nomenclature_sid) AND ((goods_nomenclature_successors1.absorbed_goods_nomenclature_item_id)::text = (goods_nomenclature_successors2.absorbed_goods_nomenclature_item_id)::text) AND ((goods_nomenclature_successors1.absorbed_productline_suffix)::text = (goods_nomenclature_successors2.absorbed_productline_suffix)::text) AND ((goods_nomenclature_successors1.goods_nomenclature_item_id)::text = (goods_nomenclature_successors2.goods_nomenclature_item_id)::text) AND ((goods_nomenclature_successors1.productline_suffix)::text = (goods_nomenclature_successors2.productline_suffix)::text)))) AND ((goods_nomenclature_successors1.operation)::text <> 'D'::text));
 
 
@@ -2920,7 +2962,7 @@ CREATE VIEW goods_nomenclature_successors AS
 -- Name: goods_nomenclature_successors_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE goods_nomenclature_successors_oid_seq
+CREATE SEQUENCE public.goods_nomenclature_successors_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2932,14 +2974,14 @@ CREATE SEQUENCE goods_nomenclature_successors_oid_seq
 -- Name: goods_nomenclature_successors_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE goods_nomenclature_successors_oid_seq OWNED BY goods_nomenclature_successors_oplog.oid;
+ALTER SEQUENCE public.goods_nomenclature_successors_oid_seq OWNED BY public.goods_nomenclature_successors_oplog.oid;
 
 
 --
 -- Name: goods_nomenclatures_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE goods_nomenclatures_oplog (
+CREATE TABLE public.goods_nomenclatures_oplog (
     goods_nomenclature_sid integer,
     goods_nomenclature_item_id character varying(10),
     producline_suffix character varying(255),
@@ -2957,7 +2999,7 @@ CREATE TABLE goods_nomenclatures_oplog (
 -- Name: goods_nomenclatures; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW goods_nomenclatures AS
+CREATE VIEW public.goods_nomenclatures AS
  SELECT goods_nomenclatures1.goods_nomenclature_sid,
     goods_nomenclatures1.goods_nomenclature_item_id,
     goods_nomenclatures1.producline_suffix,
@@ -2967,9 +3009,9 @@ CREATE VIEW goods_nomenclatures AS
     goods_nomenclatures1.oid,
     goods_nomenclatures1.operation,
     goods_nomenclatures1.operation_date
-   FROM goods_nomenclatures_oplog goods_nomenclatures1
+   FROM public.goods_nomenclatures_oplog goods_nomenclatures1
   WHERE ((goods_nomenclatures1.oid IN ( SELECT max(goods_nomenclatures2.oid) AS max
-           FROM goods_nomenclatures_oplog goods_nomenclatures2
+           FROM public.goods_nomenclatures_oplog goods_nomenclatures2
           WHERE (goods_nomenclatures1.goods_nomenclature_sid = goods_nomenclatures2.goods_nomenclature_sid))) AND ((goods_nomenclatures1.operation)::text <> 'D'::text));
 
 
@@ -2977,7 +3019,7 @@ CREATE VIEW goods_nomenclatures AS
 -- Name: goods_nomenclatures_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE goods_nomenclatures_oid_seq
+CREATE SEQUENCE public.goods_nomenclatures_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2989,14 +3031,14 @@ CREATE SEQUENCE goods_nomenclatures_oid_seq
 -- Name: goods_nomenclatures_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE goods_nomenclatures_oid_seq OWNED BY goods_nomenclatures_oplog.oid;
+ALTER SEQUENCE public.goods_nomenclatures_oid_seq OWNED BY public.goods_nomenclatures_oplog.oid;
 
 
 --
 -- Name: hidden_goods_nomenclatures; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE hidden_goods_nomenclatures (
+CREATE TABLE public.hidden_goods_nomenclatures (
     goods_nomenclature_item_id text,
     created_at timestamp without time zone
 );
@@ -3006,7 +3048,7 @@ CREATE TABLE hidden_goods_nomenclatures (
 -- Name: language_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE language_descriptions_oplog (
+CREATE TABLE public.language_descriptions_oplog (
     language_code_id character varying(255),
     language_id character varying(5),
     description text,
@@ -3021,16 +3063,16 @@ CREATE TABLE language_descriptions_oplog (
 -- Name: language_descriptions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW language_descriptions AS
+CREATE VIEW public.language_descriptions AS
  SELECT language_descriptions1.language_code_id,
     language_descriptions1.language_id,
     language_descriptions1.description,
     language_descriptions1.oid,
     language_descriptions1.operation,
     language_descriptions1.operation_date
-   FROM language_descriptions_oplog language_descriptions1
+   FROM public.language_descriptions_oplog language_descriptions1
   WHERE ((language_descriptions1.oid IN ( SELECT max(language_descriptions2.oid) AS max
-           FROM language_descriptions_oplog language_descriptions2
+           FROM public.language_descriptions_oplog language_descriptions2
           WHERE (((language_descriptions1.language_id)::text = (language_descriptions2.language_id)::text) AND ((language_descriptions1.language_code_id)::text = (language_descriptions2.language_code_id)::text)))) AND ((language_descriptions1.operation)::text <> 'D'::text));
 
 
@@ -3038,7 +3080,7 @@ CREATE VIEW language_descriptions AS
 -- Name: language_descriptions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE language_descriptions_oid_seq
+CREATE SEQUENCE public.language_descriptions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3050,14 +3092,14 @@ CREATE SEQUENCE language_descriptions_oid_seq
 -- Name: language_descriptions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE language_descriptions_oid_seq OWNED BY language_descriptions_oplog.oid;
+ALTER SEQUENCE public.language_descriptions_oid_seq OWNED BY public.language_descriptions_oplog.oid;
 
 
 --
 -- Name: languages_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE languages_oplog (
+CREATE TABLE public.languages_oplog (
     language_id character varying(5),
     validity_start_date timestamp without time zone,
     validity_end_date timestamp without time zone,
@@ -3072,16 +3114,16 @@ CREATE TABLE languages_oplog (
 -- Name: languages; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW languages AS
+CREATE VIEW public.languages AS
  SELECT languages1.language_id,
     languages1.validity_start_date,
     languages1.validity_end_date,
     languages1.oid,
     languages1.operation,
     languages1.operation_date
-   FROM languages_oplog languages1
+   FROM public.languages_oplog languages1
   WHERE ((languages1.oid IN ( SELECT max(languages2.oid) AS max
-           FROM languages_oplog languages2
+           FROM public.languages_oplog languages2
           WHERE ((languages1.language_id)::text = (languages2.language_id)::text))) AND ((languages1.operation)::text <> 'D'::text));
 
 
@@ -3089,7 +3131,7 @@ CREATE VIEW languages AS
 -- Name: languages_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE languages_oid_seq
+CREATE SEQUENCE public.languages_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3101,14 +3143,14 @@ CREATE SEQUENCE languages_oid_seq
 -- Name: languages_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE languages_oid_seq OWNED BY languages_oplog.oid;
+ALTER SEQUENCE public.languages_oid_seq OWNED BY public.languages_oplog.oid;
 
 
 --
 -- Name: measure_action_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE measure_action_descriptions_oplog (
+CREATE TABLE public.measure_action_descriptions_oplog (
     action_code character varying(255),
     language_id character varying(5),
     description text,
@@ -3123,16 +3165,16 @@ CREATE TABLE measure_action_descriptions_oplog (
 -- Name: measure_action_descriptions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW measure_action_descriptions AS
+CREATE VIEW public.measure_action_descriptions AS
  SELECT measure_action_descriptions1.action_code,
     measure_action_descriptions1.language_id,
     measure_action_descriptions1.description,
     measure_action_descriptions1.oid,
     measure_action_descriptions1.operation,
     measure_action_descriptions1.operation_date
-   FROM measure_action_descriptions_oplog measure_action_descriptions1
+   FROM public.measure_action_descriptions_oplog measure_action_descriptions1
   WHERE ((measure_action_descriptions1.oid IN ( SELECT max(measure_action_descriptions2.oid) AS max
-           FROM measure_action_descriptions_oplog measure_action_descriptions2
+           FROM public.measure_action_descriptions_oplog measure_action_descriptions2
           WHERE ((measure_action_descriptions1.action_code)::text = (measure_action_descriptions2.action_code)::text))) AND ((measure_action_descriptions1.operation)::text <> 'D'::text));
 
 
@@ -3140,7 +3182,7 @@ CREATE VIEW measure_action_descriptions AS
 -- Name: measure_action_descriptions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE measure_action_descriptions_oid_seq
+CREATE SEQUENCE public.measure_action_descriptions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3152,14 +3194,14 @@ CREATE SEQUENCE measure_action_descriptions_oid_seq
 -- Name: measure_action_descriptions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE measure_action_descriptions_oid_seq OWNED BY measure_action_descriptions_oplog.oid;
+ALTER SEQUENCE public.measure_action_descriptions_oid_seq OWNED BY public.measure_action_descriptions_oplog.oid;
 
 
 --
 -- Name: measure_actions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE measure_actions_oplog (
+CREATE TABLE public.measure_actions_oplog (
     action_code character varying(255),
     validity_start_date timestamp without time zone,
     validity_end_date timestamp without time zone,
@@ -3174,16 +3216,16 @@ CREATE TABLE measure_actions_oplog (
 -- Name: measure_actions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW measure_actions AS
+CREATE VIEW public.measure_actions AS
  SELECT measure_actions1.action_code,
     measure_actions1.validity_start_date,
     measure_actions1.validity_end_date,
     measure_actions1.oid,
     measure_actions1.operation,
     measure_actions1.operation_date
-   FROM measure_actions_oplog measure_actions1
+   FROM public.measure_actions_oplog measure_actions1
   WHERE ((measure_actions1.oid IN ( SELECT max(measure_actions2.oid) AS max
-           FROM measure_actions_oplog measure_actions2
+           FROM public.measure_actions_oplog measure_actions2
           WHERE ((measure_actions1.action_code)::text = (measure_actions2.action_code)::text))) AND ((measure_actions1.operation)::text <> 'D'::text));
 
 
@@ -3191,7 +3233,7 @@ CREATE VIEW measure_actions AS
 -- Name: measure_actions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE measure_actions_oid_seq
+CREATE SEQUENCE public.measure_actions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3203,14 +3245,14 @@ CREATE SEQUENCE measure_actions_oid_seq
 -- Name: measure_actions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE measure_actions_oid_seq OWNED BY measure_actions_oplog.oid;
+ALTER SEQUENCE public.measure_actions_oid_seq OWNED BY public.measure_actions_oplog.oid;
 
 
 --
 -- Name: measure_components_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE measure_components_oplog (
+CREATE TABLE public.measure_components_oplog (
     measure_sid integer,
     duty_expression_id character varying(255),
     duty_amount double precision,
@@ -3228,7 +3270,7 @@ CREATE TABLE measure_components_oplog (
 -- Name: measure_components; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW measure_components AS
+CREATE VIEW public.measure_components AS
  SELECT measure_components1.measure_sid,
     measure_components1.duty_expression_id,
     measure_components1.duty_amount,
@@ -3238,9 +3280,9 @@ CREATE VIEW measure_components AS
     measure_components1.oid,
     measure_components1.operation,
     measure_components1.operation_date
-   FROM measure_components_oplog measure_components1
+   FROM public.measure_components_oplog measure_components1
   WHERE ((measure_components1.oid IN ( SELECT max(measure_components2.oid) AS max
-           FROM measure_components_oplog measure_components2
+           FROM public.measure_components_oplog measure_components2
           WHERE ((measure_components1.measure_sid = measure_components2.measure_sid) AND ((measure_components1.duty_expression_id)::text = (measure_components2.duty_expression_id)::text)))) AND ((measure_components1.operation)::text <> 'D'::text));
 
 
@@ -3248,7 +3290,7 @@ CREATE VIEW measure_components AS
 -- Name: measure_components_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE measure_components_oid_seq
+CREATE SEQUENCE public.measure_components_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3260,14 +3302,14 @@ CREATE SEQUENCE measure_components_oid_seq
 -- Name: measure_components_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE measure_components_oid_seq OWNED BY measure_components_oplog.oid;
+ALTER SEQUENCE public.measure_components_oid_seq OWNED BY public.measure_components_oplog.oid;
 
 
 --
 -- Name: measure_condition_code_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE measure_condition_code_descriptions_oplog (
+CREATE TABLE public.measure_condition_code_descriptions_oplog (
     condition_code character varying(255),
     language_id character varying(5),
     description text,
@@ -3282,16 +3324,16 @@ CREATE TABLE measure_condition_code_descriptions_oplog (
 -- Name: measure_condition_code_descriptions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW measure_condition_code_descriptions AS
+CREATE VIEW public.measure_condition_code_descriptions AS
  SELECT measure_condition_code_descriptions1.condition_code,
     measure_condition_code_descriptions1.language_id,
     measure_condition_code_descriptions1.description,
     measure_condition_code_descriptions1.oid,
     measure_condition_code_descriptions1.operation,
     measure_condition_code_descriptions1.operation_date
-   FROM measure_condition_code_descriptions_oplog measure_condition_code_descriptions1
+   FROM public.measure_condition_code_descriptions_oplog measure_condition_code_descriptions1
   WHERE ((measure_condition_code_descriptions1.oid IN ( SELECT max(measure_condition_code_descriptions2.oid) AS max
-           FROM measure_condition_code_descriptions_oplog measure_condition_code_descriptions2
+           FROM public.measure_condition_code_descriptions_oplog measure_condition_code_descriptions2
           WHERE ((measure_condition_code_descriptions1.condition_code)::text = (measure_condition_code_descriptions2.condition_code)::text))) AND ((measure_condition_code_descriptions1.operation)::text <> 'D'::text));
 
 
@@ -3299,7 +3341,7 @@ CREATE VIEW measure_condition_code_descriptions AS
 -- Name: measure_condition_code_descriptions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE measure_condition_code_descriptions_oid_seq
+CREATE SEQUENCE public.measure_condition_code_descriptions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3311,14 +3353,14 @@ CREATE SEQUENCE measure_condition_code_descriptions_oid_seq
 -- Name: measure_condition_code_descriptions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE measure_condition_code_descriptions_oid_seq OWNED BY measure_condition_code_descriptions_oplog.oid;
+ALTER SEQUENCE public.measure_condition_code_descriptions_oid_seq OWNED BY public.measure_condition_code_descriptions_oplog.oid;
 
 
 --
 -- Name: measure_condition_codes_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE measure_condition_codes_oplog (
+CREATE TABLE public.measure_condition_codes_oplog (
     condition_code character varying(255),
     validity_start_date timestamp without time zone,
     validity_end_date timestamp without time zone,
@@ -3333,16 +3375,16 @@ CREATE TABLE measure_condition_codes_oplog (
 -- Name: measure_condition_codes; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW measure_condition_codes AS
+CREATE VIEW public.measure_condition_codes AS
  SELECT measure_condition_codes1.condition_code,
     measure_condition_codes1.validity_start_date,
     measure_condition_codes1.validity_end_date,
     measure_condition_codes1.oid,
     measure_condition_codes1.operation,
     measure_condition_codes1.operation_date
-   FROM measure_condition_codes_oplog measure_condition_codes1
+   FROM public.measure_condition_codes_oplog measure_condition_codes1
   WHERE ((measure_condition_codes1.oid IN ( SELECT max(measure_condition_codes2.oid) AS max
-           FROM measure_condition_codes_oplog measure_condition_codes2
+           FROM public.measure_condition_codes_oplog measure_condition_codes2
           WHERE ((measure_condition_codes1.condition_code)::text = (measure_condition_codes2.condition_code)::text))) AND ((measure_condition_codes1.operation)::text <> 'D'::text));
 
 
@@ -3350,7 +3392,7 @@ CREATE VIEW measure_condition_codes AS
 -- Name: measure_condition_codes_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE measure_condition_codes_oid_seq
+CREATE SEQUENCE public.measure_condition_codes_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3362,14 +3404,14 @@ CREATE SEQUENCE measure_condition_codes_oid_seq
 -- Name: measure_condition_codes_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE measure_condition_codes_oid_seq OWNED BY measure_condition_codes_oplog.oid;
+ALTER SEQUENCE public.measure_condition_codes_oid_seq OWNED BY public.measure_condition_codes_oplog.oid;
 
 
 --
 -- Name: measure_condition_components_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE measure_condition_components_oplog (
+CREATE TABLE public.measure_condition_components_oplog (
     measure_condition_sid integer,
     duty_expression_id character varying(255),
     duty_amount double precision,
@@ -3387,7 +3429,7 @@ CREATE TABLE measure_condition_components_oplog (
 -- Name: measure_condition_components; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW measure_condition_components AS
+CREATE VIEW public.measure_condition_components AS
  SELECT measure_condition_components1.measure_condition_sid,
     measure_condition_components1.duty_expression_id,
     measure_condition_components1.duty_amount,
@@ -3397,9 +3439,9 @@ CREATE VIEW measure_condition_components AS
     measure_condition_components1.oid,
     measure_condition_components1.operation,
     measure_condition_components1.operation_date
-   FROM measure_condition_components_oplog measure_condition_components1
+   FROM public.measure_condition_components_oplog measure_condition_components1
   WHERE ((measure_condition_components1.oid IN ( SELECT max(measure_condition_components2.oid) AS max
-           FROM measure_condition_components_oplog measure_condition_components2
+           FROM public.measure_condition_components_oplog measure_condition_components2
           WHERE ((measure_condition_components1.measure_condition_sid = measure_condition_components2.measure_condition_sid) AND ((measure_condition_components1.duty_expression_id)::text = (measure_condition_components2.duty_expression_id)::text)))) AND ((measure_condition_components1.operation)::text <> 'D'::text));
 
 
@@ -3407,7 +3449,7 @@ CREATE VIEW measure_condition_components AS
 -- Name: measure_condition_components_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE measure_condition_components_oid_seq
+CREATE SEQUENCE public.measure_condition_components_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3419,14 +3461,14 @@ CREATE SEQUENCE measure_condition_components_oid_seq
 -- Name: measure_condition_components_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE measure_condition_components_oid_seq OWNED BY measure_condition_components_oplog.oid;
+ALTER SEQUENCE public.measure_condition_components_oid_seq OWNED BY public.measure_condition_components_oplog.oid;
 
 
 --
 -- Name: measure_conditions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE measure_conditions_oplog (
+CREATE TABLE public.measure_conditions_oplog (
     measure_condition_sid integer,
     measure_sid integer,
     condition_code character varying(255),
@@ -3449,7 +3491,7 @@ CREATE TABLE measure_conditions_oplog (
 -- Name: measure_conditions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW measure_conditions AS
+CREATE VIEW public.measure_conditions AS
  SELECT measure_conditions1.measure_condition_sid,
     measure_conditions1.measure_sid,
     measure_conditions1.condition_code,
@@ -3464,9 +3506,9 @@ CREATE VIEW measure_conditions AS
     measure_conditions1.oid,
     measure_conditions1.operation,
     measure_conditions1.operation_date
-   FROM measure_conditions_oplog measure_conditions1
+   FROM public.measure_conditions_oplog measure_conditions1
   WHERE ((measure_conditions1.oid IN ( SELECT max(measure_conditions2.oid) AS max
-           FROM measure_conditions_oplog measure_conditions2
+           FROM public.measure_conditions_oplog measure_conditions2
           WHERE (measure_conditions1.measure_condition_sid = measure_conditions2.measure_condition_sid))) AND ((measure_conditions1.operation)::text <> 'D'::text));
 
 
@@ -3474,7 +3516,7 @@ CREATE VIEW measure_conditions AS
 -- Name: measure_conditions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE measure_conditions_oid_seq
+CREATE SEQUENCE public.measure_conditions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3486,14 +3528,14 @@ CREATE SEQUENCE measure_conditions_oid_seq
 -- Name: measure_conditions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE measure_conditions_oid_seq OWNED BY measure_conditions_oplog.oid;
+ALTER SEQUENCE public.measure_conditions_oid_seq OWNED BY public.measure_conditions_oplog.oid;
 
 
 --
 -- Name: measure_excluded_geographical_areas_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE measure_excluded_geographical_areas_oplog (
+CREATE TABLE public.measure_excluded_geographical_areas_oplog (
     measure_sid integer,
     excluded_geographical_area character varying(255),
     geographical_area_sid integer,
@@ -3508,16 +3550,16 @@ CREATE TABLE measure_excluded_geographical_areas_oplog (
 -- Name: measure_excluded_geographical_areas; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW measure_excluded_geographical_areas AS
+CREATE VIEW public.measure_excluded_geographical_areas AS
  SELECT measure_excluded_geographical_areas1.measure_sid,
     measure_excluded_geographical_areas1.excluded_geographical_area,
     measure_excluded_geographical_areas1.geographical_area_sid,
     measure_excluded_geographical_areas1.oid,
     measure_excluded_geographical_areas1.operation,
     measure_excluded_geographical_areas1.operation_date
-   FROM measure_excluded_geographical_areas_oplog measure_excluded_geographical_areas1
+   FROM public.measure_excluded_geographical_areas_oplog measure_excluded_geographical_areas1
   WHERE ((measure_excluded_geographical_areas1.oid IN ( SELECT max(measure_excluded_geographical_areas2.oid) AS max
-           FROM measure_excluded_geographical_areas_oplog measure_excluded_geographical_areas2
+           FROM public.measure_excluded_geographical_areas_oplog measure_excluded_geographical_areas2
           WHERE ((measure_excluded_geographical_areas1.measure_sid = measure_excluded_geographical_areas2.measure_sid) AND (measure_excluded_geographical_areas1.geographical_area_sid = measure_excluded_geographical_areas2.geographical_area_sid)))) AND ((measure_excluded_geographical_areas1.operation)::text <> 'D'::text));
 
 
@@ -3525,7 +3567,7 @@ CREATE VIEW measure_excluded_geographical_areas AS
 -- Name: measure_excluded_geographical_areas_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE measure_excluded_geographical_areas_oid_seq
+CREATE SEQUENCE public.measure_excluded_geographical_areas_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3537,14 +3579,14 @@ CREATE SEQUENCE measure_excluded_geographical_areas_oid_seq
 -- Name: measure_excluded_geographical_areas_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE measure_excluded_geographical_areas_oid_seq OWNED BY measure_excluded_geographical_areas_oplog.oid;
+ALTER SEQUENCE public.measure_excluded_geographical_areas_oid_seq OWNED BY public.measure_excluded_geographical_areas_oplog.oid;
 
 
 --
 -- Name: measure_partial_temporary_stops_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE measure_partial_temporary_stops_oplog (
+CREATE TABLE public.measure_partial_temporary_stops_oplog (
     measure_sid integer,
     validity_start_date timestamp without time zone,
     validity_end_date timestamp without time zone,
@@ -3565,7 +3607,7 @@ CREATE TABLE measure_partial_temporary_stops_oplog (
 -- Name: measure_partial_temporary_stops; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW measure_partial_temporary_stops AS
+CREATE VIEW public.measure_partial_temporary_stops AS
  SELECT measure_partial_temporary_stops1.measure_sid,
     measure_partial_temporary_stops1.validity_start_date,
     measure_partial_temporary_stops1.validity_end_date,
@@ -3578,9 +3620,9 @@ CREATE VIEW measure_partial_temporary_stops AS
     measure_partial_temporary_stops1.oid,
     measure_partial_temporary_stops1.operation,
     measure_partial_temporary_stops1.operation_date
-   FROM measure_partial_temporary_stops_oplog measure_partial_temporary_stops1
+   FROM public.measure_partial_temporary_stops_oplog measure_partial_temporary_stops1
   WHERE ((measure_partial_temporary_stops1.oid IN ( SELECT max(measure_partial_temporary_stops2.oid) AS max
-           FROM measure_partial_temporary_stops_oplog measure_partial_temporary_stops2
+           FROM public.measure_partial_temporary_stops_oplog measure_partial_temporary_stops2
           WHERE ((measure_partial_temporary_stops1.measure_sid = measure_partial_temporary_stops2.measure_sid) AND ((measure_partial_temporary_stops1.partial_temporary_stop_regulation_id)::text = (measure_partial_temporary_stops2.partial_temporary_stop_regulation_id)::text)))) AND ((measure_partial_temporary_stops1.operation)::text <> 'D'::text));
 
 
@@ -3588,7 +3630,7 @@ CREATE VIEW measure_partial_temporary_stops AS
 -- Name: measure_partial_temporary_stops_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE measure_partial_temporary_stops_oid_seq
+CREATE SEQUENCE public.measure_partial_temporary_stops_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3600,14 +3642,14 @@ CREATE SEQUENCE measure_partial_temporary_stops_oid_seq
 -- Name: measure_partial_temporary_stops_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE measure_partial_temporary_stops_oid_seq OWNED BY measure_partial_temporary_stops_oplog.oid;
+ALTER SEQUENCE public.measure_partial_temporary_stops_oid_seq OWNED BY public.measure_partial_temporary_stops_oplog.oid;
 
 
 --
 -- Name: measure_type_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE measure_type_descriptions_oplog (
+CREATE TABLE public.measure_type_descriptions_oplog (
     measure_type_id character varying(3),
     language_id character varying(5),
     description text,
@@ -3623,7 +3665,7 @@ CREATE TABLE measure_type_descriptions_oplog (
 -- Name: measure_type_descriptions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW measure_type_descriptions AS
+CREATE VIEW public.measure_type_descriptions AS
  SELECT measure_type_descriptions1.measure_type_id,
     measure_type_descriptions1.language_id,
     measure_type_descriptions1.description,
@@ -3631,9 +3673,9 @@ CREATE VIEW measure_type_descriptions AS
     measure_type_descriptions1.oid,
     measure_type_descriptions1.operation,
     measure_type_descriptions1.operation_date
-   FROM measure_type_descriptions_oplog measure_type_descriptions1
+   FROM public.measure_type_descriptions_oplog measure_type_descriptions1
   WHERE ((measure_type_descriptions1.oid IN ( SELECT max(measure_type_descriptions2.oid) AS max
-           FROM measure_type_descriptions_oplog measure_type_descriptions2
+           FROM public.measure_type_descriptions_oplog measure_type_descriptions2
           WHERE ((measure_type_descriptions1.measure_type_id)::text = (measure_type_descriptions2.measure_type_id)::text))) AND ((measure_type_descriptions1.operation)::text <> 'D'::text));
 
 
@@ -3641,7 +3683,7 @@ CREATE VIEW measure_type_descriptions AS
 -- Name: measure_type_descriptions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE measure_type_descriptions_oid_seq
+CREATE SEQUENCE public.measure_type_descriptions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3653,14 +3695,14 @@ CREATE SEQUENCE measure_type_descriptions_oid_seq
 -- Name: measure_type_descriptions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE measure_type_descriptions_oid_seq OWNED BY measure_type_descriptions_oplog.oid;
+ALTER SEQUENCE public.measure_type_descriptions_oid_seq OWNED BY public.measure_type_descriptions_oplog.oid;
 
 
 --
 -- Name: measure_type_series_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE measure_type_series_oplog (
+CREATE TABLE public.measure_type_series_oplog (
     measure_type_series_id character varying(255),
     validity_start_date timestamp without time zone,
     validity_end_date timestamp without time zone,
@@ -3676,7 +3718,7 @@ CREATE TABLE measure_type_series_oplog (
 -- Name: measure_type_series; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW measure_type_series AS
+CREATE VIEW public.measure_type_series AS
  SELECT measure_type_series1.measure_type_series_id,
     measure_type_series1.validity_start_date,
     measure_type_series1.validity_end_date,
@@ -3684,9 +3726,9 @@ CREATE VIEW measure_type_series AS
     measure_type_series1.oid,
     measure_type_series1.operation,
     measure_type_series1.operation_date
-   FROM measure_type_series_oplog measure_type_series1
+   FROM public.measure_type_series_oplog measure_type_series1
   WHERE ((measure_type_series1.oid IN ( SELECT max(measure_type_series2.oid) AS max
-           FROM measure_type_series_oplog measure_type_series2
+           FROM public.measure_type_series_oplog measure_type_series2
           WHERE ((measure_type_series1.measure_type_series_id)::text = (measure_type_series2.measure_type_series_id)::text))) AND ((measure_type_series1.operation)::text <> 'D'::text));
 
 
@@ -3694,7 +3736,7 @@ CREATE VIEW measure_type_series AS
 -- Name: measure_type_series_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE measure_type_series_descriptions_oplog (
+CREATE TABLE public.measure_type_series_descriptions_oplog (
     measure_type_series_id character varying(255),
     language_id character varying(5),
     description text,
@@ -3709,16 +3751,16 @@ CREATE TABLE measure_type_series_descriptions_oplog (
 -- Name: measure_type_series_descriptions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW measure_type_series_descriptions AS
+CREATE VIEW public.measure_type_series_descriptions AS
  SELECT measure_type_series_descriptions1.measure_type_series_id,
     measure_type_series_descriptions1.language_id,
     measure_type_series_descriptions1.description,
     measure_type_series_descriptions1.oid,
     measure_type_series_descriptions1.operation,
     measure_type_series_descriptions1.operation_date
-   FROM measure_type_series_descriptions_oplog measure_type_series_descriptions1
+   FROM public.measure_type_series_descriptions_oplog measure_type_series_descriptions1
   WHERE ((measure_type_series_descriptions1.oid IN ( SELECT max(measure_type_series_descriptions2.oid) AS max
-           FROM measure_type_series_descriptions_oplog measure_type_series_descriptions2
+           FROM public.measure_type_series_descriptions_oplog measure_type_series_descriptions2
           WHERE ((measure_type_series_descriptions1.measure_type_series_id)::text = (measure_type_series_descriptions2.measure_type_series_id)::text))) AND ((measure_type_series_descriptions1.operation)::text <> 'D'::text));
 
 
@@ -3726,7 +3768,7 @@ CREATE VIEW measure_type_series_descriptions AS
 -- Name: measure_type_series_descriptions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE measure_type_series_descriptions_oid_seq
+CREATE SEQUENCE public.measure_type_series_descriptions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3738,14 +3780,14 @@ CREATE SEQUENCE measure_type_series_descriptions_oid_seq
 -- Name: measure_type_series_descriptions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE measure_type_series_descriptions_oid_seq OWNED BY measure_type_series_descriptions_oplog.oid;
+ALTER SEQUENCE public.measure_type_series_descriptions_oid_seq OWNED BY public.measure_type_series_descriptions_oplog.oid;
 
 
 --
 -- Name: measure_type_series_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE measure_type_series_oid_seq
+CREATE SEQUENCE public.measure_type_series_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3757,14 +3799,14 @@ CREATE SEQUENCE measure_type_series_oid_seq
 -- Name: measure_type_series_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE measure_type_series_oid_seq OWNED BY measure_type_series_oplog.oid;
+ALTER SEQUENCE public.measure_type_series_oid_seq OWNED BY public.measure_type_series_oplog.oid;
 
 
 --
 -- Name: measure_types_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE measure_types_oplog (
+CREATE TABLE public.measure_types_oplog (
     measure_type_id character varying(3),
     validity_start_date timestamp without time zone,
     validity_end_date timestamp without time zone,
@@ -3788,7 +3830,7 @@ CREATE TABLE measure_types_oplog (
 -- Name: measure_types; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW measure_types AS
+CREATE VIEW public.measure_types AS
  SELECT measure_types1.measure_type_id,
     measure_types1.validity_start_date,
     measure_types1.validity_end_date,
@@ -3804,9 +3846,9 @@ CREATE VIEW measure_types AS
     measure_types1.oid,
     measure_types1.operation,
     measure_types1.operation_date
-   FROM measure_types_oplog measure_types1
+   FROM public.measure_types_oplog measure_types1
   WHERE ((measure_types1.oid IN ( SELECT max(measure_types2.oid) AS max
-           FROM measure_types_oplog measure_types2
+           FROM public.measure_types_oplog measure_types2
           WHERE ((measure_types1.measure_type_id)::text = (measure_types2.measure_type_id)::text))) AND ((measure_types1.operation)::text <> 'D'::text));
 
 
@@ -3814,7 +3856,7 @@ CREATE VIEW measure_types AS
 -- Name: measure_types_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE measure_types_oid_seq
+CREATE SEQUENCE public.measure_types_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3826,14 +3868,14 @@ CREATE SEQUENCE measure_types_oid_seq
 -- Name: measure_types_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE measure_types_oid_seq OWNED BY measure_types_oplog.oid;
+ALTER SEQUENCE public.measure_types_oid_seq OWNED BY public.measure_types_oplog.oid;
 
 
 --
 -- Name: measurement_unit_abbreviations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE measurement_unit_abbreviations (
+CREATE TABLE public.measurement_unit_abbreviations (
     id integer NOT NULL,
     abbreviation text,
     measurement_unit_code text,
@@ -3845,7 +3887,7 @@ CREATE TABLE measurement_unit_abbreviations (
 -- Name: measurement_unit_abbreviations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE measurement_unit_abbreviations_id_seq
+CREATE SEQUENCE public.measurement_unit_abbreviations_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3857,14 +3899,14 @@ CREATE SEQUENCE measurement_unit_abbreviations_id_seq
 -- Name: measurement_unit_abbreviations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE measurement_unit_abbreviations_id_seq OWNED BY measurement_unit_abbreviations.id;
+ALTER SEQUENCE public.measurement_unit_abbreviations_id_seq OWNED BY public.measurement_unit_abbreviations.id;
 
 
 --
 -- Name: measurement_unit_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE measurement_unit_descriptions_oplog (
+CREATE TABLE public.measurement_unit_descriptions_oplog (
     measurement_unit_code character varying(3),
     language_id character varying(5),
     description text,
@@ -3879,16 +3921,16 @@ CREATE TABLE measurement_unit_descriptions_oplog (
 -- Name: measurement_unit_descriptions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW measurement_unit_descriptions AS
+CREATE VIEW public.measurement_unit_descriptions AS
  SELECT measurement_unit_descriptions1.measurement_unit_code,
     measurement_unit_descriptions1.language_id,
     measurement_unit_descriptions1.description,
     measurement_unit_descriptions1.oid,
     measurement_unit_descriptions1.operation,
     measurement_unit_descriptions1.operation_date
-   FROM measurement_unit_descriptions_oplog measurement_unit_descriptions1
+   FROM public.measurement_unit_descriptions_oplog measurement_unit_descriptions1
   WHERE ((measurement_unit_descriptions1.oid IN ( SELECT max(measurement_unit_descriptions2.oid) AS max
-           FROM measurement_unit_descriptions_oplog measurement_unit_descriptions2
+           FROM public.measurement_unit_descriptions_oplog measurement_unit_descriptions2
           WHERE ((measurement_unit_descriptions1.measurement_unit_code)::text = (measurement_unit_descriptions2.measurement_unit_code)::text))) AND ((measurement_unit_descriptions1.operation)::text <> 'D'::text));
 
 
@@ -3896,7 +3938,7 @@ CREATE VIEW measurement_unit_descriptions AS
 -- Name: measurement_unit_descriptions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE measurement_unit_descriptions_oid_seq
+CREATE SEQUENCE public.measurement_unit_descriptions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3908,14 +3950,14 @@ CREATE SEQUENCE measurement_unit_descriptions_oid_seq
 -- Name: measurement_unit_descriptions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE measurement_unit_descriptions_oid_seq OWNED BY measurement_unit_descriptions_oplog.oid;
+ALTER SEQUENCE public.measurement_unit_descriptions_oid_seq OWNED BY public.measurement_unit_descriptions_oplog.oid;
 
 
 --
 -- Name: measurement_unit_qualifier_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE measurement_unit_qualifier_descriptions_oplog (
+CREATE TABLE public.measurement_unit_qualifier_descriptions_oplog (
     measurement_unit_qualifier_code character varying(1),
     language_id character varying(5),
     description text,
@@ -3930,16 +3972,16 @@ CREATE TABLE measurement_unit_qualifier_descriptions_oplog (
 -- Name: measurement_unit_qualifier_descriptions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW measurement_unit_qualifier_descriptions AS
+CREATE VIEW public.measurement_unit_qualifier_descriptions AS
  SELECT measurement_unit_qualifier_descriptions1.measurement_unit_qualifier_code,
     measurement_unit_qualifier_descriptions1.language_id,
     measurement_unit_qualifier_descriptions1.description,
     measurement_unit_qualifier_descriptions1.oid,
     measurement_unit_qualifier_descriptions1.operation,
     measurement_unit_qualifier_descriptions1.operation_date
-   FROM measurement_unit_qualifier_descriptions_oplog measurement_unit_qualifier_descriptions1
+   FROM public.measurement_unit_qualifier_descriptions_oplog measurement_unit_qualifier_descriptions1
   WHERE ((measurement_unit_qualifier_descriptions1.oid IN ( SELECT max(measurement_unit_qualifier_descriptions2.oid) AS max
-           FROM measurement_unit_qualifier_descriptions_oplog measurement_unit_qualifier_descriptions2
+           FROM public.measurement_unit_qualifier_descriptions_oplog measurement_unit_qualifier_descriptions2
           WHERE ((measurement_unit_qualifier_descriptions1.measurement_unit_qualifier_code)::text = (measurement_unit_qualifier_descriptions2.measurement_unit_qualifier_code)::text))) AND ((measurement_unit_qualifier_descriptions1.operation)::text <> 'D'::text));
 
 
@@ -3947,7 +3989,7 @@ CREATE VIEW measurement_unit_qualifier_descriptions AS
 -- Name: measurement_unit_qualifier_descriptions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE measurement_unit_qualifier_descriptions_oid_seq
+CREATE SEQUENCE public.measurement_unit_qualifier_descriptions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3959,14 +4001,14 @@ CREATE SEQUENCE measurement_unit_qualifier_descriptions_oid_seq
 -- Name: measurement_unit_qualifier_descriptions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE measurement_unit_qualifier_descriptions_oid_seq OWNED BY measurement_unit_qualifier_descriptions_oplog.oid;
+ALTER SEQUENCE public.measurement_unit_qualifier_descriptions_oid_seq OWNED BY public.measurement_unit_qualifier_descriptions_oplog.oid;
 
 
 --
 -- Name: measurement_unit_qualifiers_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE measurement_unit_qualifiers_oplog (
+CREATE TABLE public.measurement_unit_qualifiers_oplog (
     measurement_unit_qualifier_code character varying(1),
     validity_start_date timestamp without time zone,
     validity_end_date timestamp without time zone,
@@ -3981,16 +4023,16 @@ CREATE TABLE measurement_unit_qualifiers_oplog (
 -- Name: measurement_unit_qualifiers; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW measurement_unit_qualifiers AS
+CREATE VIEW public.measurement_unit_qualifiers AS
  SELECT measurement_unit_qualifiers1.measurement_unit_qualifier_code,
     measurement_unit_qualifiers1.validity_start_date,
     measurement_unit_qualifiers1.validity_end_date,
     measurement_unit_qualifiers1.oid,
     measurement_unit_qualifiers1.operation,
     measurement_unit_qualifiers1.operation_date
-   FROM measurement_unit_qualifiers_oplog measurement_unit_qualifiers1
+   FROM public.measurement_unit_qualifiers_oplog measurement_unit_qualifiers1
   WHERE ((measurement_unit_qualifiers1.oid IN ( SELECT max(measurement_unit_qualifiers2.oid) AS max
-           FROM measurement_unit_qualifiers_oplog measurement_unit_qualifiers2
+           FROM public.measurement_unit_qualifiers_oplog measurement_unit_qualifiers2
           WHERE ((measurement_unit_qualifiers1.measurement_unit_qualifier_code)::text = (measurement_unit_qualifiers2.measurement_unit_qualifier_code)::text))) AND ((measurement_unit_qualifiers1.operation)::text <> 'D'::text));
 
 
@@ -3998,7 +4040,7 @@ CREATE VIEW measurement_unit_qualifiers AS
 -- Name: measurement_unit_qualifiers_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE measurement_unit_qualifiers_oid_seq
+CREATE SEQUENCE public.measurement_unit_qualifiers_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -4010,14 +4052,14 @@ CREATE SEQUENCE measurement_unit_qualifiers_oid_seq
 -- Name: measurement_unit_qualifiers_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE measurement_unit_qualifiers_oid_seq OWNED BY measurement_unit_qualifiers_oplog.oid;
+ALTER SEQUENCE public.measurement_unit_qualifiers_oid_seq OWNED BY public.measurement_unit_qualifiers_oplog.oid;
 
 
 --
 -- Name: measurement_units_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE measurement_units_oplog (
+CREATE TABLE public.measurement_units_oplog (
     measurement_unit_code character varying(3),
     validity_start_date timestamp without time zone,
     validity_end_date timestamp without time zone,
@@ -4032,16 +4074,16 @@ CREATE TABLE measurement_units_oplog (
 -- Name: measurement_units; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW measurement_units AS
+CREATE VIEW public.measurement_units AS
  SELECT measurement_units1.measurement_unit_code,
     measurement_units1.validity_start_date,
     measurement_units1.validity_end_date,
     measurement_units1.oid,
     measurement_units1.operation,
     measurement_units1.operation_date
-   FROM measurement_units_oplog measurement_units1
+   FROM public.measurement_units_oplog measurement_units1
   WHERE ((measurement_units1.oid IN ( SELECT max(measurement_units2.oid) AS max
-           FROM measurement_units_oplog measurement_units2
+           FROM public.measurement_units_oplog measurement_units2
           WHERE ((measurement_units1.measurement_unit_code)::text = (measurement_units2.measurement_unit_code)::text))) AND ((measurement_units1.operation)::text <> 'D'::text));
 
 
@@ -4049,7 +4091,7 @@ CREATE VIEW measurement_units AS
 -- Name: measurement_units_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE measurement_units_oid_seq
+CREATE SEQUENCE public.measurement_units_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -4061,14 +4103,14 @@ CREATE SEQUENCE measurement_units_oid_seq
 -- Name: measurement_units_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE measurement_units_oid_seq OWNED BY measurement_units_oplog.oid;
+ALTER SEQUENCE public.measurement_units_oid_seq OWNED BY public.measurement_units_oplog.oid;
 
 
 --
 -- Name: measurements_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE measurements_oplog (
+CREATE TABLE public.measurements_oplog (
     measurement_unit_code character varying(3),
     measurement_unit_qualifier_code character varying(1),
     validity_start_date timestamp without time zone,
@@ -4084,7 +4126,7 @@ CREATE TABLE measurements_oplog (
 -- Name: measurements; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW measurements AS
+CREATE VIEW public.measurements AS
  SELECT measurements1.measurement_unit_code,
     measurements1.measurement_unit_qualifier_code,
     measurements1.validity_start_date,
@@ -4092,9 +4134,9 @@ CREATE VIEW measurements AS
     measurements1.oid,
     measurements1.operation,
     measurements1.operation_date
-   FROM measurements_oplog measurements1
+   FROM public.measurements_oplog measurements1
   WHERE ((measurements1.oid IN ( SELECT max(measurements2.oid) AS max
-           FROM measurements_oplog measurements2
+           FROM public.measurements_oplog measurements2
           WHERE (((measurements1.measurement_unit_code)::text = (measurements2.measurement_unit_code)::text) AND ((measurements1.measurement_unit_qualifier_code)::text = (measurements2.measurement_unit_qualifier_code)::text)))) AND ((measurements1.operation)::text <> 'D'::text));
 
 
@@ -4102,7 +4144,7 @@ CREATE VIEW measurements AS
 -- Name: measurements_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE measurements_oid_seq
+CREATE SEQUENCE public.measurements_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -4114,14 +4156,14 @@ CREATE SEQUENCE measurements_oid_seq
 -- Name: measurements_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE measurements_oid_seq OWNED BY measurements_oplog.oid;
+ALTER SEQUENCE public.measurements_oid_seq OWNED BY public.measurements_oplog.oid;
 
 
 --
 -- Name: measures_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE measures_oplog (
+CREATE TABLE public.measures_oplog (
     measure_sid integer,
     measure_type_id character varying(3),
     geographical_area_id character varying(255),
@@ -4156,7 +4198,7 @@ CREATE TABLE measures_oplog (
 -- Name: measures; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW measures AS
+CREATE VIEW public.measures AS
  SELECT measures1.measure_sid,
     measures1.measure_type_id,
     measures1.geographical_area_id,
@@ -4183,9 +4225,9 @@ CREATE VIEW measures AS
     measures1.oid,
     measures1.operation,
     measures1.operation_date
-   FROM measures_oplog measures1
+   FROM public.measures_oplog measures1
   WHERE ((measures1.oid IN ( SELECT max(measures2.oid) AS max
-           FROM measures_oplog measures2
+           FROM public.measures_oplog measures2
           WHERE (measures1.measure_sid = measures2.measure_sid))) AND ((measures1.operation)::text <> 'D'::text));
 
 
@@ -4193,7 +4235,7 @@ CREATE VIEW measures AS
 -- Name: measures_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE measures_oid_seq
+CREATE SEQUENCE public.measures_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -4205,14 +4247,14 @@ CREATE SEQUENCE measures_oid_seq
 -- Name: measures_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE measures_oid_seq OWNED BY measures_oplog.oid;
+ALTER SEQUENCE public.measures_oid_seq OWNED BY public.measures_oplog.oid;
 
 
 --
 -- Name: meursing_additional_codes_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE meursing_additional_codes_oplog (
+CREATE TABLE public.meursing_additional_codes_oplog (
     meursing_additional_code_sid integer,
     additional_code character varying(3),
     validity_start_date timestamp without time zone,
@@ -4228,7 +4270,7 @@ CREATE TABLE meursing_additional_codes_oplog (
 -- Name: meursing_additional_codes; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW meursing_additional_codes AS
+CREATE VIEW public.meursing_additional_codes AS
  SELECT meursing_additional_codes1.meursing_additional_code_sid,
     meursing_additional_codes1.additional_code,
     meursing_additional_codes1.validity_start_date,
@@ -4236,9 +4278,9 @@ CREATE VIEW meursing_additional_codes AS
     meursing_additional_codes1.oid,
     meursing_additional_codes1.operation,
     meursing_additional_codes1.operation_date
-   FROM meursing_additional_codes_oplog meursing_additional_codes1
+   FROM public.meursing_additional_codes_oplog meursing_additional_codes1
   WHERE ((meursing_additional_codes1.oid IN ( SELECT max(meursing_additional_codes2.oid) AS max
-           FROM meursing_additional_codes_oplog meursing_additional_codes2
+           FROM public.meursing_additional_codes_oplog meursing_additional_codes2
           WHERE (meursing_additional_codes1.meursing_additional_code_sid = meursing_additional_codes2.meursing_additional_code_sid))) AND ((meursing_additional_codes1.operation)::text <> 'D'::text));
 
 
@@ -4246,7 +4288,7 @@ CREATE VIEW meursing_additional_codes AS
 -- Name: meursing_additional_codes_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE meursing_additional_codes_oid_seq
+CREATE SEQUENCE public.meursing_additional_codes_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -4258,14 +4300,14 @@ CREATE SEQUENCE meursing_additional_codes_oid_seq
 -- Name: meursing_additional_codes_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE meursing_additional_codes_oid_seq OWNED BY meursing_additional_codes_oplog.oid;
+ALTER SEQUENCE public.meursing_additional_codes_oid_seq OWNED BY public.meursing_additional_codes_oplog.oid;
 
 
 --
 -- Name: meursing_heading_texts_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE meursing_heading_texts_oplog (
+CREATE TABLE public.meursing_heading_texts_oplog (
     meursing_table_plan_id character varying(2),
     meursing_heading_number integer,
     row_column_code integer,
@@ -4282,7 +4324,7 @@ CREATE TABLE meursing_heading_texts_oplog (
 -- Name: meursing_heading_texts; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW meursing_heading_texts AS
+CREATE VIEW public.meursing_heading_texts AS
  SELECT meursing_heading_texts1.meursing_table_plan_id,
     meursing_heading_texts1.meursing_heading_number,
     meursing_heading_texts1.row_column_code,
@@ -4291,9 +4333,9 @@ CREATE VIEW meursing_heading_texts AS
     meursing_heading_texts1.oid,
     meursing_heading_texts1.operation,
     meursing_heading_texts1.operation_date
-   FROM meursing_heading_texts_oplog meursing_heading_texts1
+   FROM public.meursing_heading_texts_oplog meursing_heading_texts1
   WHERE ((meursing_heading_texts1.oid IN ( SELECT max(meursing_heading_texts2.oid) AS max
-           FROM meursing_heading_texts_oplog meursing_heading_texts2
+           FROM public.meursing_heading_texts_oplog meursing_heading_texts2
           WHERE (((meursing_heading_texts1.meursing_table_plan_id)::text = (meursing_heading_texts2.meursing_table_plan_id)::text) AND (meursing_heading_texts1.meursing_heading_number = meursing_heading_texts2.meursing_heading_number) AND (meursing_heading_texts1.row_column_code = meursing_heading_texts2.row_column_code)))) AND ((meursing_heading_texts1.operation)::text <> 'D'::text));
 
 
@@ -4301,7 +4343,7 @@ CREATE VIEW meursing_heading_texts AS
 -- Name: meursing_heading_texts_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE meursing_heading_texts_oid_seq
+CREATE SEQUENCE public.meursing_heading_texts_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -4313,14 +4355,14 @@ CREATE SEQUENCE meursing_heading_texts_oid_seq
 -- Name: meursing_heading_texts_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE meursing_heading_texts_oid_seq OWNED BY meursing_heading_texts_oplog.oid;
+ALTER SEQUENCE public.meursing_heading_texts_oid_seq OWNED BY public.meursing_heading_texts_oplog.oid;
 
 
 --
 -- Name: meursing_headings_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE meursing_headings_oplog (
+CREATE TABLE public.meursing_headings_oplog (
     meursing_table_plan_id character varying(2),
     meursing_heading_number text,
     row_column_code integer,
@@ -4337,7 +4379,7 @@ CREATE TABLE meursing_headings_oplog (
 -- Name: meursing_headings; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW meursing_headings AS
+CREATE VIEW public.meursing_headings AS
  SELECT meursing_headings1.meursing_table_plan_id,
     meursing_headings1.meursing_heading_number,
     meursing_headings1.row_column_code,
@@ -4346,9 +4388,9 @@ CREATE VIEW meursing_headings AS
     meursing_headings1.oid,
     meursing_headings1.operation,
     meursing_headings1.operation_date
-   FROM meursing_headings_oplog meursing_headings1
+   FROM public.meursing_headings_oplog meursing_headings1
   WHERE ((meursing_headings1.oid IN ( SELECT max(meursing_headings2.oid) AS max
-           FROM meursing_headings_oplog meursing_headings2
+           FROM public.meursing_headings_oplog meursing_headings2
           WHERE (((meursing_headings1.meursing_table_plan_id)::text = (meursing_headings2.meursing_table_plan_id)::text) AND (meursing_headings1.meursing_heading_number = meursing_headings2.meursing_heading_number) AND (meursing_headings1.row_column_code = meursing_headings2.row_column_code)))) AND ((meursing_headings1.operation)::text <> 'D'::text));
 
 
@@ -4356,7 +4398,7 @@ CREATE VIEW meursing_headings AS
 -- Name: meursing_headings_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE meursing_headings_oid_seq
+CREATE SEQUENCE public.meursing_headings_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -4368,14 +4410,14 @@ CREATE SEQUENCE meursing_headings_oid_seq
 -- Name: meursing_headings_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE meursing_headings_oid_seq OWNED BY meursing_headings_oplog.oid;
+ALTER SEQUENCE public.meursing_headings_oid_seq OWNED BY public.meursing_headings_oplog.oid;
 
 
 --
 -- Name: meursing_subheadings_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE meursing_subheadings_oplog (
+CREATE TABLE public.meursing_subheadings_oplog (
     meursing_table_plan_id character varying(2),
     meursing_heading_number integer,
     row_column_code integer,
@@ -4394,7 +4436,7 @@ CREATE TABLE meursing_subheadings_oplog (
 -- Name: meursing_subheadings; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW meursing_subheadings AS
+CREATE VIEW public.meursing_subheadings AS
  SELECT meursing_subheadings1.meursing_table_plan_id,
     meursing_subheadings1.meursing_heading_number,
     meursing_subheadings1.row_column_code,
@@ -4405,9 +4447,9 @@ CREATE VIEW meursing_subheadings AS
     meursing_subheadings1.oid,
     meursing_subheadings1.operation,
     meursing_subheadings1.operation_date
-   FROM meursing_subheadings_oplog meursing_subheadings1
+   FROM public.meursing_subheadings_oplog meursing_subheadings1
   WHERE ((meursing_subheadings1.oid IN ( SELECT max(meursing_subheadings2.oid) AS max
-           FROM meursing_subheadings_oplog meursing_subheadings2
+           FROM public.meursing_subheadings_oplog meursing_subheadings2
           WHERE (((meursing_subheadings1.meursing_table_plan_id)::text = (meursing_subheadings2.meursing_table_plan_id)::text) AND (meursing_subheadings1.meursing_heading_number = meursing_subheadings2.meursing_heading_number) AND (meursing_subheadings1.row_column_code = meursing_subheadings2.row_column_code) AND (meursing_subheadings1.subheading_sequence_number = meursing_subheadings2.subheading_sequence_number)))) AND ((meursing_subheadings1.operation)::text <> 'D'::text));
 
 
@@ -4415,7 +4457,7 @@ CREATE VIEW meursing_subheadings AS
 -- Name: meursing_subheadings_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE meursing_subheadings_oid_seq
+CREATE SEQUENCE public.meursing_subheadings_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -4427,14 +4469,14 @@ CREATE SEQUENCE meursing_subheadings_oid_seq
 -- Name: meursing_subheadings_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE meursing_subheadings_oid_seq OWNED BY meursing_subheadings_oplog.oid;
+ALTER SEQUENCE public.meursing_subheadings_oid_seq OWNED BY public.meursing_subheadings_oplog.oid;
 
 
 --
 -- Name: meursing_table_cell_components_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE meursing_table_cell_components_oplog (
+CREATE TABLE public.meursing_table_cell_components_oplog (
     meursing_additional_code_sid integer,
     meursing_table_plan_id character varying(2),
     heading_number integer,
@@ -4454,7 +4496,7 @@ CREATE TABLE meursing_table_cell_components_oplog (
 -- Name: meursing_table_cell_components; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW meursing_table_cell_components AS
+CREATE VIEW public.meursing_table_cell_components AS
  SELECT meursing_table_cell_components1.meursing_additional_code_sid,
     meursing_table_cell_components1.meursing_table_plan_id,
     meursing_table_cell_components1.heading_number,
@@ -4466,9 +4508,9 @@ CREATE VIEW meursing_table_cell_components AS
     meursing_table_cell_components1.oid,
     meursing_table_cell_components1.operation,
     meursing_table_cell_components1.operation_date
-   FROM meursing_table_cell_components_oplog meursing_table_cell_components1
+   FROM public.meursing_table_cell_components_oplog meursing_table_cell_components1
   WHERE ((meursing_table_cell_components1.oid IN ( SELECT max(meursing_table_cell_components2.oid) AS max
-           FROM meursing_table_cell_components_oplog meursing_table_cell_components2
+           FROM public.meursing_table_cell_components_oplog meursing_table_cell_components2
           WHERE (((meursing_table_cell_components1.meursing_table_plan_id)::text = (meursing_table_cell_components2.meursing_table_plan_id)::text) AND (meursing_table_cell_components1.heading_number = meursing_table_cell_components2.heading_number) AND (meursing_table_cell_components1.row_column_code = meursing_table_cell_components2.row_column_code) AND (meursing_table_cell_components1.meursing_additional_code_sid = meursing_table_cell_components2.meursing_additional_code_sid)))) AND ((meursing_table_cell_components1.operation)::text <> 'D'::text));
 
 
@@ -4476,7 +4518,7 @@ CREATE VIEW meursing_table_cell_components AS
 -- Name: meursing_table_cell_components_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE meursing_table_cell_components_oid_seq
+CREATE SEQUENCE public.meursing_table_cell_components_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -4488,14 +4530,14 @@ CREATE SEQUENCE meursing_table_cell_components_oid_seq
 -- Name: meursing_table_cell_components_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE meursing_table_cell_components_oid_seq OWNED BY meursing_table_cell_components_oplog.oid;
+ALTER SEQUENCE public.meursing_table_cell_components_oid_seq OWNED BY public.meursing_table_cell_components_oplog.oid;
 
 
 --
 -- Name: meursing_table_plans_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE meursing_table_plans_oplog (
+CREATE TABLE public.meursing_table_plans_oplog (
     meursing_table_plan_id character varying(2),
     validity_start_date timestamp without time zone,
     validity_end_date timestamp without time zone,
@@ -4510,16 +4552,16 @@ CREATE TABLE meursing_table_plans_oplog (
 -- Name: meursing_table_plans; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW meursing_table_plans AS
+CREATE VIEW public.meursing_table_plans AS
  SELECT meursing_table_plans1.meursing_table_plan_id,
     meursing_table_plans1.validity_start_date,
     meursing_table_plans1.validity_end_date,
     meursing_table_plans1.oid,
     meursing_table_plans1.operation,
     meursing_table_plans1.operation_date
-   FROM meursing_table_plans_oplog meursing_table_plans1
+   FROM public.meursing_table_plans_oplog meursing_table_plans1
   WHERE ((meursing_table_plans1.oid IN ( SELECT max(meursing_table_plans2.oid) AS max
-           FROM meursing_table_plans_oplog meursing_table_plans2
+           FROM public.meursing_table_plans_oplog meursing_table_plans2
           WHERE ((meursing_table_plans1.meursing_table_plan_id)::text = (meursing_table_plans2.meursing_table_plan_id)::text))) AND ((meursing_table_plans1.operation)::text <> 'D'::text));
 
 
@@ -4527,7 +4569,7 @@ CREATE VIEW meursing_table_plans AS
 -- Name: meursing_table_plans_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE meursing_table_plans_oid_seq
+CREATE SEQUENCE public.meursing_table_plans_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -4539,14 +4581,14 @@ CREATE SEQUENCE meursing_table_plans_oid_seq
 -- Name: meursing_table_plans_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE meursing_table_plans_oid_seq OWNED BY meursing_table_plans_oplog.oid;
+ALTER SEQUENCE public.meursing_table_plans_oid_seq OWNED BY public.meursing_table_plans_oplog.oid;
 
 
 --
 -- Name: modification_regulations_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE modification_regulations_oplog (
+CREATE TABLE public.modification_regulations_oplog (
     modification_regulation_role integer,
     modification_regulation_id character varying(255),
     validity_start_date timestamp without time zone,
@@ -4576,7 +4618,7 @@ CREATE TABLE modification_regulations_oplog (
 -- Name: modification_regulations; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW modification_regulations AS
+CREATE VIEW public.modification_regulations AS
  SELECT modification_regulations1.modification_regulation_role,
     modification_regulations1.modification_regulation_id,
     modification_regulations1.validity_start_date,
@@ -4598,9 +4640,9 @@ CREATE VIEW modification_regulations AS
     modification_regulations1.oid,
     modification_regulations1.operation,
     modification_regulations1.operation_date
-   FROM modification_regulations_oplog modification_regulations1
+   FROM public.modification_regulations_oplog modification_regulations1
   WHERE ((modification_regulations1.oid IN ( SELECT max(modification_regulations2.oid) AS max
-           FROM modification_regulations_oplog modification_regulations2
+           FROM public.modification_regulations_oplog modification_regulations2
           WHERE (((modification_regulations1.modification_regulation_id)::text = (modification_regulations2.modification_regulation_id)::text) AND (modification_regulations1.modification_regulation_role = modification_regulations2.modification_regulation_role)))) AND ((modification_regulations1.operation)::text <> 'D'::text));
 
 
@@ -4608,7 +4650,7 @@ CREATE VIEW modification_regulations AS
 -- Name: modification_regulations_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE modification_regulations_oid_seq
+CREATE SEQUENCE public.modification_regulations_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -4620,14 +4662,14 @@ CREATE SEQUENCE modification_regulations_oid_seq
 -- Name: modification_regulations_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE modification_regulations_oid_seq OWNED BY modification_regulations_oplog.oid;
+ALTER SEQUENCE public.modification_regulations_oid_seq OWNED BY public.modification_regulations_oplog.oid;
 
 
 --
 -- Name: monetary_exchange_periods_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE monetary_exchange_periods_oplog (
+CREATE TABLE public.monetary_exchange_periods_oplog (
     monetary_exchange_period_sid integer,
     parent_monetary_unit_code character varying(255),
     validity_start_date timestamp without time zone,
@@ -4643,7 +4685,7 @@ CREATE TABLE monetary_exchange_periods_oplog (
 -- Name: monetary_exchange_periods; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW monetary_exchange_periods AS
+CREATE VIEW public.monetary_exchange_periods AS
  SELECT monetary_exchange_periods1.monetary_exchange_period_sid,
     monetary_exchange_periods1.parent_monetary_unit_code,
     monetary_exchange_periods1.validity_start_date,
@@ -4651,9 +4693,9 @@ CREATE VIEW monetary_exchange_periods AS
     monetary_exchange_periods1.oid,
     monetary_exchange_periods1.operation,
     monetary_exchange_periods1.operation_date
-   FROM monetary_exchange_periods_oplog monetary_exchange_periods1
+   FROM public.monetary_exchange_periods_oplog monetary_exchange_periods1
   WHERE ((monetary_exchange_periods1.oid IN ( SELECT max(monetary_exchange_periods2.oid) AS max
-           FROM monetary_exchange_periods_oplog monetary_exchange_periods2
+           FROM public.monetary_exchange_periods_oplog monetary_exchange_periods2
           WHERE ((monetary_exchange_periods1.monetary_exchange_period_sid = monetary_exchange_periods2.monetary_exchange_period_sid) AND ((monetary_exchange_periods1.parent_monetary_unit_code)::text = (monetary_exchange_periods2.parent_monetary_unit_code)::text)))) AND ((monetary_exchange_periods1.operation)::text <> 'D'::text));
 
 
@@ -4661,7 +4703,7 @@ CREATE VIEW monetary_exchange_periods AS
 -- Name: monetary_exchange_periods_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE monetary_exchange_periods_oid_seq
+CREATE SEQUENCE public.monetary_exchange_periods_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -4673,14 +4715,14 @@ CREATE SEQUENCE monetary_exchange_periods_oid_seq
 -- Name: monetary_exchange_periods_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE monetary_exchange_periods_oid_seq OWNED BY monetary_exchange_periods_oplog.oid;
+ALTER SEQUENCE public.monetary_exchange_periods_oid_seq OWNED BY public.monetary_exchange_periods_oplog.oid;
 
 
 --
 -- Name: monetary_exchange_rates_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE monetary_exchange_rates_oplog (
+CREATE TABLE public.monetary_exchange_rates_oplog (
     monetary_exchange_period_sid integer,
     child_monetary_unit_code character varying(255),
     exchange_rate numeric(16,8),
@@ -4695,16 +4737,16 @@ CREATE TABLE monetary_exchange_rates_oplog (
 -- Name: monetary_exchange_rates; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW monetary_exchange_rates AS
+CREATE VIEW public.monetary_exchange_rates AS
  SELECT monetary_exchange_rates1.monetary_exchange_period_sid,
     monetary_exchange_rates1.child_monetary_unit_code,
     monetary_exchange_rates1.exchange_rate,
     monetary_exchange_rates1.oid,
     monetary_exchange_rates1.operation,
     monetary_exchange_rates1.operation_date
-   FROM monetary_exchange_rates_oplog monetary_exchange_rates1
+   FROM public.monetary_exchange_rates_oplog monetary_exchange_rates1
   WHERE ((monetary_exchange_rates1.oid IN ( SELECT max(monetary_exchange_rates2.oid) AS max
-           FROM monetary_exchange_rates_oplog monetary_exchange_rates2
+           FROM public.monetary_exchange_rates_oplog monetary_exchange_rates2
           WHERE ((monetary_exchange_rates1.monetary_exchange_period_sid = monetary_exchange_rates2.monetary_exchange_period_sid) AND ((monetary_exchange_rates1.child_monetary_unit_code)::text = (monetary_exchange_rates2.child_monetary_unit_code)::text)))) AND ((monetary_exchange_rates1.operation)::text <> 'D'::text));
 
 
@@ -4712,7 +4754,7 @@ CREATE VIEW monetary_exchange_rates AS
 -- Name: monetary_exchange_rates_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE monetary_exchange_rates_oid_seq
+CREATE SEQUENCE public.monetary_exchange_rates_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -4724,14 +4766,14 @@ CREATE SEQUENCE monetary_exchange_rates_oid_seq
 -- Name: monetary_exchange_rates_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE monetary_exchange_rates_oid_seq OWNED BY monetary_exchange_rates_oplog.oid;
+ALTER SEQUENCE public.monetary_exchange_rates_oid_seq OWNED BY public.monetary_exchange_rates_oplog.oid;
 
 
 --
 -- Name: monetary_unit_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE monetary_unit_descriptions_oplog (
+CREATE TABLE public.monetary_unit_descriptions_oplog (
     monetary_unit_code character varying(255),
     language_id character varying(5),
     description text,
@@ -4746,16 +4788,16 @@ CREATE TABLE monetary_unit_descriptions_oplog (
 -- Name: monetary_unit_descriptions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW monetary_unit_descriptions AS
+CREATE VIEW public.monetary_unit_descriptions AS
  SELECT monetary_unit_descriptions1.monetary_unit_code,
     monetary_unit_descriptions1.language_id,
     monetary_unit_descriptions1.description,
     monetary_unit_descriptions1.oid,
     monetary_unit_descriptions1.operation,
     monetary_unit_descriptions1.operation_date
-   FROM monetary_unit_descriptions_oplog monetary_unit_descriptions1
+   FROM public.monetary_unit_descriptions_oplog monetary_unit_descriptions1
   WHERE ((monetary_unit_descriptions1.oid IN ( SELECT max(monetary_unit_descriptions2.oid) AS max
-           FROM monetary_unit_descriptions_oplog monetary_unit_descriptions2
+           FROM public.monetary_unit_descriptions_oplog monetary_unit_descriptions2
           WHERE ((monetary_unit_descriptions1.monetary_unit_code)::text = (monetary_unit_descriptions2.monetary_unit_code)::text))) AND ((monetary_unit_descriptions1.operation)::text <> 'D'::text));
 
 
@@ -4763,7 +4805,7 @@ CREATE VIEW monetary_unit_descriptions AS
 -- Name: monetary_unit_descriptions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE monetary_unit_descriptions_oid_seq
+CREATE SEQUENCE public.monetary_unit_descriptions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -4775,14 +4817,14 @@ CREATE SEQUENCE monetary_unit_descriptions_oid_seq
 -- Name: monetary_unit_descriptions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE monetary_unit_descriptions_oid_seq OWNED BY monetary_unit_descriptions_oplog.oid;
+ALTER SEQUENCE public.monetary_unit_descriptions_oid_seq OWNED BY public.monetary_unit_descriptions_oplog.oid;
 
 
 --
 -- Name: monetary_units_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE monetary_units_oplog (
+CREATE TABLE public.monetary_units_oplog (
     monetary_unit_code character varying(255),
     validity_start_date timestamp without time zone,
     validity_end_date timestamp without time zone,
@@ -4797,16 +4839,16 @@ CREATE TABLE monetary_units_oplog (
 -- Name: monetary_units; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW monetary_units AS
+CREATE VIEW public.monetary_units AS
  SELECT monetary_units1.monetary_unit_code,
     monetary_units1.validity_start_date,
     monetary_units1.validity_end_date,
     monetary_units1.oid,
     monetary_units1.operation,
     monetary_units1.operation_date
-   FROM monetary_units_oplog monetary_units1
+   FROM public.monetary_units_oplog monetary_units1
   WHERE ((monetary_units1.oid IN ( SELECT max(monetary_units2.oid) AS max
-           FROM monetary_units_oplog monetary_units2
+           FROM public.monetary_units_oplog monetary_units2
           WHERE ((monetary_units1.monetary_unit_code)::text = (monetary_units2.monetary_unit_code)::text))) AND ((monetary_units1.operation)::text <> 'D'::text));
 
 
@@ -4814,7 +4856,7 @@ CREATE VIEW monetary_units AS
 -- Name: monetary_units_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE monetary_units_oid_seq
+CREATE SEQUENCE public.monetary_units_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -4826,14 +4868,14 @@ CREATE SEQUENCE monetary_units_oid_seq
 -- Name: monetary_units_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE monetary_units_oid_seq OWNED BY monetary_units_oplog.oid;
+ALTER SEQUENCE public.monetary_units_oid_seq OWNED BY public.monetary_units_oplog.oid;
 
 
 --
 -- Name: nomenclature_group_memberships_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE nomenclature_group_memberships_oplog (
+CREATE TABLE public.nomenclature_group_memberships_oplog (
     goods_nomenclature_sid integer,
     goods_nomenclature_group_type character varying(1),
     goods_nomenclature_group_id character varying(6),
@@ -4852,7 +4894,7 @@ CREATE TABLE nomenclature_group_memberships_oplog (
 -- Name: nomenclature_group_memberships; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW nomenclature_group_memberships AS
+CREATE VIEW public.nomenclature_group_memberships AS
  SELECT nomenclature_group_memberships1.goods_nomenclature_sid,
     nomenclature_group_memberships1.goods_nomenclature_group_type,
     nomenclature_group_memberships1.goods_nomenclature_group_id,
@@ -4863,9 +4905,9 @@ CREATE VIEW nomenclature_group_memberships AS
     nomenclature_group_memberships1.oid,
     nomenclature_group_memberships1.operation,
     nomenclature_group_memberships1.operation_date
-   FROM nomenclature_group_memberships_oplog nomenclature_group_memberships1
+   FROM public.nomenclature_group_memberships_oplog nomenclature_group_memberships1
   WHERE ((nomenclature_group_memberships1.oid IN ( SELECT max(nomenclature_group_memberships2.oid) AS max
-           FROM nomenclature_group_memberships_oplog nomenclature_group_memberships2
+           FROM public.nomenclature_group_memberships_oplog nomenclature_group_memberships2
           WHERE ((nomenclature_group_memberships1.goods_nomenclature_sid = nomenclature_group_memberships2.goods_nomenclature_sid) AND ((nomenclature_group_memberships1.goods_nomenclature_group_id)::text = (nomenclature_group_memberships2.goods_nomenclature_group_id)::text) AND ((nomenclature_group_memberships1.goods_nomenclature_group_type)::text = (nomenclature_group_memberships2.goods_nomenclature_group_type)::text) AND ((nomenclature_group_memberships1.goods_nomenclature_item_id)::text = (nomenclature_group_memberships2.goods_nomenclature_item_id)::text) AND (nomenclature_group_memberships1.validity_start_date = nomenclature_group_memberships2.validity_start_date)))) AND ((nomenclature_group_memberships1.operation)::text <> 'D'::text));
 
 
@@ -4873,7 +4915,7 @@ CREATE VIEW nomenclature_group_memberships AS
 -- Name: nomenclature_group_memberships_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE nomenclature_group_memberships_oid_seq
+CREATE SEQUENCE public.nomenclature_group_memberships_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -4885,14 +4927,14 @@ CREATE SEQUENCE nomenclature_group_memberships_oid_seq
 -- Name: nomenclature_group_memberships_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE nomenclature_group_memberships_oid_seq OWNED BY nomenclature_group_memberships_oplog.oid;
+ALTER SEQUENCE public.nomenclature_group_memberships_oid_seq OWNED BY public.nomenclature_group_memberships_oplog.oid;
 
 
 --
 -- Name: prorogation_regulation_actions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE prorogation_regulation_actions_oplog (
+CREATE TABLE public.prorogation_regulation_actions_oplog (
     prorogation_regulation_role integer,
     prorogation_regulation_id character varying(8),
     prorogated_regulation_role integer,
@@ -4909,7 +4951,7 @@ CREATE TABLE prorogation_regulation_actions_oplog (
 -- Name: prorogation_regulation_actions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW prorogation_regulation_actions AS
+CREATE VIEW public.prorogation_regulation_actions AS
  SELECT prorogation_regulation_actions1.prorogation_regulation_role,
     prorogation_regulation_actions1.prorogation_regulation_id,
     prorogation_regulation_actions1.prorogated_regulation_role,
@@ -4918,9 +4960,9 @@ CREATE VIEW prorogation_regulation_actions AS
     prorogation_regulation_actions1.oid,
     prorogation_regulation_actions1.operation,
     prorogation_regulation_actions1.operation_date
-   FROM prorogation_regulation_actions_oplog prorogation_regulation_actions1
+   FROM public.prorogation_regulation_actions_oplog prorogation_regulation_actions1
   WHERE ((prorogation_regulation_actions1.oid IN ( SELECT max(prorogation_regulation_actions2.oid) AS max
-           FROM prorogation_regulation_actions_oplog prorogation_regulation_actions2
+           FROM public.prorogation_regulation_actions_oplog prorogation_regulation_actions2
           WHERE (((prorogation_regulation_actions1.prorogation_regulation_id)::text = (prorogation_regulation_actions2.prorogation_regulation_id)::text) AND (prorogation_regulation_actions1.prorogation_regulation_role = prorogation_regulation_actions2.prorogation_regulation_role) AND ((prorogation_regulation_actions1.prorogated_regulation_id)::text = (prorogation_regulation_actions2.prorogated_regulation_id)::text) AND (prorogation_regulation_actions1.prorogated_regulation_role = prorogation_regulation_actions2.prorogated_regulation_role)))) AND ((prorogation_regulation_actions1.operation)::text <> 'D'::text));
 
 
@@ -4928,7 +4970,7 @@ CREATE VIEW prorogation_regulation_actions AS
 -- Name: prorogation_regulation_actions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE prorogation_regulation_actions_oid_seq
+CREATE SEQUENCE public.prorogation_regulation_actions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -4940,14 +4982,14 @@ CREATE SEQUENCE prorogation_regulation_actions_oid_seq
 -- Name: prorogation_regulation_actions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE prorogation_regulation_actions_oid_seq OWNED BY prorogation_regulation_actions_oplog.oid;
+ALTER SEQUENCE public.prorogation_regulation_actions_oid_seq OWNED BY public.prorogation_regulation_actions_oplog.oid;
 
 
 --
 -- Name: prorogation_regulations_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE prorogation_regulations_oplog (
+CREATE TABLE public.prorogation_regulations_oplog (
     prorogation_regulation_role integer,
     prorogation_regulation_id character varying(255),
     published_date date,
@@ -4967,7 +5009,7 @@ CREATE TABLE prorogation_regulations_oplog (
 -- Name: prorogation_regulations; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW prorogation_regulations AS
+CREATE VIEW public.prorogation_regulations AS
  SELECT prorogation_regulations1.prorogation_regulation_role,
     prorogation_regulations1.prorogation_regulation_id,
     prorogation_regulations1.published_date,
@@ -4979,9 +5021,9 @@ CREATE VIEW prorogation_regulations AS
     prorogation_regulations1.oid,
     prorogation_regulations1.operation,
     prorogation_regulations1.operation_date
-   FROM prorogation_regulations_oplog prorogation_regulations1
+   FROM public.prorogation_regulations_oplog prorogation_regulations1
   WHERE ((prorogation_regulations1.oid IN ( SELECT max(prorogation_regulations2.oid) AS max
-           FROM prorogation_regulations_oplog prorogation_regulations2
+           FROM public.prorogation_regulations_oplog prorogation_regulations2
           WHERE (((prorogation_regulations1.prorogation_regulation_id)::text = (prorogation_regulations2.prorogation_regulation_id)::text) AND (prorogation_regulations1.prorogation_regulation_role = prorogation_regulations2.prorogation_regulation_role)))) AND ((prorogation_regulations1.operation)::text <> 'D'::text));
 
 
@@ -4989,7 +5031,7 @@ CREATE VIEW prorogation_regulations AS
 -- Name: prorogation_regulations_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE prorogation_regulations_oid_seq
+CREATE SEQUENCE public.prorogation_regulations_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -5001,14 +5043,14 @@ CREATE SEQUENCE prorogation_regulations_oid_seq
 -- Name: prorogation_regulations_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE prorogation_regulations_oid_seq OWNED BY prorogation_regulations_oplog.oid;
+ALTER SEQUENCE public.prorogation_regulations_oid_seq OWNED BY public.prorogation_regulations_oplog.oid;
 
 
 --
 -- Name: publication_sigles_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE publication_sigles_oplog (
+CREATE TABLE public.publication_sigles_oplog (
     oid integer NOT NULL,
     code_type_id character varying(4),
     code character varying(10),
@@ -5026,7 +5068,7 @@ CREATE TABLE publication_sigles_oplog (
 -- Name: publication_sigles; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW publication_sigles AS
+CREATE VIEW public.publication_sigles AS
  SELECT publication_sigles1.oid,
     publication_sigles1.code_type_id,
     publication_sigles1.code,
@@ -5036,9 +5078,9 @@ CREATE VIEW publication_sigles AS
     publication_sigles1.validity_start_date,
     publication_sigles1.operation,
     publication_sigles1.operation_date
-   FROM publication_sigles_oplog publication_sigles1
+   FROM public.publication_sigles_oplog publication_sigles1
   WHERE ((publication_sigles1.oid IN ( SELECT max(publication_sigles2.oid) AS max
-           FROM publication_sigles_oplog publication_sigles2
+           FROM public.publication_sigles_oplog publication_sigles2
           WHERE (((publication_sigles1.code)::text = (publication_sigles2.code)::text) AND ((publication_sigles1.code_type_id)::text = (publication_sigles2.code_type_id)::text)))) AND ((publication_sigles1.operation)::text <> 'D'::text));
 
 
@@ -5046,7 +5088,7 @@ CREATE VIEW publication_sigles AS
 -- Name: publication_sigles_oplog_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE publication_sigles_oplog_oid_seq
+CREATE SEQUENCE public.publication_sigles_oplog_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -5058,14 +5100,14 @@ CREATE SEQUENCE publication_sigles_oplog_oid_seq
 -- Name: publication_sigles_oplog_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE publication_sigles_oplog_oid_seq OWNED BY publication_sigles_oplog.oid;
+ALTER SEQUENCE public.publication_sigles_oplog_oid_seq OWNED BY public.publication_sigles_oplog.oid;
 
 
 --
 -- Name: quota_associations_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE quota_associations_oplog (
+CREATE TABLE public.quota_associations_oplog (
     main_quota_definition_sid integer,
     sub_quota_definition_sid integer,
     relation_type character varying(255),
@@ -5081,7 +5123,7 @@ CREATE TABLE quota_associations_oplog (
 -- Name: quota_associations; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW quota_associations AS
+CREATE VIEW public.quota_associations AS
  SELECT quota_associations1.main_quota_definition_sid,
     quota_associations1.sub_quota_definition_sid,
     quota_associations1.relation_type,
@@ -5089,9 +5131,9 @@ CREATE VIEW quota_associations AS
     quota_associations1.oid,
     quota_associations1.operation,
     quota_associations1.operation_date
-   FROM quota_associations_oplog quota_associations1
+   FROM public.quota_associations_oplog quota_associations1
   WHERE ((quota_associations1.oid IN ( SELECT max(quota_associations2.oid) AS max
-           FROM quota_associations_oplog quota_associations2
+           FROM public.quota_associations_oplog quota_associations2
           WHERE ((quota_associations1.main_quota_definition_sid = quota_associations2.main_quota_definition_sid) AND (quota_associations1.sub_quota_definition_sid = quota_associations2.sub_quota_definition_sid)))) AND ((quota_associations1.operation)::text <> 'D'::text));
 
 
@@ -5099,7 +5141,7 @@ CREATE VIEW quota_associations AS
 -- Name: quota_associations_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE quota_associations_oid_seq
+CREATE SEQUENCE public.quota_associations_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -5111,14 +5153,14 @@ CREATE SEQUENCE quota_associations_oid_seq
 -- Name: quota_associations_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE quota_associations_oid_seq OWNED BY quota_associations_oplog.oid;
+ALTER SEQUENCE public.quota_associations_oid_seq OWNED BY public.quota_associations_oplog.oid;
 
 
 --
 -- Name: quota_balance_events_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE quota_balance_events_oplog (
+CREATE TABLE public.quota_balance_events_oplog (
     quota_definition_sid integer,
     occurrence_timestamp timestamp without time zone,
     last_import_date_in_allocation date,
@@ -5136,7 +5178,7 @@ CREATE TABLE quota_balance_events_oplog (
 -- Name: quota_balance_events; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW quota_balance_events AS
+CREATE VIEW public.quota_balance_events AS
  SELECT quota_balance_events1.quota_definition_sid,
     quota_balance_events1.occurrence_timestamp,
     quota_balance_events1.last_import_date_in_allocation,
@@ -5146,9 +5188,9 @@ CREATE VIEW quota_balance_events AS
     quota_balance_events1.oid,
     quota_balance_events1.operation,
     quota_balance_events1.operation_date
-   FROM quota_balance_events_oplog quota_balance_events1
+   FROM public.quota_balance_events_oplog quota_balance_events1
   WHERE ((quota_balance_events1.oid IN ( SELECT max(quota_balance_events2.oid) AS max
-           FROM quota_balance_events_oplog quota_balance_events2
+           FROM public.quota_balance_events_oplog quota_balance_events2
           WHERE ((quota_balance_events1.quota_definition_sid = quota_balance_events2.quota_definition_sid) AND (quota_balance_events1.occurrence_timestamp = quota_balance_events2.occurrence_timestamp)))) AND ((quota_balance_events1.operation)::text <> 'D'::text));
 
 
@@ -5156,7 +5198,7 @@ CREATE VIEW quota_balance_events AS
 -- Name: quota_balance_events_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE quota_balance_events_oid_seq
+CREATE SEQUENCE public.quota_balance_events_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -5168,14 +5210,14 @@ CREATE SEQUENCE quota_balance_events_oid_seq
 -- Name: quota_balance_events_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE quota_balance_events_oid_seq OWNED BY quota_balance_events_oplog.oid;
+ALTER SEQUENCE public.quota_balance_events_oid_seq OWNED BY public.quota_balance_events_oplog.oid;
 
 
 --
 -- Name: quota_blocking_periods_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE quota_blocking_periods_oplog (
+CREATE TABLE public.quota_blocking_periods_oplog (
     quota_blocking_period_sid integer,
     quota_definition_sid integer,
     blocking_start_date date,
@@ -5193,7 +5235,7 @@ CREATE TABLE quota_blocking_periods_oplog (
 -- Name: quota_blocking_periods; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW quota_blocking_periods AS
+CREATE VIEW public.quota_blocking_periods AS
  SELECT quota_blocking_periods1.quota_blocking_period_sid,
     quota_blocking_periods1.quota_definition_sid,
     quota_blocking_periods1.blocking_start_date,
@@ -5203,9 +5245,9 @@ CREATE VIEW quota_blocking_periods AS
     quota_blocking_periods1.oid,
     quota_blocking_periods1.operation,
     quota_blocking_periods1.operation_date
-   FROM quota_blocking_periods_oplog quota_blocking_periods1
+   FROM public.quota_blocking_periods_oplog quota_blocking_periods1
   WHERE ((quota_blocking_periods1.oid IN ( SELECT max(quota_blocking_periods2.oid) AS max
-           FROM quota_blocking_periods_oplog quota_blocking_periods2
+           FROM public.quota_blocking_periods_oplog quota_blocking_periods2
           WHERE (quota_blocking_periods1.quota_blocking_period_sid = quota_blocking_periods2.quota_blocking_period_sid))) AND ((quota_blocking_periods1.operation)::text <> 'D'::text));
 
 
@@ -5213,7 +5255,7 @@ CREATE VIEW quota_blocking_periods AS
 -- Name: quota_blocking_periods_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE quota_blocking_periods_oid_seq
+CREATE SEQUENCE public.quota_blocking_periods_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -5225,14 +5267,14 @@ CREATE SEQUENCE quota_blocking_periods_oid_seq
 -- Name: quota_blocking_periods_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE quota_blocking_periods_oid_seq OWNED BY quota_blocking_periods_oplog.oid;
+ALTER SEQUENCE public.quota_blocking_periods_oid_seq OWNED BY public.quota_blocking_periods_oplog.oid;
 
 
 --
 -- Name: quota_critical_events_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE quota_critical_events_oplog (
+CREATE TABLE public.quota_critical_events_oplog (
     quota_definition_sid integer,
     occurrence_timestamp timestamp without time zone,
     critical_state character varying(255),
@@ -5248,7 +5290,7 @@ CREATE TABLE quota_critical_events_oplog (
 -- Name: quota_critical_events; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW quota_critical_events AS
+CREATE VIEW public.quota_critical_events AS
  SELECT quota_critical_events1.quota_definition_sid,
     quota_critical_events1.occurrence_timestamp,
     quota_critical_events1.critical_state,
@@ -5256,9 +5298,9 @@ CREATE VIEW quota_critical_events AS
     quota_critical_events1.oid,
     quota_critical_events1.operation,
     quota_critical_events1.operation_date
-   FROM quota_critical_events_oplog quota_critical_events1
+   FROM public.quota_critical_events_oplog quota_critical_events1
   WHERE ((quota_critical_events1.oid IN ( SELECT max(quota_critical_events2.oid) AS max
-           FROM quota_critical_events_oplog quota_critical_events2
+           FROM public.quota_critical_events_oplog quota_critical_events2
           WHERE ((quota_critical_events1.quota_definition_sid = quota_critical_events2.quota_definition_sid) AND (quota_critical_events1.occurrence_timestamp = quota_critical_events2.occurrence_timestamp))
           GROUP BY quota_critical_events2.oid
           ORDER BY quota_critical_events2.oid DESC)) AND ((quota_critical_events1.operation)::text <> 'D'::text));
@@ -5268,7 +5310,7 @@ CREATE VIEW quota_critical_events AS
 -- Name: quota_critical_events_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE quota_critical_events_oid_seq
+CREATE SEQUENCE public.quota_critical_events_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -5280,14 +5322,14 @@ CREATE SEQUENCE quota_critical_events_oid_seq
 -- Name: quota_critical_events_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE quota_critical_events_oid_seq OWNED BY quota_critical_events_oplog.oid;
+ALTER SEQUENCE public.quota_critical_events_oid_seq OWNED BY public.quota_critical_events_oplog.oid;
 
 
 --
 -- Name: quota_definitions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE quota_definitions_oplog (
+CREATE TABLE public.quota_definitions_oplog (
     quota_definition_sid integer,
     quota_order_number_id character varying(255),
     validity_start_date timestamp without time zone,
@@ -5313,7 +5355,7 @@ CREATE TABLE quota_definitions_oplog (
 -- Name: quota_definitions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW quota_definitions AS
+CREATE VIEW public.quota_definitions AS
  SELECT quota_definitions1.quota_definition_sid,
     quota_definitions1.quota_order_number_id,
     quota_definitions1.validity_start_date,
@@ -5331,9 +5373,9 @@ CREATE VIEW quota_definitions AS
     quota_definitions1.oid,
     quota_definitions1.operation,
     quota_definitions1.operation_date
-   FROM quota_definitions_oplog quota_definitions1
+   FROM public.quota_definitions_oplog quota_definitions1
   WHERE ((quota_definitions1.oid IN ( SELECT max(quota_definitions2.oid) AS max
-           FROM quota_definitions_oplog quota_definitions2
+           FROM public.quota_definitions_oplog quota_definitions2
           WHERE (quota_definitions1.quota_definition_sid = quota_definitions2.quota_definition_sid))) AND ((quota_definitions1.operation)::text <> 'D'::text));
 
 
@@ -5341,7 +5383,7 @@ CREATE VIEW quota_definitions AS
 -- Name: quota_definitions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE quota_definitions_oid_seq
+CREATE SEQUENCE public.quota_definitions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -5353,14 +5395,14 @@ CREATE SEQUENCE quota_definitions_oid_seq
 -- Name: quota_definitions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE quota_definitions_oid_seq OWNED BY quota_definitions_oplog.oid;
+ALTER SEQUENCE public.quota_definitions_oid_seq OWNED BY public.quota_definitions_oplog.oid;
 
 
 --
 -- Name: quota_exhaustion_events_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE quota_exhaustion_events_oplog (
+CREATE TABLE public.quota_exhaustion_events_oplog (
     quota_definition_sid integer,
     occurrence_timestamp timestamp without time zone,
     exhaustion_date date,
@@ -5375,16 +5417,16 @@ CREATE TABLE quota_exhaustion_events_oplog (
 -- Name: quota_exhaustion_events; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW quota_exhaustion_events AS
+CREATE VIEW public.quota_exhaustion_events AS
  SELECT quota_exhaustion_events1.quota_definition_sid,
     quota_exhaustion_events1.occurrence_timestamp,
     quota_exhaustion_events1.exhaustion_date,
     quota_exhaustion_events1.oid,
     quota_exhaustion_events1.operation,
     quota_exhaustion_events1.operation_date
-   FROM quota_exhaustion_events_oplog quota_exhaustion_events1
+   FROM public.quota_exhaustion_events_oplog quota_exhaustion_events1
   WHERE ((quota_exhaustion_events1.oid IN ( SELECT max(quota_exhaustion_events2.oid) AS max
-           FROM quota_exhaustion_events_oplog quota_exhaustion_events2
+           FROM public.quota_exhaustion_events_oplog quota_exhaustion_events2
           WHERE (quota_exhaustion_events1.quota_definition_sid = quota_exhaustion_events2.quota_definition_sid))) AND ((quota_exhaustion_events1.operation)::text <> 'D'::text));
 
 
@@ -5392,7 +5434,7 @@ CREATE VIEW quota_exhaustion_events AS
 -- Name: quota_exhaustion_events_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE quota_exhaustion_events_oid_seq
+CREATE SEQUENCE public.quota_exhaustion_events_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -5404,14 +5446,14 @@ CREATE SEQUENCE quota_exhaustion_events_oid_seq
 -- Name: quota_exhaustion_events_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE quota_exhaustion_events_oid_seq OWNED BY quota_exhaustion_events_oplog.oid;
+ALTER SEQUENCE public.quota_exhaustion_events_oid_seq OWNED BY public.quota_exhaustion_events_oplog.oid;
 
 
 --
 -- Name: quota_order_number_origin_exclusions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE quota_order_number_origin_exclusions_oplog (
+CREATE TABLE public.quota_order_number_origin_exclusions_oplog (
     quota_order_number_origin_sid integer,
     excluded_geographical_area_sid integer,
     created_at timestamp without time zone,
@@ -5425,15 +5467,15 @@ CREATE TABLE quota_order_number_origin_exclusions_oplog (
 -- Name: quota_order_number_origin_exclusions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW quota_order_number_origin_exclusions AS
+CREATE VIEW public.quota_order_number_origin_exclusions AS
  SELECT quota_order_number_origin_exclusions1.quota_order_number_origin_sid,
     quota_order_number_origin_exclusions1.excluded_geographical_area_sid,
     quota_order_number_origin_exclusions1.oid,
     quota_order_number_origin_exclusions1.operation,
     quota_order_number_origin_exclusions1.operation_date
-   FROM quota_order_number_origin_exclusions_oplog quota_order_number_origin_exclusions1
+   FROM public.quota_order_number_origin_exclusions_oplog quota_order_number_origin_exclusions1
   WHERE ((quota_order_number_origin_exclusions1.oid IN ( SELECT max(quota_order_number_origin_exclusions2.oid) AS max
-           FROM quota_order_number_origin_exclusions_oplog quota_order_number_origin_exclusions2
+           FROM public.quota_order_number_origin_exclusions_oplog quota_order_number_origin_exclusions2
           WHERE ((quota_order_number_origin_exclusions1.quota_order_number_origin_sid = quota_order_number_origin_exclusions2.quota_order_number_origin_sid) AND (quota_order_number_origin_exclusions1.excluded_geographical_area_sid = quota_order_number_origin_exclusions2.excluded_geographical_area_sid)))) AND ((quota_order_number_origin_exclusions1.operation)::text <> 'D'::text));
 
 
@@ -5441,7 +5483,7 @@ CREATE VIEW quota_order_number_origin_exclusions AS
 -- Name: quota_order_number_origin_exclusions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE quota_order_number_origin_exclusions_oid_seq
+CREATE SEQUENCE public.quota_order_number_origin_exclusions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -5453,14 +5495,14 @@ CREATE SEQUENCE quota_order_number_origin_exclusions_oid_seq
 -- Name: quota_order_number_origin_exclusions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE quota_order_number_origin_exclusions_oid_seq OWNED BY quota_order_number_origin_exclusions_oplog.oid;
+ALTER SEQUENCE public.quota_order_number_origin_exclusions_oid_seq OWNED BY public.quota_order_number_origin_exclusions_oplog.oid;
 
 
 --
 -- Name: quota_order_number_origins_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE quota_order_number_origins_oplog (
+CREATE TABLE public.quota_order_number_origins_oplog (
     quota_order_number_origin_sid integer,
     quota_order_number_sid integer,
     geographical_area_id character varying(255),
@@ -5478,7 +5520,7 @@ CREATE TABLE quota_order_number_origins_oplog (
 -- Name: quota_order_number_origins; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW quota_order_number_origins AS
+CREATE VIEW public.quota_order_number_origins AS
  SELECT quota_order_number_origins1.quota_order_number_origin_sid,
     quota_order_number_origins1.quota_order_number_sid,
     quota_order_number_origins1.geographical_area_id,
@@ -5488,9 +5530,9 @@ CREATE VIEW quota_order_number_origins AS
     quota_order_number_origins1.oid,
     quota_order_number_origins1.operation,
     quota_order_number_origins1.operation_date
-   FROM quota_order_number_origins_oplog quota_order_number_origins1
+   FROM public.quota_order_number_origins_oplog quota_order_number_origins1
   WHERE ((quota_order_number_origins1.oid IN ( SELECT max(quota_order_number_origins2.oid) AS max
-           FROM quota_order_number_origins_oplog quota_order_number_origins2
+           FROM public.quota_order_number_origins_oplog quota_order_number_origins2
           WHERE (quota_order_number_origins1.quota_order_number_origin_sid = quota_order_number_origins2.quota_order_number_origin_sid))) AND ((quota_order_number_origins1.operation)::text <> 'D'::text));
 
 
@@ -5498,7 +5540,7 @@ CREATE VIEW quota_order_number_origins AS
 -- Name: quota_order_number_origins_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE quota_order_number_origins_oid_seq
+CREATE SEQUENCE public.quota_order_number_origins_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -5510,14 +5552,14 @@ CREATE SEQUENCE quota_order_number_origins_oid_seq
 -- Name: quota_order_number_origins_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE quota_order_number_origins_oid_seq OWNED BY quota_order_number_origins_oplog.oid;
+ALTER SEQUENCE public.quota_order_number_origins_oid_seq OWNED BY public.quota_order_number_origins_oplog.oid;
 
 
 --
 -- Name: quota_order_numbers_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE quota_order_numbers_oplog (
+CREATE TABLE public.quota_order_numbers_oplog (
     quota_order_number_sid integer,
     quota_order_number_id character varying(255),
     validity_start_date timestamp without time zone,
@@ -5533,7 +5575,7 @@ CREATE TABLE quota_order_numbers_oplog (
 -- Name: quota_order_numbers; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW quota_order_numbers AS
+CREATE VIEW public.quota_order_numbers AS
  SELECT quota_order_numbers1.quota_order_number_sid,
     quota_order_numbers1.quota_order_number_id,
     quota_order_numbers1.validity_start_date,
@@ -5541,9 +5583,9 @@ CREATE VIEW quota_order_numbers AS
     quota_order_numbers1.oid,
     quota_order_numbers1.operation,
     quota_order_numbers1.operation_date
-   FROM quota_order_numbers_oplog quota_order_numbers1
+   FROM public.quota_order_numbers_oplog quota_order_numbers1
   WHERE ((quota_order_numbers1.oid IN ( SELECT max(quota_order_numbers2.oid) AS max
-           FROM quota_order_numbers_oplog quota_order_numbers2
+           FROM public.quota_order_numbers_oplog quota_order_numbers2
           WHERE (quota_order_numbers1.quota_order_number_sid = quota_order_numbers2.quota_order_number_sid))) AND ((quota_order_numbers1.operation)::text <> 'D'::text));
 
 
@@ -5551,7 +5593,7 @@ CREATE VIEW quota_order_numbers AS
 -- Name: quota_order_numbers_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE quota_order_numbers_oid_seq
+CREATE SEQUENCE public.quota_order_numbers_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -5563,14 +5605,14 @@ CREATE SEQUENCE quota_order_numbers_oid_seq
 -- Name: quota_order_numbers_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE quota_order_numbers_oid_seq OWNED BY quota_order_numbers_oplog.oid;
+ALTER SEQUENCE public.quota_order_numbers_oid_seq OWNED BY public.quota_order_numbers_oplog.oid;
 
 
 --
 -- Name: quota_reopening_events_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE quota_reopening_events_oplog (
+CREATE TABLE public.quota_reopening_events_oplog (
     quota_definition_sid integer,
     occurrence_timestamp timestamp without time zone,
     reopening_date date,
@@ -5585,16 +5627,16 @@ CREATE TABLE quota_reopening_events_oplog (
 -- Name: quota_reopening_events; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW quota_reopening_events AS
+CREATE VIEW public.quota_reopening_events AS
  SELECT quota_reopening_events1.quota_definition_sid,
     quota_reopening_events1.occurrence_timestamp,
     quota_reopening_events1.reopening_date,
     quota_reopening_events1.oid,
     quota_reopening_events1.operation,
     quota_reopening_events1.operation_date
-   FROM quota_reopening_events_oplog quota_reopening_events1
+   FROM public.quota_reopening_events_oplog quota_reopening_events1
   WHERE ((quota_reopening_events1.oid IN ( SELECT max(quota_reopening_events2.oid) AS max
-           FROM quota_reopening_events_oplog quota_reopening_events2
+           FROM public.quota_reopening_events_oplog quota_reopening_events2
           WHERE (quota_reopening_events1.quota_definition_sid = quota_reopening_events2.quota_definition_sid))) AND ((quota_reopening_events1.operation)::text <> 'D'::text));
 
 
@@ -5602,7 +5644,7 @@ CREATE VIEW quota_reopening_events AS
 -- Name: quota_reopening_events_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE quota_reopening_events_oid_seq
+CREATE SEQUENCE public.quota_reopening_events_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -5614,14 +5656,14 @@ CREATE SEQUENCE quota_reopening_events_oid_seq
 -- Name: quota_reopening_events_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE quota_reopening_events_oid_seq OWNED BY quota_reopening_events_oplog.oid;
+ALTER SEQUENCE public.quota_reopening_events_oid_seq OWNED BY public.quota_reopening_events_oplog.oid;
 
 
 --
 -- Name: quota_suspension_periods_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE quota_suspension_periods_oplog (
+CREATE TABLE public.quota_suspension_periods_oplog (
     quota_suspension_period_sid integer,
     quota_definition_sid integer,
     suspension_start_date date,
@@ -5638,7 +5680,7 @@ CREATE TABLE quota_suspension_periods_oplog (
 -- Name: quota_suspension_periods; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW quota_suspension_periods AS
+CREATE VIEW public.quota_suspension_periods AS
  SELECT quota_suspension_periods1.quota_suspension_period_sid,
     quota_suspension_periods1.quota_definition_sid,
     quota_suspension_periods1.suspension_start_date,
@@ -5647,9 +5689,9 @@ CREATE VIEW quota_suspension_periods AS
     quota_suspension_periods1.oid,
     quota_suspension_periods1.operation,
     quota_suspension_periods1.operation_date
-   FROM quota_suspension_periods_oplog quota_suspension_periods1
+   FROM public.quota_suspension_periods_oplog quota_suspension_periods1
   WHERE ((quota_suspension_periods1.oid IN ( SELECT max(quota_suspension_periods2.oid) AS max
-           FROM quota_suspension_periods_oplog quota_suspension_periods2
+           FROM public.quota_suspension_periods_oplog quota_suspension_periods2
           WHERE (quota_suspension_periods1.quota_suspension_period_sid = quota_suspension_periods2.quota_suspension_period_sid))) AND ((quota_suspension_periods1.operation)::text <> 'D'::text));
 
 
@@ -5657,7 +5699,7 @@ CREATE VIEW quota_suspension_periods AS
 -- Name: quota_suspension_periods_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE quota_suspension_periods_oid_seq
+CREATE SEQUENCE public.quota_suspension_periods_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -5669,14 +5711,14 @@ CREATE SEQUENCE quota_suspension_periods_oid_seq
 -- Name: quota_suspension_periods_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE quota_suspension_periods_oid_seq OWNED BY quota_suspension_periods_oplog.oid;
+ALTER SEQUENCE public.quota_suspension_periods_oid_seq OWNED BY public.quota_suspension_periods_oplog.oid;
 
 
 --
 -- Name: quota_unblocking_events_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE quota_unblocking_events_oplog (
+CREATE TABLE public.quota_unblocking_events_oplog (
     quota_definition_sid integer,
     occurrence_timestamp timestamp without time zone,
     unblocking_date date,
@@ -5691,16 +5733,16 @@ CREATE TABLE quota_unblocking_events_oplog (
 -- Name: quota_unblocking_events; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW quota_unblocking_events AS
+CREATE VIEW public.quota_unblocking_events AS
  SELECT quota_unblocking_events1.quota_definition_sid,
     quota_unblocking_events1.occurrence_timestamp,
     quota_unblocking_events1.unblocking_date,
     quota_unblocking_events1.oid,
     quota_unblocking_events1.operation,
     quota_unblocking_events1.operation_date
-   FROM quota_unblocking_events_oplog quota_unblocking_events1
+   FROM public.quota_unblocking_events_oplog quota_unblocking_events1
   WHERE ((quota_unblocking_events1.oid IN ( SELECT max(quota_unblocking_events2.oid) AS max
-           FROM quota_unblocking_events_oplog quota_unblocking_events2
+           FROM public.quota_unblocking_events_oplog quota_unblocking_events2
           WHERE (quota_unblocking_events1.quota_definition_sid = quota_unblocking_events2.quota_definition_sid))) AND ((quota_unblocking_events1.operation)::text <> 'D'::text));
 
 
@@ -5708,7 +5750,7 @@ CREATE VIEW quota_unblocking_events AS
 -- Name: quota_unblocking_events_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE quota_unblocking_events_oid_seq
+CREATE SEQUENCE public.quota_unblocking_events_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -5720,14 +5762,14 @@ CREATE SEQUENCE quota_unblocking_events_oid_seq
 -- Name: quota_unblocking_events_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE quota_unblocking_events_oid_seq OWNED BY quota_unblocking_events_oplog.oid;
+ALTER SEQUENCE public.quota_unblocking_events_oid_seq OWNED BY public.quota_unblocking_events_oplog.oid;
 
 
 --
 -- Name: quota_unsuspension_events_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE quota_unsuspension_events_oplog (
+CREATE TABLE public.quota_unsuspension_events_oplog (
     quota_definition_sid integer,
     occurrence_timestamp timestamp without time zone,
     unsuspension_date date,
@@ -5742,16 +5784,16 @@ CREATE TABLE quota_unsuspension_events_oplog (
 -- Name: quota_unsuspension_events; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW quota_unsuspension_events AS
+CREATE VIEW public.quota_unsuspension_events AS
  SELECT quota_unsuspension_events1.quota_definition_sid,
     quota_unsuspension_events1.occurrence_timestamp,
     quota_unsuspension_events1.unsuspension_date,
     quota_unsuspension_events1.oid,
     quota_unsuspension_events1.operation,
     quota_unsuspension_events1.operation_date
-   FROM quota_unsuspension_events_oplog quota_unsuspension_events1
+   FROM public.quota_unsuspension_events_oplog quota_unsuspension_events1
   WHERE ((quota_unsuspension_events1.oid IN ( SELECT max(quota_unsuspension_events2.oid) AS max
-           FROM quota_unsuspension_events_oplog quota_unsuspension_events2
+           FROM public.quota_unsuspension_events_oplog quota_unsuspension_events2
           WHERE (quota_unsuspension_events1.quota_definition_sid = quota_unsuspension_events2.quota_definition_sid))) AND ((quota_unsuspension_events1.operation)::text <> 'D'::text));
 
 
@@ -5759,7 +5801,7 @@ CREATE VIEW quota_unsuspension_events AS
 -- Name: quota_unsuspension_events_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE quota_unsuspension_events_oid_seq
+CREATE SEQUENCE public.quota_unsuspension_events_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -5771,14 +5813,14 @@ CREATE SEQUENCE quota_unsuspension_events_oid_seq
 -- Name: quota_unsuspension_events_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE quota_unsuspension_events_oid_seq OWNED BY quota_unsuspension_events_oplog.oid;
+ALTER SEQUENCE public.quota_unsuspension_events_oid_seq OWNED BY public.quota_unsuspension_events_oplog.oid;
 
 
 --
 -- Name: regulation_group_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE regulation_group_descriptions_oplog (
+CREATE TABLE public.regulation_group_descriptions_oplog (
     regulation_group_id character varying(255),
     language_id character varying(5),
     description text,
@@ -5794,7 +5836,7 @@ CREATE TABLE regulation_group_descriptions_oplog (
 -- Name: regulation_group_descriptions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW regulation_group_descriptions AS
+CREATE VIEW public.regulation_group_descriptions AS
  SELECT regulation_group_descriptions1.regulation_group_id,
     regulation_group_descriptions1.language_id,
     regulation_group_descriptions1.description,
@@ -5802,9 +5844,9 @@ CREATE VIEW regulation_group_descriptions AS
     regulation_group_descriptions1.oid,
     regulation_group_descriptions1.operation,
     regulation_group_descriptions1.operation_date
-   FROM regulation_group_descriptions_oplog regulation_group_descriptions1
+   FROM public.regulation_group_descriptions_oplog regulation_group_descriptions1
   WHERE ((regulation_group_descriptions1.oid IN ( SELECT max(regulation_group_descriptions2.oid) AS max
-           FROM regulation_group_descriptions_oplog regulation_group_descriptions2
+           FROM public.regulation_group_descriptions_oplog regulation_group_descriptions2
           WHERE ((regulation_group_descriptions1.regulation_group_id)::text = (regulation_group_descriptions2.regulation_group_id)::text))) AND ((regulation_group_descriptions1.operation)::text <> 'D'::text));
 
 
@@ -5812,7 +5854,7 @@ CREATE VIEW regulation_group_descriptions AS
 -- Name: regulation_group_descriptions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE regulation_group_descriptions_oid_seq
+CREATE SEQUENCE public.regulation_group_descriptions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -5824,14 +5866,14 @@ CREATE SEQUENCE regulation_group_descriptions_oid_seq
 -- Name: regulation_group_descriptions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE regulation_group_descriptions_oid_seq OWNED BY regulation_group_descriptions_oplog.oid;
+ALTER SEQUENCE public.regulation_group_descriptions_oid_seq OWNED BY public.regulation_group_descriptions_oplog.oid;
 
 
 --
 -- Name: regulation_groups_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE regulation_groups_oplog (
+CREATE TABLE public.regulation_groups_oplog (
     regulation_group_id character varying(255),
     validity_start_date timestamp without time zone,
     validity_end_date timestamp without time zone,
@@ -5847,7 +5889,7 @@ CREATE TABLE regulation_groups_oplog (
 -- Name: regulation_groups; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW regulation_groups AS
+CREATE VIEW public.regulation_groups AS
  SELECT regulation_groups1.regulation_group_id,
     regulation_groups1.validity_start_date,
     regulation_groups1.validity_end_date,
@@ -5855,9 +5897,9 @@ CREATE VIEW regulation_groups AS
     regulation_groups1.oid,
     regulation_groups1.operation,
     regulation_groups1.operation_date
-   FROM regulation_groups_oplog regulation_groups1
+   FROM public.regulation_groups_oplog regulation_groups1
   WHERE ((regulation_groups1.oid IN ( SELECT max(regulation_groups2.oid) AS max
-           FROM regulation_groups_oplog regulation_groups2
+           FROM public.regulation_groups_oplog regulation_groups2
           WHERE ((regulation_groups1.regulation_group_id)::text = (regulation_groups2.regulation_group_id)::text))) AND ((regulation_groups1.operation)::text <> 'D'::text));
 
 
@@ -5865,7 +5907,7 @@ CREATE VIEW regulation_groups AS
 -- Name: regulation_groups_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE regulation_groups_oid_seq
+CREATE SEQUENCE public.regulation_groups_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -5877,14 +5919,14 @@ CREATE SEQUENCE regulation_groups_oid_seq
 -- Name: regulation_groups_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE regulation_groups_oid_seq OWNED BY regulation_groups_oplog.oid;
+ALTER SEQUENCE public.regulation_groups_oid_seq OWNED BY public.regulation_groups_oplog.oid;
 
 
 --
 -- Name: regulation_replacements_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE regulation_replacements_oplog (
+CREATE TABLE public.regulation_replacements_oplog (
     geographical_area_id character varying(255),
     chapter_heading character varying(255),
     replacing_regulation_role integer,
@@ -5903,7 +5945,7 @@ CREATE TABLE regulation_replacements_oplog (
 -- Name: regulation_replacements; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW regulation_replacements AS
+CREATE VIEW public.regulation_replacements AS
  SELECT regulation_replacements1.geographical_area_id,
     regulation_replacements1.chapter_heading,
     regulation_replacements1.replacing_regulation_role,
@@ -5914,9 +5956,9 @@ CREATE VIEW regulation_replacements AS
     regulation_replacements1.oid,
     regulation_replacements1.operation,
     regulation_replacements1.operation_date
-   FROM regulation_replacements_oplog regulation_replacements1
+   FROM public.regulation_replacements_oplog regulation_replacements1
   WHERE ((regulation_replacements1.oid IN ( SELECT max(regulation_replacements2.oid) AS max
-           FROM regulation_replacements_oplog regulation_replacements2
+           FROM public.regulation_replacements_oplog regulation_replacements2
           WHERE (((regulation_replacements1.replacing_regulation_id)::text = (regulation_replacements2.replacing_regulation_id)::text) AND (regulation_replacements1.replacing_regulation_role = regulation_replacements2.replacing_regulation_role) AND ((regulation_replacements1.replaced_regulation_id)::text = (regulation_replacements2.replaced_regulation_id)::text) AND (regulation_replacements1.replaced_regulation_role = regulation_replacements2.replaced_regulation_role)))) AND ((regulation_replacements1.operation)::text <> 'D'::text));
 
 
@@ -5924,7 +5966,7 @@ CREATE VIEW regulation_replacements AS
 -- Name: regulation_replacements_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE regulation_replacements_oid_seq
+CREATE SEQUENCE public.regulation_replacements_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -5936,14 +5978,14 @@ CREATE SEQUENCE regulation_replacements_oid_seq
 -- Name: regulation_replacements_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE regulation_replacements_oid_seq OWNED BY regulation_replacements_oplog.oid;
+ALTER SEQUENCE public.regulation_replacements_oid_seq OWNED BY public.regulation_replacements_oplog.oid;
 
 
 --
 -- Name: regulation_role_type_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE regulation_role_type_descriptions_oplog (
+CREATE TABLE public.regulation_role_type_descriptions_oplog (
     regulation_role_type_id character varying(255),
     language_id character varying(5),
     description text,
@@ -5959,7 +6001,7 @@ CREATE TABLE regulation_role_type_descriptions_oplog (
 -- Name: regulation_role_type_descriptions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW regulation_role_type_descriptions AS
+CREATE VIEW public.regulation_role_type_descriptions AS
  SELECT regulation_role_type_descriptions1.regulation_role_type_id,
     regulation_role_type_descriptions1.language_id,
     regulation_role_type_descriptions1.description,
@@ -5967,9 +6009,9 @@ CREATE VIEW regulation_role_type_descriptions AS
     regulation_role_type_descriptions1.oid,
     regulation_role_type_descriptions1.operation,
     regulation_role_type_descriptions1.operation_date
-   FROM regulation_role_type_descriptions_oplog regulation_role_type_descriptions1
+   FROM public.regulation_role_type_descriptions_oplog regulation_role_type_descriptions1
   WHERE ((regulation_role_type_descriptions1.oid IN ( SELECT max(regulation_role_type_descriptions2.oid) AS max
-           FROM regulation_role_type_descriptions_oplog regulation_role_type_descriptions2
+           FROM public.regulation_role_type_descriptions_oplog regulation_role_type_descriptions2
           WHERE ((regulation_role_type_descriptions1.regulation_role_type_id)::text = (regulation_role_type_descriptions2.regulation_role_type_id)::text))) AND ((regulation_role_type_descriptions1.operation)::text <> 'D'::text));
 
 
@@ -5977,7 +6019,7 @@ CREATE VIEW regulation_role_type_descriptions AS
 -- Name: regulation_role_type_descriptions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE regulation_role_type_descriptions_oid_seq
+CREATE SEQUENCE public.regulation_role_type_descriptions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -5989,14 +6031,14 @@ CREATE SEQUENCE regulation_role_type_descriptions_oid_seq
 -- Name: regulation_role_type_descriptions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE regulation_role_type_descriptions_oid_seq OWNED BY regulation_role_type_descriptions_oplog.oid;
+ALTER SEQUENCE public.regulation_role_type_descriptions_oid_seq OWNED BY public.regulation_role_type_descriptions_oplog.oid;
 
 
 --
 -- Name: regulation_role_types_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE regulation_role_types_oplog (
+CREATE TABLE public.regulation_role_types_oplog (
     regulation_role_type_id integer,
     validity_start_date timestamp without time zone,
     validity_end_date timestamp without time zone,
@@ -6012,7 +6054,7 @@ CREATE TABLE regulation_role_types_oplog (
 -- Name: regulation_role_types; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW regulation_role_types AS
+CREATE VIEW public.regulation_role_types AS
  SELECT regulation_role_types1.regulation_role_type_id,
     regulation_role_types1.validity_start_date,
     regulation_role_types1.validity_end_date,
@@ -6020,9 +6062,9 @@ CREATE VIEW regulation_role_types AS
     regulation_role_types1.oid,
     regulation_role_types1.operation,
     regulation_role_types1.operation_date
-   FROM regulation_role_types_oplog regulation_role_types1
+   FROM public.regulation_role_types_oplog regulation_role_types1
   WHERE ((regulation_role_types1.oid IN ( SELECT max(regulation_role_types2.oid) AS max
-           FROM regulation_role_types_oplog regulation_role_types2
+           FROM public.regulation_role_types_oplog regulation_role_types2
           WHERE (regulation_role_types1.regulation_role_type_id = regulation_role_types2.regulation_role_type_id))) AND ((regulation_role_types1.operation)::text <> 'D'::text));
 
 
@@ -6030,7 +6072,7 @@ CREATE VIEW regulation_role_types AS
 -- Name: regulation_role_types_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE regulation_role_types_oid_seq
+CREATE SEQUENCE public.regulation_role_types_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -6042,14 +6084,14 @@ CREATE SEQUENCE regulation_role_types_oid_seq
 -- Name: regulation_role_types_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE regulation_role_types_oid_seq OWNED BY regulation_role_types_oplog.oid;
+ALTER SEQUENCE public.regulation_role_types_oid_seq OWNED BY public.regulation_role_types_oplog.oid;
 
 
 --
 -- Name: rollbacks; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE rollbacks (
+CREATE TABLE public.rollbacks (
     id integer NOT NULL,
     user_id integer,
     date date,
@@ -6063,7 +6105,7 @@ CREATE TABLE rollbacks (
 -- Name: rollbacks_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE rollbacks_id_seq
+CREATE SEQUENCE public.rollbacks_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -6075,14 +6117,14 @@ CREATE SEQUENCE rollbacks_id_seq
 -- Name: rollbacks_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE rollbacks_id_seq OWNED BY rollbacks.id;
+ALTER SEQUENCE public.rollbacks_id_seq OWNED BY public.rollbacks.id;
 
 
 --
 -- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE schema_migrations (
+CREATE TABLE public.schema_migrations (
     filename text NOT NULL
 );
 
@@ -6091,7 +6133,7 @@ CREATE TABLE schema_migrations (
 -- Name: search_references; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE search_references (
+CREATE TABLE public.search_references (
     id integer NOT NULL,
     title text,
     referenced_id character varying(10),
@@ -6103,7 +6145,7 @@ CREATE TABLE search_references (
 -- Name: search_references_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE search_references_id_seq
+CREATE SEQUENCE public.search_references_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -6115,14 +6157,14 @@ CREATE SEQUENCE search_references_id_seq
 -- Name: search_references_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE search_references_id_seq OWNED BY search_references.id;
+ALTER SEQUENCE public.search_references_id_seq OWNED BY public.search_references.id;
 
 
 --
 -- Name: section_notes; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE section_notes (
+CREATE TABLE public.section_notes (
     id integer NOT NULL,
     section_id integer,
     content text
@@ -6133,7 +6175,7 @@ CREATE TABLE section_notes (
 -- Name: section_notes_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE section_notes_id_seq
+CREATE SEQUENCE public.section_notes_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -6145,14 +6187,14 @@ CREATE SEQUENCE section_notes_id_seq
 -- Name: section_notes_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE section_notes_id_seq OWNED BY section_notes.id;
+ALTER SEQUENCE public.section_notes_id_seq OWNED BY public.section_notes.id;
 
 
 --
 -- Name: sections; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE sections (
+CREATE TABLE public.sections (
     id integer NOT NULL,
     "position" integer,
     numeral character varying(255),
@@ -6165,7 +6207,7 @@ CREATE TABLE sections (
 -- Name: sections_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE sections_id_seq
+CREATE SEQUENCE public.sections_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -6177,14 +6219,14 @@ CREATE SEQUENCE sections_id_seq
 -- Name: sections_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE sections_id_seq OWNED BY sections.id;
+ALTER SEQUENCE public.sections_id_seq OWNED BY public.sections.id;
 
 
 --
 -- Name: tariff_update_conformance_errors; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE tariff_update_conformance_errors (
+CREATE TABLE public.tariff_update_conformance_errors (
     id integer NOT NULL,
     tariff_update_filename text NOT NULL,
     model_name text NOT NULL,
@@ -6198,7 +6240,7 @@ CREATE TABLE tariff_update_conformance_errors (
 -- Name: tariff_update_conformance_errors_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE tariff_update_conformance_errors_id_seq
+CREATE SEQUENCE public.tariff_update_conformance_errors_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -6210,14 +6252,14 @@ CREATE SEQUENCE tariff_update_conformance_errors_id_seq
 -- Name: tariff_update_conformance_errors_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE tariff_update_conformance_errors_id_seq OWNED BY tariff_update_conformance_errors.id;
+ALTER SEQUENCE public.tariff_update_conformance_errors_id_seq OWNED BY public.tariff_update_conformance_errors.id;
 
 
 --
 -- Name: tariff_updates; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE tariff_updates (
+CREATE TABLE public.tariff_updates (
     filename character varying(30) NOT NULL,
     update_type character varying(50),
     state character varying(1),
@@ -6238,7 +6280,7 @@ CREATE TABLE tariff_updates (
 -- Name: transmission_comments_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE transmission_comments_oplog (
+CREATE TABLE public.transmission_comments_oplog (
     comment_sid integer,
     language_id character varying(5),
     comment_text text,
@@ -6253,16 +6295,16 @@ CREATE TABLE transmission_comments_oplog (
 -- Name: transmission_comments; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW transmission_comments AS
+CREATE VIEW public.transmission_comments AS
  SELECT transmission_comments1.comment_sid,
     transmission_comments1.language_id,
     transmission_comments1.comment_text,
     transmission_comments1.oid,
     transmission_comments1.operation,
     transmission_comments1.operation_date
-   FROM transmission_comments_oplog transmission_comments1
+   FROM public.transmission_comments_oplog transmission_comments1
   WHERE ((transmission_comments1.oid IN ( SELECT max(transmission_comments2.oid) AS max
-           FROM transmission_comments_oplog transmission_comments2
+           FROM public.transmission_comments_oplog transmission_comments2
           WHERE ((transmission_comments1.comment_sid = transmission_comments2.comment_sid) AND ((transmission_comments1.language_id)::text = (transmission_comments2.language_id)::text)))) AND ((transmission_comments1.operation)::text <> 'D'::text));
 
 
@@ -6270,7 +6312,7 @@ CREATE VIEW transmission_comments AS
 -- Name: transmission_comments_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE transmission_comments_oid_seq
+CREATE SEQUENCE public.transmission_comments_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -6282,14 +6324,14 @@ CREATE SEQUENCE transmission_comments_oid_seq
 -- Name: transmission_comments_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE transmission_comments_oid_seq OWNED BY transmission_comments_oplog.oid;
+ALTER SEQUENCE public.transmission_comments_oid_seq OWNED BY public.transmission_comments_oplog.oid;
 
 
 --
 -- Name: users; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE users (
+CREATE TABLE public.users (
     id integer NOT NULL,
     uid text,
     name text,
@@ -6309,7 +6351,7 @@ CREATE TABLE users (
 -- Name: users_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE users_id_seq
+CREATE SEQUENCE public.users_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -6321,791 +6363,791 @@ CREATE SEQUENCE users_id_seq
 -- Name: users_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE users_id_seq OWNED BY users.id;
+ALTER SEQUENCE public.users_id_seq OWNED BY public.users.id;
 
 
 --
 -- Name: additional_code_description_periods_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY additional_code_description_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('additional_code_description_periods_oid_seq'::regclass);
+ALTER TABLE ONLY public.additional_code_description_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('public.additional_code_description_periods_oid_seq'::regclass);
 
 
 --
 -- Name: additional_code_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY additional_code_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('additional_code_descriptions_oid_seq'::regclass);
+ALTER TABLE ONLY public.additional_code_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.additional_code_descriptions_oid_seq'::regclass);
 
 
 --
 -- Name: additional_code_type_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY additional_code_type_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('additional_code_type_descriptions_oid_seq'::regclass);
+ALTER TABLE ONLY public.additional_code_type_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.additional_code_type_descriptions_oid_seq'::regclass);
 
 
 --
 -- Name: additional_code_type_measure_types_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY additional_code_type_measure_types_oplog ALTER COLUMN oid SET DEFAULT nextval('additional_code_type_measure_types_oid_seq'::regclass);
+ALTER TABLE ONLY public.additional_code_type_measure_types_oplog ALTER COLUMN oid SET DEFAULT nextval('public.additional_code_type_measure_types_oid_seq'::regclass);
 
 
 --
 -- Name: additional_code_types_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY additional_code_types_oplog ALTER COLUMN oid SET DEFAULT nextval('additional_code_types_oid_seq'::regclass);
+ALTER TABLE ONLY public.additional_code_types_oplog ALTER COLUMN oid SET DEFAULT nextval('public.additional_code_types_oid_seq'::regclass);
 
 
 --
 -- Name: additional_codes_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY additional_codes_oplog ALTER COLUMN oid SET DEFAULT nextval('additional_codes_oid_seq'::regclass);
+ALTER TABLE ONLY public.additional_codes_oplog ALTER COLUMN oid SET DEFAULT nextval('public.additional_codes_oid_seq'::regclass);
 
 
 --
 -- Name: audits id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY audits ALTER COLUMN id SET DEFAULT nextval('audits_id_seq'::regclass);
+ALTER TABLE ONLY public.audits ALTER COLUMN id SET DEFAULT nextval('public.audits_id_seq'::regclass);
 
 
 --
 -- Name: base_regulations_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY base_regulations_oplog ALTER COLUMN oid SET DEFAULT nextval('base_regulations_oid_seq'::regclass);
+ALTER TABLE ONLY public.base_regulations_oplog ALTER COLUMN oid SET DEFAULT nextval('public.base_regulations_oid_seq'::regclass);
 
 
 --
 -- Name: certificate_description_periods_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY certificate_description_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('certificate_description_periods_oid_seq'::regclass);
+ALTER TABLE ONLY public.certificate_description_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('public.certificate_description_periods_oid_seq'::regclass);
 
 
 --
 -- Name: certificate_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY certificate_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('certificate_descriptions_oid_seq'::regclass);
+ALTER TABLE ONLY public.certificate_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.certificate_descriptions_oid_seq'::regclass);
 
 
 --
 -- Name: certificate_type_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY certificate_type_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('certificate_type_descriptions_oid_seq'::regclass);
+ALTER TABLE ONLY public.certificate_type_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.certificate_type_descriptions_oid_seq'::regclass);
 
 
 --
 -- Name: certificate_types_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY certificate_types_oplog ALTER COLUMN oid SET DEFAULT nextval('certificate_types_oid_seq'::regclass);
+ALTER TABLE ONLY public.certificate_types_oplog ALTER COLUMN oid SET DEFAULT nextval('public.certificate_types_oid_seq'::regclass);
 
 
 --
 -- Name: certificates_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY certificates_oplog ALTER COLUMN oid SET DEFAULT nextval('certificates_oid_seq'::regclass);
+ALTER TABLE ONLY public.certificates_oplog ALTER COLUMN oid SET DEFAULT nextval('public.certificates_oid_seq'::regclass);
 
 
 --
 -- Name: chapter_notes id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY chapter_notes ALTER COLUMN id SET DEFAULT nextval('chapter_notes_id_seq'::regclass);
+ALTER TABLE ONLY public.chapter_notes ALTER COLUMN id SET DEFAULT nextval('public.chapter_notes_id_seq'::regclass);
 
 
 --
 -- Name: chief_duty_expression id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY chief_duty_expression ALTER COLUMN id SET DEFAULT nextval('chief_duty_expression_id_seq'::regclass);
+ALTER TABLE ONLY public.chief_duty_expression ALTER COLUMN id SET DEFAULT nextval('public.chief_duty_expression_id_seq'::regclass);
 
 
 --
 -- Name: chief_measure_type_footnote id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY chief_measure_type_footnote ALTER COLUMN id SET DEFAULT nextval('chief_measure_type_footnote_id_seq'::regclass);
+ALTER TABLE ONLY public.chief_measure_type_footnote ALTER COLUMN id SET DEFAULT nextval('public.chief_measure_type_footnote_id_seq'::regclass);
 
 
 --
 -- Name: chief_measurement_unit id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY chief_measurement_unit ALTER COLUMN id SET DEFAULT nextval('chief_measurement_unit_id_seq'::regclass);
+ALTER TABLE ONLY public.chief_measurement_unit ALTER COLUMN id SET DEFAULT nextval('public.chief_measurement_unit_id_seq'::regclass);
 
 
 --
 -- Name: complete_abrogation_regulations_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY complete_abrogation_regulations_oplog ALTER COLUMN oid SET DEFAULT nextval('complete_abrogation_regulations_oid_seq'::regclass);
+ALTER TABLE ONLY public.complete_abrogation_regulations_oplog ALTER COLUMN oid SET DEFAULT nextval('public.complete_abrogation_regulations_oid_seq'::regclass);
 
 
 --
 -- Name: duty_expression_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY duty_expression_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('duty_expression_descriptions_oid_seq'::regclass);
+ALTER TABLE ONLY public.duty_expression_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.duty_expression_descriptions_oid_seq'::regclass);
 
 
 --
 -- Name: duty_expressions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY duty_expressions_oplog ALTER COLUMN oid SET DEFAULT nextval('duty_expressions_oid_seq'::regclass);
+ALTER TABLE ONLY public.duty_expressions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.duty_expressions_oid_seq'::regclass);
 
 
 --
 -- Name: explicit_abrogation_regulations_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY explicit_abrogation_regulations_oplog ALTER COLUMN oid SET DEFAULT nextval('explicit_abrogation_regulations_oid_seq'::regclass);
+ALTER TABLE ONLY public.explicit_abrogation_regulations_oplog ALTER COLUMN oid SET DEFAULT nextval('public.explicit_abrogation_regulations_oid_seq'::regclass);
 
 
 --
 -- Name: export_refund_nomenclature_description_periods_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY export_refund_nomenclature_description_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('export_refund_nomenclature_description_periods_oid_seq'::regclass);
+ALTER TABLE ONLY public.export_refund_nomenclature_description_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('public.export_refund_nomenclature_description_periods_oid_seq'::regclass);
 
 
 --
 -- Name: export_refund_nomenclature_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY export_refund_nomenclature_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('export_refund_nomenclature_descriptions_oid_seq'::regclass);
+ALTER TABLE ONLY public.export_refund_nomenclature_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.export_refund_nomenclature_descriptions_oid_seq'::regclass);
 
 
 --
 -- Name: export_refund_nomenclature_indents_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY export_refund_nomenclature_indents_oplog ALTER COLUMN oid SET DEFAULT nextval('export_refund_nomenclature_indents_oid_seq'::regclass);
+ALTER TABLE ONLY public.export_refund_nomenclature_indents_oplog ALTER COLUMN oid SET DEFAULT nextval('public.export_refund_nomenclature_indents_oid_seq'::regclass);
 
 
 --
 -- Name: export_refund_nomenclatures_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY export_refund_nomenclatures_oplog ALTER COLUMN oid SET DEFAULT nextval('export_refund_nomenclatures_oid_seq'::regclass);
+ALTER TABLE ONLY public.export_refund_nomenclatures_oplog ALTER COLUMN oid SET DEFAULT nextval('public.export_refund_nomenclatures_oid_seq'::regclass);
 
 
 --
 -- Name: footnote_association_additional_codes_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY footnote_association_additional_codes_oplog ALTER COLUMN oid SET DEFAULT nextval('footnote_association_additional_codes_oid_seq'::regclass);
+ALTER TABLE ONLY public.footnote_association_additional_codes_oplog ALTER COLUMN oid SET DEFAULT nextval('public.footnote_association_additional_codes_oid_seq'::regclass);
 
 
 --
 -- Name: footnote_association_erns_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY footnote_association_erns_oplog ALTER COLUMN oid SET DEFAULT nextval('footnote_association_erns_oid_seq'::regclass);
+ALTER TABLE ONLY public.footnote_association_erns_oplog ALTER COLUMN oid SET DEFAULT nextval('public.footnote_association_erns_oid_seq'::regclass);
 
 
 --
 -- Name: footnote_association_goods_nomenclatures_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY footnote_association_goods_nomenclatures_oplog ALTER COLUMN oid SET DEFAULT nextval('footnote_association_goods_nomenclatures_oid_seq'::regclass);
+ALTER TABLE ONLY public.footnote_association_goods_nomenclatures_oplog ALTER COLUMN oid SET DEFAULT nextval('public.footnote_association_goods_nomenclatures_oid_seq'::regclass);
 
 
 --
 -- Name: footnote_association_measures_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY footnote_association_measures_oplog ALTER COLUMN oid SET DEFAULT nextval('footnote_association_measures_oid_seq'::regclass);
+ALTER TABLE ONLY public.footnote_association_measures_oplog ALTER COLUMN oid SET DEFAULT nextval('public.footnote_association_measures_oid_seq'::regclass);
 
 
 --
 -- Name: footnote_association_meursing_headings_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY footnote_association_meursing_headings_oplog ALTER COLUMN oid SET DEFAULT nextval('footnote_association_meursing_headings_oid_seq'::regclass);
+ALTER TABLE ONLY public.footnote_association_meursing_headings_oplog ALTER COLUMN oid SET DEFAULT nextval('public.footnote_association_meursing_headings_oid_seq'::regclass);
 
 
 --
 -- Name: footnote_description_periods_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY footnote_description_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('footnote_description_periods_oid_seq'::regclass);
+ALTER TABLE ONLY public.footnote_description_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('public.footnote_description_periods_oid_seq'::regclass);
 
 
 --
 -- Name: footnote_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY footnote_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('footnote_descriptions_oid_seq'::regclass);
+ALTER TABLE ONLY public.footnote_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.footnote_descriptions_oid_seq'::regclass);
 
 
 --
 -- Name: footnote_type_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY footnote_type_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('footnote_type_descriptions_oid_seq'::regclass);
+ALTER TABLE ONLY public.footnote_type_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.footnote_type_descriptions_oid_seq'::regclass);
 
 
 --
 -- Name: footnote_types_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY footnote_types_oplog ALTER COLUMN oid SET DEFAULT nextval('footnote_types_oid_seq'::regclass);
+ALTER TABLE ONLY public.footnote_types_oplog ALTER COLUMN oid SET DEFAULT nextval('public.footnote_types_oid_seq'::regclass);
 
 
 --
 -- Name: footnotes_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY footnotes_oplog ALTER COLUMN oid SET DEFAULT nextval('footnotes_oid_seq'::regclass);
+ALTER TABLE ONLY public.footnotes_oplog ALTER COLUMN oid SET DEFAULT nextval('public.footnotes_oid_seq'::regclass);
 
 
 --
 -- Name: fts_regulation_actions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY fts_regulation_actions_oplog ALTER COLUMN oid SET DEFAULT nextval('fts_regulation_actions_oid_seq'::regclass);
+ALTER TABLE ONLY public.fts_regulation_actions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.fts_regulation_actions_oid_seq'::regclass);
 
 
 --
 -- Name: full_temporary_stop_regulations_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY full_temporary_stop_regulations_oplog ALTER COLUMN oid SET DEFAULT nextval('full_temporary_stop_regulations_oid_seq'::regclass);
+ALTER TABLE ONLY public.full_temporary_stop_regulations_oplog ALTER COLUMN oid SET DEFAULT nextval('public.full_temporary_stop_regulations_oid_seq'::regclass);
 
 
 --
 -- Name: geographical_area_description_periods_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY geographical_area_description_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('geographical_area_description_periods_oid_seq'::regclass);
+ALTER TABLE ONLY public.geographical_area_description_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('public.geographical_area_description_periods_oid_seq'::regclass);
 
 
 --
 -- Name: geographical_area_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY geographical_area_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('geographical_area_descriptions_oid_seq'::regclass);
+ALTER TABLE ONLY public.geographical_area_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.geographical_area_descriptions_oid_seq'::regclass);
 
 
 --
 -- Name: geographical_area_memberships_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY geographical_area_memberships_oplog ALTER COLUMN oid SET DEFAULT nextval('geographical_area_memberships_oid_seq'::regclass);
+ALTER TABLE ONLY public.geographical_area_memberships_oplog ALTER COLUMN oid SET DEFAULT nextval('public.geographical_area_memberships_oid_seq'::regclass);
 
 
 --
 -- Name: geographical_areas_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY geographical_areas_oplog ALTER COLUMN oid SET DEFAULT nextval('geographical_areas_oid_seq'::regclass);
+ALTER TABLE ONLY public.geographical_areas_oplog ALTER COLUMN oid SET DEFAULT nextval('public.geographical_areas_oid_seq'::regclass);
 
 
 --
 -- Name: goods_nomenclature_description_periods_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY goods_nomenclature_description_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('goods_nomenclature_description_periods_oid_seq'::regclass);
+ALTER TABLE ONLY public.goods_nomenclature_description_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('public.goods_nomenclature_description_periods_oid_seq'::regclass);
 
 
 --
 -- Name: goods_nomenclature_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY goods_nomenclature_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('goods_nomenclature_descriptions_oid_seq'::regclass);
+ALTER TABLE ONLY public.goods_nomenclature_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.goods_nomenclature_descriptions_oid_seq'::regclass);
 
 
 --
 -- Name: goods_nomenclature_group_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY goods_nomenclature_group_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('goods_nomenclature_group_descriptions_oid_seq'::regclass);
+ALTER TABLE ONLY public.goods_nomenclature_group_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.goods_nomenclature_group_descriptions_oid_seq'::regclass);
 
 
 --
 -- Name: goods_nomenclature_groups_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY goods_nomenclature_groups_oplog ALTER COLUMN oid SET DEFAULT nextval('goods_nomenclature_groups_oid_seq'::regclass);
+ALTER TABLE ONLY public.goods_nomenclature_groups_oplog ALTER COLUMN oid SET DEFAULT nextval('public.goods_nomenclature_groups_oid_seq'::regclass);
 
 
 --
 -- Name: goods_nomenclature_indents_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY goods_nomenclature_indents_oplog ALTER COLUMN oid SET DEFAULT nextval('goods_nomenclature_indents_oid_seq'::regclass);
+ALTER TABLE ONLY public.goods_nomenclature_indents_oplog ALTER COLUMN oid SET DEFAULT nextval('public.goods_nomenclature_indents_oid_seq'::regclass);
 
 
 --
 -- Name: goods_nomenclature_origins_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY goods_nomenclature_origins_oplog ALTER COLUMN oid SET DEFAULT nextval('goods_nomenclature_origins_oid_seq'::regclass);
+ALTER TABLE ONLY public.goods_nomenclature_origins_oplog ALTER COLUMN oid SET DEFAULT nextval('public.goods_nomenclature_origins_oid_seq'::regclass);
 
 
 --
 -- Name: goods_nomenclature_successors_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY goods_nomenclature_successors_oplog ALTER COLUMN oid SET DEFAULT nextval('goods_nomenclature_successors_oid_seq'::regclass);
+ALTER TABLE ONLY public.goods_nomenclature_successors_oplog ALTER COLUMN oid SET DEFAULT nextval('public.goods_nomenclature_successors_oid_seq'::regclass);
 
 
 --
 -- Name: goods_nomenclatures_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY goods_nomenclatures_oplog ALTER COLUMN oid SET DEFAULT nextval('goods_nomenclatures_oid_seq'::regclass);
+ALTER TABLE ONLY public.goods_nomenclatures_oplog ALTER COLUMN oid SET DEFAULT nextval('public.goods_nomenclatures_oid_seq'::regclass);
 
 
 --
 -- Name: language_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY language_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('language_descriptions_oid_seq'::regclass);
+ALTER TABLE ONLY public.language_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.language_descriptions_oid_seq'::regclass);
 
 
 --
 -- Name: languages_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY languages_oplog ALTER COLUMN oid SET DEFAULT nextval('languages_oid_seq'::regclass);
+ALTER TABLE ONLY public.languages_oplog ALTER COLUMN oid SET DEFAULT nextval('public.languages_oid_seq'::regclass);
 
 
 --
 -- Name: measure_action_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY measure_action_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('measure_action_descriptions_oid_seq'::regclass);
+ALTER TABLE ONLY public.measure_action_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.measure_action_descriptions_oid_seq'::regclass);
 
 
 --
 -- Name: measure_actions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY measure_actions_oplog ALTER COLUMN oid SET DEFAULT nextval('measure_actions_oid_seq'::regclass);
+ALTER TABLE ONLY public.measure_actions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.measure_actions_oid_seq'::regclass);
 
 
 --
 -- Name: measure_components_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY measure_components_oplog ALTER COLUMN oid SET DEFAULT nextval('measure_components_oid_seq'::regclass);
+ALTER TABLE ONLY public.measure_components_oplog ALTER COLUMN oid SET DEFAULT nextval('public.measure_components_oid_seq'::regclass);
 
 
 --
 -- Name: measure_condition_code_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY measure_condition_code_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('measure_condition_code_descriptions_oid_seq'::regclass);
+ALTER TABLE ONLY public.measure_condition_code_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.measure_condition_code_descriptions_oid_seq'::regclass);
 
 
 --
 -- Name: measure_condition_codes_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY measure_condition_codes_oplog ALTER COLUMN oid SET DEFAULT nextval('measure_condition_codes_oid_seq'::regclass);
+ALTER TABLE ONLY public.measure_condition_codes_oplog ALTER COLUMN oid SET DEFAULT nextval('public.measure_condition_codes_oid_seq'::regclass);
 
 
 --
 -- Name: measure_condition_components_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY measure_condition_components_oplog ALTER COLUMN oid SET DEFAULT nextval('measure_condition_components_oid_seq'::regclass);
+ALTER TABLE ONLY public.measure_condition_components_oplog ALTER COLUMN oid SET DEFAULT nextval('public.measure_condition_components_oid_seq'::regclass);
 
 
 --
 -- Name: measure_conditions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY measure_conditions_oplog ALTER COLUMN oid SET DEFAULT nextval('measure_conditions_oid_seq'::regclass);
+ALTER TABLE ONLY public.measure_conditions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.measure_conditions_oid_seq'::regclass);
 
 
 --
 -- Name: measure_excluded_geographical_areas_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY measure_excluded_geographical_areas_oplog ALTER COLUMN oid SET DEFAULT nextval('measure_excluded_geographical_areas_oid_seq'::regclass);
+ALTER TABLE ONLY public.measure_excluded_geographical_areas_oplog ALTER COLUMN oid SET DEFAULT nextval('public.measure_excluded_geographical_areas_oid_seq'::regclass);
 
 
 --
 -- Name: measure_partial_temporary_stops_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY measure_partial_temporary_stops_oplog ALTER COLUMN oid SET DEFAULT nextval('measure_partial_temporary_stops_oid_seq'::regclass);
+ALTER TABLE ONLY public.measure_partial_temporary_stops_oplog ALTER COLUMN oid SET DEFAULT nextval('public.measure_partial_temporary_stops_oid_seq'::regclass);
 
 
 --
 -- Name: measure_type_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY measure_type_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('measure_type_descriptions_oid_seq'::regclass);
+ALTER TABLE ONLY public.measure_type_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.measure_type_descriptions_oid_seq'::regclass);
 
 
 --
 -- Name: measure_type_series_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY measure_type_series_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('measure_type_series_descriptions_oid_seq'::regclass);
+ALTER TABLE ONLY public.measure_type_series_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.measure_type_series_descriptions_oid_seq'::regclass);
 
 
 --
 -- Name: measure_type_series_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY measure_type_series_oplog ALTER COLUMN oid SET DEFAULT nextval('measure_type_series_oid_seq'::regclass);
+ALTER TABLE ONLY public.measure_type_series_oplog ALTER COLUMN oid SET DEFAULT nextval('public.measure_type_series_oid_seq'::regclass);
 
 
 --
 -- Name: measure_types_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY measure_types_oplog ALTER COLUMN oid SET DEFAULT nextval('measure_types_oid_seq'::regclass);
+ALTER TABLE ONLY public.measure_types_oplog ALTER COLUMN oid SET DEFAULT nextval('public.measure_types_oid_seq'::regclass);
 
 
 --
 -- Name: measurement_unit_abbreviations id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY measurement_unit_abbreviations ALTER COLUMN id SET DEFAULT nextval('measurement_unit_abbreviations_id_seq'::regclass);
+ALTER TABLE ONLY public.measurement_unit_abbreviations ALTER COLUMN id SET DEFAULT nextval('public.measurement_unit_abbreviations_id_seq'::regclass);
 
 
 --
 -- Name: measurement_unit_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY measurement_unit_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('measurement_unit_descriptions_oid_seq'::regclass);
+ALTER TABLE ONLY public.measurement_unit_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.measurement_unit_descriptions_oid_seq'::regclass);
 
 
 --
 -- Name: measurement_unit_qualifier_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY measurement_unit_qualifier_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('measurement_unit_qualifier_descriptions_oid_seq'::regclass);
+ALTER TABLE ONLY public.measurement_unit_qualifier_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.measurement_unit_qualifier_descriptions_oid_seq'::regclass);
 
 
 --
 -- Name: measurement_unit_qualifiers_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY measurement_unit_qualifiers_oplog ALTER COLUMN oid SET DEFAULT nextval('measurement_unit_qualifiers_oid_seq'::regclass);
+ALTER TABLE ONLY public.measurement_unit_qualifiers_oplog ALTER COLUMN oid SET DEFAULT nextval('public.measurement_unit_qualifiers_oid_seq'::regclass);
 
 
 --
 -- Name: measurement_units_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY measurement_units_oplog ALTER COLUMN oid SET DEFAULT nextval('measurement_units_oid_seq'::regclass);
+ALTER TABLE ONLY public.measurement_units_oplog ALTER COLUMN oid SET DEFAULT nextval('public.measurement_units_oid_seq'::regclass);
 
 
 --
 -- Name: measurements_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY measurements_oplog ALTER COLUMN oid SET DEFAULT nextval('measurements_oid_seq'::regclass);
+ALTER TABLE ONLY public.measurements_oplog ALTER COLUMN oid SET DEFAULT nextval('public.measurements_oid_seq'::regclass);
 
 
 --
 -- Name: measures_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY measures_oplog ALTER COLUMN oid SET DEFAULT nextval('measures_oid_seq'::regclass);
+ALTER TABLE ONLY public.measures_oplog ALTER COLUMN oid SET DEFAULT nextval('public.measures_oid_seq'::regclass);
 
 
 --
 -- Name: meursing_additional_codes_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY meursing_additional_codes_oplog ALTER COLUMN oid SET DEFAULT nextval('meursing_additional_codes_oid_seq'::regclass);
+ALTER TABLE ONLY public.meursing_additional_codes_oplog ALTER COLUMN oid SET DEFAULT nextval('public.meursing_additional_codes_oid_seq'::regclass);
 
 
 --
 -- Name: meursing_heading_texts_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY meursing_heading_texts_oplog ALTER COLUMN oid SET DEFAULT nextval('meursing_heading_texts_oid_seq'::regclass);
+ALTER TABLE ONLY public.meursing_heading_texts_oplog ALTER COLUMN oid SET DEFAULT nextval('public.meursing_heading_texts_oid_seq'::regclass);
 
 
 --
 -- Name: meursing_headings_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY meursing_headings_oplog ALTER COLUMN oid SET DEFAULT nextval('meursing_headings_oid_seq'::regclass);
+ALTER TABLE ONLY public.meursing_headings_oplog ALTER COLUMN oid SET DEFAULT nextval('public.meursing_headings_oid_seq'::regclass);
 
 
 --
 -- Name: meursing_subheadings_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY meursing_subheadings_oplog ALTER COLUMN oid SET DEFAULT nextval('meursing_subheadings_oid_seq'::regclass);
+ALTER TABLE ONLY public.meursing_subheadings_oplog ALTER COLUMN oid SET DEFAULT nextval('public.meursing_subheadings_oid_seq'::regclass);
 
 
 --
 -- Name: meursing_table_cell_components_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY meursing_table_cell_components_oplog ALTER COLUMN oid SET DEFAULT nextval('meursing_table_cell_components_oid_seq'::regclass);
+ALTER TABLE ONLY public.meursing_table_cell_components_oplog ALTER COLUMN oid SET DEFAULT nextval('public.meursing_table_cell_components_oid_seq'::regclass);
 
 
 --
 -- Name: meursing_table_plans_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY meursing_table_plans_oplog ALTER COLUMN oid SET DEFAULT nextval('meursing_table_plans_oid_seq'::regclass);
+ALTER TABLE ONLY public.meursing_table_plans_oplog ALTER COLUMN oid SET DEFAULT nextval('public.meursing_table_plans_oid_seq'::regclass);
 
 
 --
 -- Name: modification_regulations_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY modification_regulations_oplog ALTER COLUMN oid SET DEFAULT nextval('modification_regulations_oid_seq'::regclass);
+ALTER TABLE ONLY public.modification_regulations_oplog ALTER COLUMN oid SET DEFAULT nextval('public.modification_regulations_oid_seq'::regclass);
 
 
 --
 -- Name: monetary_exchange_periods_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY monetary_exchange_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('monetary_exchange_periods_oid_seq'::regclass);
+ALTER TABLE ONLY public.monetary_exchange_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('public.monetary_exchange_periods_oid_seq'::regclass);
 
 
 --
 -- Name: monetary_exchange_rates_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY monetary_exchange_rates_oplog ALTER COLUMN oid SET DEFAULT nextval('monetary_exchange_rates_oid_seq'::regclass);
+ALTER TABLE ONLY public.monetary_exchange_rates_oplog ALTER COLUMN oid SET DEFAULT nextval('public.monetary_exchange_rates_oid_seq'::regclass);
 
 
 --
 -- Name: monetary_unit_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY monetary_unit_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('monetary_unit_descriptions_oid_seq'::regclass);
+ALTER TABLE ONLY public.monetary_unit_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.monetary_unit_descriptions_oid_seq'::regclass);
 
 
 --
 -- Name: monetary_units_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY monetary_units_oplog ALTER COLUMN oid SET DEFAULT nextval('monetary_units_oid_seq'::regclass);
+ALTER TABLE ONLY public.monetary_units_oplog ALTER COLUMN oid SET DEFAULT nextval('public.monetary_units_oid_seq'::regclass);
 
 
 --
 -- Name: nomenclature_group_memberships_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY nomenclature_group_memberships_oplog ALTER COLUMN oid SET DEFAULT nextval('nomenclature_group_memberships_oid_seq'::regclass);
+ALTER TABLE ONLY public.nomenclature_group_memberships_oplog ALTER COLUMN oid SET DEFAULT nextval('public.nomenclature_group_memberships_oid_seq'::regclass);
 
 
 --
 -- Name: prorogation_regulation_actions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY prorogation_regulation_actions_oplog ALTER COLUMN oid SET DEFAULT nextval('prorogation_regulation_actions_oid_seq'::regclass);
+ALTER TABLE ONLY public.prorogation_regulation_actions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.prorogation_regulation_actions_oid_seq'::regclass);
 
 
 --
 -- Name: prorogation_regulations_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY prorogation_regulations_oplog ALTER COLUMN oid SET DEFAULT nextval('prorogation_regulations_oid_seq'::regclass);
+ALTER TABLE ONLY public.prorogation_regulations_oplog ALTER COLUMN oid SET DEFAULT nextval('public.prorogation_regulations_oid_seq'::regclass);
 
 
 --
 -- Name: publication_sigles_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY publication_sigles_oplog ALTER COLUMN oid SET DEFAULT nextval('publication_sigles_oplog_oid_seq'::regclass);
+ALTER TABLE ONLY public.publication_sigles_oplog ALTER COLUMN oid SET DEFAULT nextval('public.publication_sigles_oplog_oid_seq'::regclass);
 
 
 --
 -- Name: quota_associations_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY quota_associations_oplog ALTER COLUMN oid SET DEFAULT nextval('quota_associations_oid_seq'::regclass);
+ALTER TABLE ONLY public.quota_associations_oplog ALTER COLUMN oid SET DEFAULT nextval('public.quota_associations_oid_seq'::regclass);
 
 
 --
 -- Name: quota_balance_events_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY quota_balance_events_oplog ALTER COLUMN oid SET DEFAULT nextval('quota_balance_events_oid_seq'::regclass);
+ALTER TABLE ONLY public.quota_balance_events_oplog ALTER COLUMN oid SET DEFAULT nextval('public.quota_balance_events_oid_seq'::regclass);
 
 
 --
 -- Name: quota_blocking_periods_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY quota_blocking_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('quota_blocking_periods_oid_seq'::regclass);
+ALTER TABLE ONLY public.quota_blocking_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('public.quota_blocking_periods_oid_seq'::regclass);
 
 
 --
 -- Name: quota_critical_events_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY quota_critical_events_oplog ALTER COLUMN oid SET DEFAULT nextval('quota_critical_events_oid_seq'::regclass);
+ALTER TABLE ONLY public.quota_critical_events_oplog ALTER COLUMN oid SET DEFAULT nextval('public.quota_critical_events_oid_seq'::regclass);
 
 
 --
 -- Name: quota_definitions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY quota_definitions_oplog ALTER COLUMN oid SET DEFAULT nextval('quota_definitions_oid_seq'::regclass);
+ALTER TABLE ONLY public.quota_definitions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.quota_definitions_oid_seq'::regclass);
 
 
 --
 -- Name: quota_exhaustion_events_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY quota_exhaustion_events_oplog ALTER COLUMN oid SET DEFAULT nextval('quota_exhaustion_events_oid_seq'::regclass);
+ALTER TABLE ONLY public.quota_exhaustion_events_oplog ALTER COLUMN oid SET DEFAULT nextval('public.quota_exhaustion_events_oid_seq'::regclass);
 
 
 --
 -- Name: quota_order_number_origin_exclusions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY quota_order_number_origin_exclusions_oplog ALTER COLUMN oid SET DEFAULT nextval('quota_order_number_origin_exclusions_oid_seq'::regclass);
+ALTER TABLE ONLY public.quota_order_number_origin_exclusions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.quota_order_number_origin_exclusions_oid_seq'::regclass);
 
 
 --
 -- Name: quota_order_number_origins_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY quota_order_number_origins_oplog ALTER COLUMN oid SET DEFAULT nextval('quota_order_number_origins_oid_seq'::regclass);
+ALTER TABLE ONLY public.quota_order_number_origins_oplog ALTER COLUMN oid SET DEFAULT nextval('public.quota_order_number_origins_oid_seq'::regclass);
 
 
 --
 -- Name: quota_order_numbers_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY quota_order_numbers_oplog ALTER COLUMN oid SET DEFAULT nextval('quota_order_numbers_oid_seq'::regclass);
+ALTER TABLE ONLY public.quota_order_numbers_oplog ALTER COLUMN oid SET DEFAULT nextval('public.quota_order_numbers_oid_seq'::regclass);
 
 
 --
 -- Name: quota_reopening_events_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY quota_reopening_events_oplog ALTER COLUMN oid SET DEFAULT nextval('quota_reopening_events_oid_seq'::regclass);
+ALTER TABLE ONLY public.quota_reopening_events_oplog ALTER COLUMN oid SET DEFAULT nextval('public.quota_reopening_events_oid_seq'::regclass);
 
 
 --
 -- Name: quota_suspension_periods_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY quota_suspension_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('quota_suspension_periods_oid_seq'::regclass);
+ALTER TABLE ONLY public.quota_suspension_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('public.quota_suspension_periods_oid_seq'::regclass);
 
 
 --
 -- Name: quota_unblocking_events_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY quota_unblocking_events_oplog ALTER COLUMN oid SET DEFAULT nextval('quota_unblocking_events_oid_seq'::regclass);
+ALTER TABLE ONLY public.quota_unblocking_events_oplog ALTER COLUMN oid SET DEFAULT nextval('public.quota_unblocking_events_oid_seq'::regclass);
 
 
 --
 -- Name: quota_unsuspension_events_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY quota_unsuspension_events_oplog ALTER COLUMN oid SET DEFAULT nextval('quota_unsuspension_events_oid_seq'::regclass);
+ALTER TABLE ONLY public.quota_unsuspension_events_oplog ALTER COLUMN oid SET DEFAULT nextval('public.quota_unsuspension_events_oid_seq'::regclass);
 
 
 --
 -- Name: regulation_group_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY regulation_group_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('regulation_group_descriptions_oid_seq'::regclass);
+ALTER TABLE ONLY public.regulation_group_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.regulation_group_descriptions_oid_seq'::regclass);
 
 
 --
 -- Name: regulation_groups_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY regulation_groups_oplog ALTER COLUMN oid SET DEFAULT nextval('regulation_groups_oid_seq'::regclass);
+ALTER TABLE ONLY public.regulation_groups_oplog ALTER COLUMN oid SET DEFAULT nextval('public.regulation_groups_oid_seq'::regclass);
 
 
 --
 -- Name: regulation_replacements_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY regulation_replacements_oplog ALTER COLUMN oid SET DEFAULT nextval('regulation_replacements_oid_seq'::regclass);
+ALTER TABLE ONLY public.regulation_replacements_oplog ALTER COLUMN oid SET DEFAULT nextval('public.regulation_replacements_oid_seq'::regclass);
 
 
 --
 -- Name: regulation_role_type_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY regulation_role_type_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('regulation_role_type_descriptions_oid_seq'::regclass);
+ALTER TABLE ONLY public.regulation_role_type_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.regulation_role_type_descriptions_oid_seq'::regclass);
 
 
 --
 -- Name: regulation_role_types_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY regulation_role_types_oplog ALTER COLUMN oid SET DEFAULT nextval('regulation_role_types_oid_seq'::regclass);
+ALTER TABLE ONLY public.regulation_role_types_oplog ALTER COLUMN oid SET DEFAULT nextval('public.regulation_role_types_oid_seq'::regclass);
 
 
 --
 -- Name: rollbacks id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY rollbacks ALTER COLUMN id SET DEFAULT nextval('rollbacks_id_seq'::regclass);
+ALTER TABLE ONLY public.rollbacks ALTER COLUMN id SET DEFAULT nextval('public.rollbacks_id_seq'::regclass);
 
 
 --
 -- Name: search_references id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY search_references ALTER COLUMN id SET DEFAULT nextval('search_references_id_seq'::regclass);
+ALTER TABLE ONLY public.search_references ALTER COLUMN id SET DEFAULT nextval('public.search_references_id_seq'::regclass);
 
 
 --
 -- Name: section_notes id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY section_notes ALTER COLUMN id SET DEFAULT nextval('section_notes_id_seq'::regclass);
+ALTER TABLE ONLY public.section_notes ALTER COLUMN id SET DEFAULT nextval('public.section_notes_id_seq'::regclass);
 
 
 --
 -- Name: sections id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY sections ALTER COLUMN id SET DEFAULT nextval('sections_id_seq'::regclass);
+ALTER TABLE ONLY public.sections ALTER COLUMN id SET DEFAULT nextval('public.sections_id_seq'::regclass);
 
 
 --
 -- Name: tariff_update_conformance_errors id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY tariff_update_conformance_errors ALTER COLUMN id SET DEFAULT nextval('tariff_update_conformance_errors_id_seq'::regclass);
+ALTER TABLE ONLY public.tariff_update_conformance_errors ALTER COLUMN id SET DEFAULT nextval('public.tariff_update_conformance_errors_id_seq'::regclass);
 
 
 --
 -- Name: transmission_comments_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY transmission_comments_oplog ALTER COLUMN oid SET DEFAULT nextval('transmission_comments_oid_seq'::regclass);
+ALTER TABLE ONLY public.transmission_comments_oplog ALTER COLUMN oid SET DEFAULT nextval('public.transmission_comments_oid_seq'::regclass);
 
 
 --
 -- Name: users id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regclass);
+ALTER TABLE ONLY public.users ALTER COLUMN id SET DEFAULT nextval('public.users_id_seq'::regclass);
 
 
 --
 -- Name: additional_code_description_periods_oplog additional_code_description_periods_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY additional_code_description_periods_oplog
+ALTER TABLE ONLY public.additional_code_description_periods_oplog
     ADD CONSTRAINT additional_code_description_periods_pkey PRIMARY KEY (oid);
 
 
@@ -7113,7 +7155,7 @@ ALTER TABLE ONLY additional_code_description_periods_oplog
 -- Name: additional_code_descriptions_oplog additional_code_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY additional_code_descriptions_oplog
+ALTER TABLE ONLY public.additional_code_descriptions_oplog
     ADD CONSTRAINT additional_code_descriptions_pkey PRIMARY KEY (oid);
 
 
@@ -7121,7 +7163,7 @@ ALTER TABLE ONLY additional_code_descriptions_oplog
 -- Name: additional_code_type_descriptions_oplog additional_code_type_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY additional_code_type_descriptions_oplog
+ALTER TABLE ONLY public.additional_code_type_descriptions_oplog
     ADD CONSTRAINT additional_code_type_descriptions_pkey PRIMARY KEY (oid);
 
 
@@ -7129,7 +7171,7 @@ ALTER TABLE ONLY additional_code_type_descriptions_oplog
 -- Name: additional_code_type_measure_types_oplog additional_code_type_measure_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY additional_code_type_measure_types_oplog
+ALTER TABLE ONLY public.additional_code_type_measure_types_oplog
     ADD CONSTRAINT additional_code_type_measure_types_pkey PRIMARY KEY (oid);
 
 
@@ -7137,7 +7179,7 @@ ALTER TABLE ONLY additional_code_type_measure_types_oplog
 -- Name: additional_code_types_oplog additional_code_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY additional_code_types_oplog
+ALTER TABLE ONLY public.additional_code_types_oplog
     ADD CONSTRAINT additional_code_types_pkey PRIMARY KEY (oid);
 
 
@@ -7145,7 +7187,7 @@ ALTER TABLE ONLY additional_code_types_oplog
 -- Name: additional_codes_oplog additional_codes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY additional_codes_oplog
+ALTER TABLE ONLY public.additional_codes_oplog
     ADD CONSTRAINT additional_codes_pkey PRIMARY KEY (oid);
 
 
@@ -7153,7 +7195,7 @@ ALTER TABLE ONLY additional_codes_oplog
 -- Name: audits audits_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY audits
+ALTER TABLE ONLY public.audits
     ADD CONSTRAINT audits_pkey PRIMARY KEY (id);
 
 
@@ -7161,7 +7203,7 @@ ALTER TABLE ONLY audits
 -- Name: base_regulations_oplog base_regulations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY base_regulations_oplog
+ALTER TABLE ONLY public.base_regulations_oplog
     ADD CONSTRAINT base_regulations_pkey PRIMARY KEY (oid);
 
 
@@ -7169,7 +7211,7 @@ ALTER TABLE ONLY base_regulations_oplog
 -- Name: certificate_description_periods_oplog certificate_description_periods_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY certificate_description_periods_oplog
+ALTER TABLE ONLY public.certificate_description_periods_oplog
     ADD CONSTRAINT certificate_description_periods_pkey PRIMARY KEY (oid);
 
 
@@ -7177,7 +7219,7 @@ ALTER TABLE ONLY certificate_description_periods_oplog
 -- Name: certificate_descriptions_oplog certificate_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY certificate_descriptions_oplog
+ALTER TABLE ONLY public.certificate_descriptions_oplog
     ADD CONSTRAINT certificate_descriptions_pkey PRIMARY KEY (oid);
 
 
@@ -7185,7 +7227,7 @@ ALTER TABLE ONLY certificate_descriptions_oplog
 -- Name: certificate_type_descriptions_oplog certificate_type_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY certificate_type_descriptions_oplog
+ALTER TABLE ONLY public.certificate_type_descriptions_oplog
     ADD CONSTRAINT certificate_type_descriptions_pkey PRIMARY KEY (oid);
 
 
@@ -7193,7 +7235,7 @@ ALTER TABLE ONLY certificate_type_descriptions_oplog
 -- Name: certificate_types_oplog certificate_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY certificate_types_oplog
+ALTER TABLE ONLY public.certificate_types_oplog
     ADD CONSTRAINT certificate_types_pkey PRIMARY KEY (oid);
 
 
@@ -7201,7 +7243,7 @@ ALTER TABLE ONLY certificate_types_oplog
 -- Name: certificates_oplog certificates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY certificates_oplog
+ALTER TABLE ONLY public.certificates_oplog
     ADD CONSTRAINT certificates_pkey PRIMARY KEY (oid);
 
 
@@ -7209,7 +7251,7 @@ ALTER TABLE ONLY certificates_oplog
 -- Name: chapter_notes chapter_notes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY chapter_notes
+ALTER TABLE ONLY public.chapter_notes
     ADD CONSTRAINT chapter_notes_pkey PRIMARY KEY (id);
 
 
@@ -7217,7 +7259,7 @@ ALTER TABLE ONLY chapter_notes
 -- Name: chief_duty_expression chief_duty_expression_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY chief_duty_expression
+ALTER TABLE ONLY public.chief_duty_expression
     ADD CONSTRAINT chief_duty_expression_pkey PRIMARY KEY (id);
 
 
@@ -7225,7 +7267,7 @@ ALTER TABLE ONLY chief_duty_expression
 -- Name: chief_measure_type_footnote chief_measure_type_footnote_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY chief_measure_type_footnote
+ALTER TABLE ONLY public.chief_measure_type_footnote
     ADD CONSTRAINT chief_measure_type_footnote_pkey PRIMARY KEY (id);
 
 
@@ -7233,7 +7275,7 @@ ALTER TABLE ONLY chief_measure_type_footnote
 -- Name: chief_measurement_unit chief_measurement_unit_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY chief_measurement_unit
+ALTER TABLE ONLY public.chief_measurement_unit
     ADD CONSTRAINT chief_measurement_unit_pkey PRIMARY KEY (id);
 
 
@@ -7241,7 +7283,7 @@ ALTER TABLE ONLY chief_measurement_unit
 -- Name: complete_abrogation_regulations_oplog complete_abrogation_regulations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY complete_abrogation_regulations_oplog
+ALTER TABLE ONLY public.complete_abrogation_regulations_oplog
     ADD CONSTRAINT complete_abrogation_regulations_pkey PRIMARY KEY (oid);
 
 
@@ -7249,7 +7291,7 @@ ALTER TABLE ONLY complete_abrogation_regulations_oplog
 -- Name: data_migrations data_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY data_migrations
+ALTER TABLE ONLY public.data_migrations
     ADD CONSTRAINT data_migrations_pkey PRIMARY KEY (filename);
 
 
@@ -7257,7 +7299,7 @@ ALTER TABLE ONLY data_migrations
 -- Name: duty_expression_descriptions_oplog duty_expression_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY duty_expression_descriptions_oplog
+ALTER TABLE ONLY public.duty_expression_descriptions_oplog
     ADD CONSTRAINT duty_expression_descriptions_pkey PRIMARY KEY (oid);
 
 
@@ -7265,7 +7307,7 @@ ALTER TABLE ONLY duty_expression_descriptions_oplog
 -- Name: duty_expressions_oplog duty_expressions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY duty_expressions_oplog
+ALTER TABLE ONLY public.duty_expressions_oplog
     ADD CONSTRAINT duty_expressions_pkey PRIMARY KEY (oid);
 
 
@@ -7273,7 +7315,7 @@ ALTER TABLE ONLY duty_expressions_oplog
 -- Name: explicit_abrogation_regulations_oplog explicit_abrogation_regulations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY explicit_abrogation_regulations_oplog
+ALTER TABLE ONLY public.explicit_abrogation_regulations_oplog
     ADD CONSTRAINT explicit_abrogation_regulations_pkey PRIMARY KEY (oid);
 
 
@@ -7281,7 +7323,7 @@ ALTER TABLE ONLY explicit_abrogation_regulations_oplog
 -- Name: export_refund_nomenclature_description_periods_oplog export_refund_nomenclature_description_periods_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY export_refund_nomenclature_description_periods_oplog
+ALTER TABLE ONLY public.export_refund_nomenclature_description_periods_oplog
     ADD CONSTRAINT export_refund_nomenclature_description_periods_pkey PRIMARY KEY (oid);
 
 
@@ -7289,7 +7331,7 @@ ALTER TABLE ONLY export_refund_nomenclature_description_periods_oplog
 -- Name: export_refund_nomenclature_descriptions_oplog export_refund_nomenclature_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY export_refund_nomenclature_descriptions_oplog
+ALTER TABLE ONLY public.export_refund_nomenclature_descriptions_oplog
     ADD CONSTRAINT export_refund_nomenclature_descriptions_pkey PRIMARY KEY (oid);
 
 
@@ -7297,7 +7339,7 @@ ALTER TABLE ONLY export_refund_nomenclature_descriptions_oplog
 -- Name: export_refund_nomenclature_indents_oplog export_refund_nomenclature_indents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY export_refund_nomenclature_indents_oplog
+ALTER TABLE ONLY public.export_refund_nomenclature_indents_oplog
     ADD CONSTRAINT export_refund_nomenclature_indents_pkey PRIMARY KEY (oid);
 
 
@@ -7305,7 +7347,7 @@ ALTER TABLE ONLY export_refund_nomenclature_indents_oplog
 -- Name: export_refund_nomenclatures_oplog export_refund_nomenclatures_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY export_refund_nomenclatures_oplog
+ALTER TABLE ONLY public.export_refund_nomenclatures_oplog
     ADD CONSTRAINT export_refund_nomenclatures_pkey PRIMARY KEY (oid);
 
 
@@ -7313,7 +7355,7 @@ ALTER TABLE ONLY export_refund_nomenclatures_oplog
 -- Name: footnote_association_additional_codes_oplog footnote_association_additional_codes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY footnote_association_additional_codes_oplog
+ALTER TABLE ONLY public.footnote_association_additional_codes_oplog
     ADD CONSTRAINT footnote_association_additional_codes_pkey PRIMARY KEY (oid);
 
 
@@ -7321,7 +7363,7 @@ ALTER TABLE ONLY footnote_association_additional_codes_oplog
 -- Name: footnote_association_erns_oplog footnote_association_erns_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY footnote_association_erns_oplog
+ALTER TABLE ONLY public.footnote_association_erns_oplog
     ADD CONSTRAINT footnote_association_erns_pkey PRIMARY KEY (oid);
 
 
@@ -7329,7 +7371,7 @@ ALTER TABLE ONLY footnote_association_erns_oplog
 -- Name: footnote_association_goods_nomenclatures_oplog footnote_association_goods_nomenclatures_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY footnote_association_goods_nomenclatures_oplog
+ALTER TABLE ONLY public.footnote_association_goods_nomenclatures_oplog
     ADD CONSTRAINT footnote_association_goods_nomenclatures_pkey PRIMARY KEY (oid);
 
 
@@ -7337,7 +7379,7 @@ ALTER TABLE ONLY footnote_association_goods_nomenclatures_oplog
 -- Name: footnote_association_measures_oplog footnote_association_measures_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY footnote_association_measures_oplog
+ALTER TABLE ONLY public.footnote_association_measures_oplog
     ADD CONSTRAINT footnote_association_measures_pkey PRIMARY KEY (oid);
 
 
@@ -7345,7 +7387,7 @@ ALTER TABLE ONLY footnote_association_measures_oplog
 -- Name: footnote_association_meursing_headings_oplog footnote_association_meursing_headings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY footnote_association_meursing_headings_oplog
+ALTER TABLE ONLY public.footnote_association_meursing_headings_oplog
     ADD CONSTRAINT footnote_association_meursing_headings_pkey PRIMARY KEY (oid);
 
 
@@ -7353,7 +7395,7 @@ ALTER TABLE ONLY footnote_association_meursing_headings_oplog
 -- Name: footnote_description_periods_oplog footnote_description_periods_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY footnote_description_periods_oplog
+ALTER TABLE ONLY public.footnote_description_periods_oplog
     ADD CONSTRAINT footnote_description_periods_pkey PRIMARY KEY (oid);
 
 
@@ -7361,7 +7403,7 @@ ALTER TABLE ONLY footnote_description_periods_oplog
 -- Name: footnote_descriptions_oplog footnote_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY footnote_descriptions_oplog
+ALTER TABLE ONLY public.footnote_descriptions_oplog
     ADD CONSTRAINT footnote_descriptions_pkey PRIMARY KEY (oid);
 
 
@@ -7369,7 +7411,7 @@ ALTER TABLE ONLY footnote_descriptions_oplog
 -- Name: footnote_type_descriptions_oplog footnote_type_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY footnote_type_descriptions_oplog
+ALTER TABLE ONLY public.footnote_type_descriptions_oplog
     ADD CONSTRAINT footnote_type_descriptions_pkey PRIMARY KEY (oid);
 
 
@@ -7377,7 +7419,7 @@ ALTER TABLE ONLY footnote_type_descriptions_oplog
 -- Name: footnote_types_oplog footnote_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY footnote_types_oplog
+ALTER TABLE ONLY public.footnote_types_oplog
     ADD CONSTRAINT footnote_types_pkey PRIMARY KEY (oid);
 
 
@@ -7385,7 +7427,7 @@ ALTER TABLE ONLY footnote_types_oplog
 -- Name: footnotes_oplog footnotes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY footnotes_oplog
+ALTER TABLE ONLY public.footnotes_oplog
     ADD CONSTRAINT footnotes_pkey PRIMARY KEY (oid);
 
 
@@ -7393,7 +7435,7 @@ ALTER TABLE ONLY footnotes_oplog
 -- Name: fts_regulation_actions_oplog fts_regulation_actions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY fts_regulation_actions_oplog
+ALTER TABLE ONLY public.fts_regulation_actions_oplog
     ADD CONSTRAINT fts_regulation_actions_pkey PRIMARY KEY (oid);
 
 
@@ -7401,7 +7443,7 @@ ALTER TABLE ONLY fts_regulation_actions_oplog
 -- Name: full_temporary_stop_regulations_oplog full_temporary_stop_regulations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY full_temporary_stop_regulations_oplog
+ALTER TABLE ONLY public.full_temporary_stop_regulations_oplog
     ADD CONSTRAINT full_temporary_stop_regulations_pkey PRIMARY KEY (oid);
 
 
@@ -7409,7 +7451,7 @@ ALTER TABLE ONLY full_temporary_stop_regulations_oplog
 -- Name: geographical_area_description_periods_oplog geographical_area_description_periods_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY geographical_area_description_periods_oplog
+ALTER TABLE ONLY public.geographical_area_description_periods_oplog
     ADD CONSTRAINT geographical_area_description_periods_pkey PRIMARY KEY (oid);
 
 
@@ -7417,7 +7459,7 @@ ALTER TABLE ONLY geographical_area_description_periods_oplog
 -- Name: geographical_area_descriptions_oplog geographical_area_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY geographical_area_descriptions_oplog
+ALTER TABLE ONLY public.geographical_area_descriptions_oplog
     ADD CONSTRAINT geographical_area_descriptions_pkey PRIMARY KEY (oid);
 
 
@@ -7425,7 +7467,7 @@ ALTER TABLE ONLY geographical_area_descriptions_oplog
 -- Name: geographical_area_memberships_oplog geographical_area_memberships_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY geographical_area_memberships_oplog
+ALTER TABLE ONLY public.geographical_area_memberships_oplog
     ADD CONSTRAINT geographical_area_memberships_pkey PRIMARY KEY (oid);
 
 
@@ -7433,7 +7475,7 @@ ALTER TABLE ONLY geographical_area_memberships_oplog
 -- Name: geographical_areas_oplog geographical_areas_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY geographical_areas_oplog
+ALTER TABLE ONLY public.geographical_areas_oplog
     ADD CONSTRAINT geographical_areas_pkey PRIMARY KEY (oid);
 
 
@@ -7441,7 +7483,7 @@ ALTER TABLE ONLY geographical_areas_oplog
 -- Name: goods_nomenclature_description_periods_oplog goods_nomenclature_description_periods_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY goods_nomenclature_description_periods_oplog
+ALTER TABLE ONLY public.goods_nomenclature_description_periods_oplog
     ADD CONSTRAINT goods_nomenclature_description_periods_pkey PRIMARY KEY (oid);
 
 
@@ -7449,7 +7491,7 @@ ALTER TABLE ONLY goods_nomenclature_description_periods_oplog
 -- Name: goods_nomenclature_descriptions_oplog goods_nomenclature_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY goods_nomenclature_descriptions_oplog
+ALTER TABLE ONLY public.goods_nomenclature_descriptions_oplog
     ADD CONSTRAINT goods_nomenclature_descriptions_pkey PRIMARY KEY (oid);
 
 
@@ -7457,7 +7499,7 @@ ALTER TABLE ONLY goods_nomenclature_descriptions_oplog
 -- Name: goods_nomenclature_group_descriptions_oplog goods_nomenclature_group_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY goods_nomenclature_group_descriptions_oplog
+ALTER TABLE ONLY public.goods_nomenclature_group_descriptions_oplog
     ADD CONSTRAINT goods_nomenclature_group_descriptions_pkey PRIMARY KEY (oid);
 
 
@@ -7465,7 +7507,7 @@ ALTER TABLE ONLY goods_nomenclature_group_descriptions_oplog
 -- Name: goods_nomenclature_groups_oplog goods_nomenclature_groups_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY goods_nomenclature_groups_oplog
+ALTER TABLE ONLY public.goods_nomenclature_groups_oplog
     ADD CONSTRAINT goods_nomenclature_groups_pkey PRIMARY KEY (oid);
 
 
@@ -7473,7 +7515,7 @@ ALTER TABLE ONLY goods_nomenclature_groups_oplog
 -- Name: goods_nomenclature_indents_oplog goods_nomenclature_indents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY goods_nomenclature_indents_oplog
+ALTER TABLE ONLY public.goods_nomenclature_indents_oplog
     ADD CONSTRAINT goods_nomenclature_indents_pkey PRIMARY KEY (oid);
 
 
@@ -7481,7 +7523,7 @@ ALTER TABLE ONLY goods_nomenclature_indents_oplog
 -- Name: goods_nomenclature_origins_oplog goods_nomenclature_origins_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY goods_nomenclature_origins_oplog
+ALTER TABLE ONLY public.goods_nomenclature_origins_oplog
     ADD CONSTRAINT goods_nomenclature_origins_pkey PRIMARY KEY (oid);
 
 
@@ -7489,7 +7531,7 @@ ALTER TABLE ONLY goods_nomenclature_origins_oplog
 -- Name: goods_nomenclature_successors_oplog goods_nomenclature_successors_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY goods_nomenclature_successors_oplog
+ALTER TABLE ONLY public.goods_nomenclature_successors_oplog
     ADD CONSTRAINT goods_nomenclature_successors_pkey PRIMARY KEY (oid);
 
 
@@ -7497,7 +7539,7 @@ ALTER TABLE ONLY goods_nomenclature_successors_oplog
 -- Name: goods_nomenclatures_oplog goods_nomenclatures_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY goods_nomenclatures_oplog
+ALTER TABLE ONLY public.goods_nomenclatures_oplog
     ADD CONSTRAINT goods_nomenclatures_pkey PRIMARY KEY (oid);
 
 
@@ -7505,7 +7547,7 @@ ALTER TABLE ONLY goods_nomenclatures_oplog
 -- Name: language_descriptions_oplog language_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY language_descriptions_oplog
+ALTER TABLE ONLY public.language_descriptions_oplog
     ADD CONSTRAINT language_descriptions_pkey PRIMARY KEY (oid);
 
 
@@ -7513,7 +7555,7 @@ ALTER TABLE ONLY language_descriptions_oplog
 -- Name: languages_oplog languages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY languages_oplog
+ALTER TABLE ONLY public.languages_oplog
     ADD CONSTRAINT languages_pkey PRIMARY KEY (oid);
 
 
@@ -7521,7 +7563,7 @@ ALTER TABLE ONLY languages_oplog
 -- Name: measure_action_descriptions_oplog measure_action_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY measure_action_descriptions_oplog
+ALTER TABLE ONLY public.measure_action_descriptions_oplog
     ADD CONSTRAINT measure_action_descriptions_pkey PRIMARY KEY (oid);
 
 
@@ -7529,7 +7571,7 @@ ALTER TABLE ONLY measure_action_descriptions_oplog
 -- Name: measure_actions_oplog measure_actions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY measure_actions_oplog
+ALTER TABLE ONLY public.measure_actions_oplog
     ADD CONSTRAINT measure_actions_pkey PRIMARY KEY (oid);
 
 
@@ -7537,7 +7579,7 @@ ALTER TABLE ONLY measure_actions_oplog
 -- Name: measure_components_oplog measure_components_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY measure_components_oplog
+ALTER TABLE ONLY public.measure_components_oplog
     ADD CONSTRAINT measure_components_pkey PRIMARY KEY (oid);
 
 
@@ -7545,7 +7587,7 @@ ALTER TABLE ONLY measure_components_oplog
 -- Name: measure_condition_code_descriptions_oplog measure_condition_code_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY measure_condition_code_descriptions_oplog
+ALTER TABLE ONLY public.measure_condition_code_descriptions_oplog
     ADD CONSTRAINT measure_condition_code_descriptions_pkey PRIMARY KEY (oid);
 
 
@@ -7553,7 +7595,7 @@ ALTER TABLE ONLY measure_condition_code_descriptions_oplog
 -- Name: measure_condition_codes_oplog measure_condition_codes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY measure_condition_codes_oplog
+ALTER TABLE ONLY public.measure_condition_codes_oplog
     ADD CONSTRAINT measure_condition_codes_pkey PRIMARY KEY (oid);
 
 
@@ -7561,7 +7603,7 @@ ALTER TABLE ONLY measure_condition_codes_oplog
 -- Name: measure_condition_components_oplog measure_condition_components_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY measure_condition_components_oplog
+ALTER TABLE ONLY public.measure_condition_components_oplog
     ADD CONSTRAINT measure_condition_components_pkey PRIMARY KEY (oid);
 
 
@@ -7569,7 +7611,7 @@ ALTER TABLE ONLY measure_condition_components_oplog
 -- Name: measure_conditions_oplog measure_conditions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY measure_conditions_oplog
+ALTER TABLE ONLY public.measure_conditions_oplog
     ADD CONSTRAINT measure_conditions_pkey PRIMARY KEY (oid);
 
 
@@ -7577,7 +7619,7 @@ ALTER TABLE ONLY measure_conditions_oplog
 -- Name: measure_excluded_geographical_areas_oplog measure_excluded_geographical_areas_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY measure_excluded_geographical_areas_oplog
+ALTER TABLE ONLY public.measure_excluded_geographical_areas_oplog
     ADD CONSTRAINT measure_excluded_geographical_areas_pkey PRIMARY KEY (oid);
 
 
@@ -7585,7 +7627,7 @@ ALTER TABLE ONLY measure_excluded_geographical_areas_oplog
 -- Name: measure_partial_temporary_stops_oplog measure_partial_temporary_stops_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY measure_partial_temporary_stops_oplog
+ALTER TABLE ONLY public.measure_partial_temporary_stops_oplog
     ADD CONSTRAINT measure_partial_temporary_stops_pkey PRIMARY KEY (oid);
 
 
@@ -7593,7 +7635,7 @@ ALTER TABLE ONLY measure_partial_temporary_stops_oplog
 -- Name: measure_type_descriptions_oplog measure_type_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY measure_type_descriptions_oplog
+ALTER TABLE ONLY public.measure_type_descriptions_oplog
     ADD CONSTRAINT measure_type_descriptions_pkey PRIMARY KEY (oid);
 
 
@@ -7601,7 +7643,7 @@ ALTER TABLE ONLY measure_type_descriptions_oplog
 -- Name: measure_type_series_descriptions_oplog measure_type_series_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY measure_type_series_descriptions_oplog
+ALTER TABLE ONLY public.measure_type_series_descriptions_oplog
     ADD CONSTRAINT measure_type_series_descriptions_pkey PRIMARY KEY (oid);
 
 
@@ -7609,7 +7651,7 @@ ALTER TABLE ONLY measure_type_series_descriptions_oplog
 -- Name: measure_type_series_oplog measure_type_series_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY measure_type_series_oplog
+ALTER TABLE ONLY public.measure_type_series_oplog
     ADD CONSTRAINT measure_type_series_pkey PRIMARY KEY (oid);
 
 
@@ -7617,7 +7659,7 @@ ALTER TABLE ONLY measure_type_series_oplog
 -- Name: measure_types_oplog measure_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY measure_types_oplog
+ALTER TABLE ONLY public.measure_types_oplog
     ADD CONSTRAINT measure_types_pkey PRIMARY KEY (oid);
 
 
@@ -7625,7 +7667,7 @@ ALTER TABLE ONLY measure_types_oplog
 -- Name: measurement_unit_abbreviations measurement_unit_abbreviations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY measurement_unit_abbreviations
+ALTER TABLE ONLY public.measurement_unit_abbreviations
     ADD CONSTRAINT measurement_unit_abbreviations_pkey PRIMARY KEY (id);
 
 
@@ -7633,7 +7675,7 @@ ALTER TABLE ONLY measurement_unit_abbreviations
 -- Name: measurement_unit_descriptions_oplog measurement_unit_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY measurement_unit_descriptions_oplog
+ALTER TABLE ONLY public.measurement_unit_descriptions_oplog
     ADD CONSTRAINT measurement_unit_descriptions_pkey PRIMARY KEY (oid);
 
 
@@ -7641,7 +7683,7 @@ ALTER TABLE ONLY measurement_unit_descriptions_oplog
 -- Name: measurement_unit_qualifier_descriptions_oplog measurement_unit_qualifier_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY measurement_unit_qualifier_descriptions_oplog
+ALTER TABLE ONLY public.measurement_unit_qualifier_descriptions_oplog
     ADD CONSTRAINT measurement_unit_qualifier_descriptions_pkey PRIMARY KEY (oid);
 
 
@@ -7649,7 +7691,7 @@ ALTER TABLE ONLY measurement_unit_qualifier_descriptions_oplog
 -- Name: measurement_unit_qualifiers_oplog measurement_unit_qualifiers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY measurement_unit_qualifiers_oplog
+ALTER TABLE ONLY public.measurement_unit_qualifiers_oplog
     ADD CONSTRAINT measurement_unit_qualifiers_pkey PRIMARY KEY (oid);
 
 
@@ -7657,7 +7699,7 @@ ALTER TABLE ONLY measurement_unit_qualifiers_oplog
 -- Name: measurement_units_oplog measurement_units_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY measurement_units_oplog
+ALTER TABLE ONLY public.measurement_units_oplog
     ADD CONSTRAINT measurement_units_pkey PRIMARY KEY (oid);
 
 
@@ -7665,7 +7707,7 @@ ALTER TABLE ONLY measurement_units_oplog
 -- Name: measurements_oplog measurements_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY measurements_oplog
+ALTER TABLE ONLY public.measurements_oplog
     ADD CONSTRAINT measurements_pkey PRIMARY KEY (oid);
 
 
@@ -7673,7 +7715,7 @@ ALTER TABLE ONLY measurements_oplog
 -- Name: measures_oplog measures_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY measures_oplog
+ALTER TABLE ONLY public.measures_oplog
     ADD CONSTRAINT measures_pkey PRIMARY KEY (oid);
 
 
@@ -7681,7 +7723,7 @@ ALTER TABLE ONLY measures_oplog
 -- Name: meursing_additional_codes_oplog meursing_additional_codes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY meursing_additional_codes_oplog
+ALTER TABLE ONLY public.meursing_additional_codes_oplog
     ADD CONSTRAINT meursing_additional_codes_pkey PRIMARY KEY (oid);
 
 
@@ -7689,7 +7731,7 @@ ALTER TABLE ONLY meursing_additional_codes_oplog
 -- Name: meursing_heading_texts_oplog meursing_heading_texts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY meursing_heading_texts_oplog
+ALTER TABLE ONLY public.meursing_heading_texts_oplog
     ADD CONSTRAINT meursing_heading_texts_pkey PRIMARY KEY (oid);
 
 
@@ -7697,7 +7739,7 @@ ALTER TABLE ONLY meursing_heading_texts_oplog
 -- Name: meursing_headings_oplog meursing_headings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY meursing_headings_oplog
+ALTER TABLE ONLY public.meursing_headings_oplog
     ADD CONSTRAINT meursing_headings_pkey PRIMARY KEY (oid);
 
 
@@ -7705,7 +7747,7 @@ ALTER TABLE ONLY meursing_headings_oplog
 -- Name: meursing_subheadings_oplog meursing_subheadings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY meursing_subheadings_oplog
+ALTER TABLE ONLY public.meursing_subheadings_oplog
     ADD CONSTRAINT meursing_subheadings_pkey PRIMARY KEY (oid);
 
 
@@ -7713,7 +7755,7 @@ ALTER TABLE ONLY meursing_subheadings_oplog
 -- Name: meursing_table_cell_components_oplog meursing_table_cell_components_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY meursing_table_cell_components_oplog
+ALTER TABLE ONLY public.meursing_table_cell_components_oplog
     ADD CONSTRAINT meursing_table_cell_components_pkey PRIMARY KEY (oid);
 
 
@@ -7721,7 +7763,7 @@ ALTER TABLE ONLY meursing_table_cell_components_oplog
 -- Name: meursing_table_plans_oplog meursing_table_plans_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY meursing_table_plans_oplog
+ALTER TABLE ONLY public.meursing_table_plans_oplog
     ADD CONSTRAINT meursing_table_plans_pkey PRIMARY KEY (oid);
 
 
@@ -7729,7 +7771,7 @@ ALTER TABLE ONLY meursing_table_plans_oplog
 -- Name: modification_regulations_oplog modification_regulations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY modification_regulations_oplog
+ALTER TABLE ONLY public.modification_regulations_oplog
     ADD CONSTRAINT modification_regulations_pkey PRIMARY KEY (oid);
 
 
@@ -7737,7 +7779,7 @@ ALTER TABLE ONLY modification_regulations_oplog
 -- Name: monetary_exchange_periods_oplog monetary_exchange_periods_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY monetary_exchange_periods_oplog
+ALTER TABLE ONLY public.monetary_exchange_periods_oplog
     ADD CONSTRAINT monetary_exchange_periods_pkey PRIMARY KEY (oid);
 
 
@@ -7745,7 +7787,7 @@ ALTER TABLE ONLY monetary_exchange_periods_oplog
 -- Name: monetary_exchange_rates_oplog monetary_exchange_rates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY monetary_exchange_rates_oplog
+ALTER TABLE ONLY public.monetary_exchange_rates_oplog
     ADD CONSTRAINT monetary_exchange_rates_pkey PRIMARY KEY (oid);
 
 
@@ -7753,7 +7795,7 @@ ALTER TABLE ONLY monetary_exchange_rates_oplog
 -- Name: monetary_unit_descriptions_oplog monetary_unit_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY monetary_unit_descriptions_oplog
+ALTER TABLE ONLY public.monetary_unit_descriptions_oplog
     ADD CONSTRAINT monetary_unit_descriptions_pkey PRIMARY KEY (oid);
 
 
@@ -7761,7 +7803,7 @@ ALTER TABLE ONLY monetary_unit_descriptions_oplog
 -- Name: monetary_units_oplog monetary_units_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY monetary_units_oplog
+ALTER TABLE ONLY public.monetary_units_oplog
     ADD CONSTRAINT monetary_units_pkey PRIMARY KEY (oid);
 
 
@@ -7769,7 +7811,7 @@ ALTER TABLE ONLY monetary_units_oplog
 -- Name: nomenclature_group_memberships_oplog nomenclature_group_memberships_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY nomenclature_group_memberships_oplog
+ALTER TABLE ONLY public.nomenclature_group_memberships_oplog
     ADD CONSTRAINT nomenclature_group_memberships_pkey PRIMARY KEY (oid);
 
 
@@ -7777,7 +7819,7 @@ ALTER TABLE ONLY nomenclature_group_memberships_oplog
 -- Name: prorogation_regulation_actions_oplog prorogation_regulation_actions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY prorogation_regulation_actions_oplog
+ALTER TABLE ONLY public.prorogation_regulation_actions_oplog
     ADD CONSTRAINT prorogation_regulation_actions_pkey PRIMARY KEY (oid);
 
 
@@ -7785,15 +7827,23 @@ ALTER TABLE ONLY prorogation_regulation_actions_oplog
 -- Name: prorogation_regulations_oplog prorogation_regulations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY prorogation_regulations_oplog
+ALTER TABLE ONLY public.prorogation_regulations_oplog
     ADD CONSTRAINT prorogation_regulations_pkey PRIMARY KEY (oid);
+
+
+--
+-- Name: publication_sigles_oplog publication_sigles_oplog_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.publication_sigles_oplog
+    ADD CONSTRAINT publication_sigles_oplog_pkey PRIMARY KEY (oid);
 
 
 --
 -- Name: quota_associations_oplog quota_associations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY quota_associations_oplog
+ALTER TABLE ONLY public.quota_associations_oplog
     ADD CONSTRAINT quota_associations_pkey PRIMARY KEY (oid);
 
 
@@ -7801,7 +7851,7 @@ ALTER TABLE ONLY quota_associations_oplog
 -- Name: quota_balance_events_oplog quota_balance_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY quota_balance_events_oplog
+ALTER TABLE ONLY public.quota_balance_events_oplog
     ADD CONSTRAINT quota_balance_events_pkey PRIMARY KEY (oid);
 
 
@@ -7809,7 +7859,7 @@ ALTER TABLE ONLY quota_balance_events_oplog
 -- Name: quota_blocking_periods_oplog quota_blocking_periods_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY quota_blocking_periods_oplog
+ALTER TABLE ONLY public.quota_blocking_periods_oplog
     ADD CONSTRAINT quota_blocking_periods_pkey PRIMARY KEY (oid);
 
 
@@ -7817,7 +7867,7 @@ ALTER TABLE ONLY quota_blocking_periods_oplog
 -- Name: quota_critical_events_oplog quota_critical_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY quota_critical_events_oplog
+ALTER TABLE ONLY public.quota_critical_events_oplog
     ADD CONSTRAINT quota_critical_events_pkey PRIMARY KEY (oid);
 
 
@@ -7825,7 +7875,7 @@ ALTER TABLE ONLY quota_critical_events_oplog
 -- Name: quota_definitions_oplog quota_definitions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY quota_definitions_oplog
+ALTER TABLE ONLY public.quota_definitions_oplog
     ADD CONSTRAINT quota_definitions_pkey PRIMARY KEY (oid);
 
 
@@ -7833,7 +7883,7 @@ ALTER TABLE ONLY quota_definitions_oplog
 -- Name: quota_exhaustion_events_oplog quota_exhaustion_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY quota_exhaustion_events_oplog
+ALTER TABLE ONLY public.quota_exhaustion_events_oplog
     ADD CONSTRAINT quota_exhaustion_events_pkey PRIMARY KEY (oid);
 
 
@@ -7841,7 +7891,7 @@ ALTER TABLE ONLY quota_exhaustion_events_oplog
 -- Name: quota_order_number_origin_exclusions_oplog quota_order_number_origin_exclusions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY quota_order_number_origin_exclusions_oplog
+ALTER TABLE ONLY public.quota_order_number_origin_exclusions_oplog
     ADD CONSTRAINT quota_order_number_origin_exclusions_pkey PRIMARY KEY (oid);
 
 
@@ -7849,7 +7899,7 @@ ALTER TABLE ONLY quota_order_number_origin_exclusions_oplog
 -- Name: quota_order_number_origins_oplog quota_order_number_origins_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY quota_order_number_origins_oplog
+ALTER TABLE ONLY public.quota_order_number_origins_oplog
     ADD CONSTRAINT quota_order_number_origins_pkey PRIMARY KEY (oid);
 
 
@@ -7857,7 +7907,7 @@ ALTER TABLE ONLY quota_order_number_origins_oplog
 -- Name: quota_order_numbers_oplog quota_order_numbers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY quota_order_numbers_oplog
+ALTER TABLE ONLY public.quota_order_numbers_oplog
     ADD CONSTRAINT quota_order_numbers_pkey PRIMARY KEY (oid);
 
 
@@ -7865,7 +7915,7 @@ ALTER TABLE ONLY quota_order_numbers_oplog
 -- Name: quota_reopening_events_oplog quota_reopening_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY quota_reopening_events_oplog
+ALTER TABLE ONLY public.quota_reopening_events_oplog
     ADD CONSTRAINT quota_reopening_events_pkey PRIMARY KEY (oid);
 
 
@@ -7873,7 +7923,7 @@ ALTER TABLE ONLY quota_reopening_events_oplog
 -- Name: quota_suspension_periods_oplog quota_suspension_periods_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY quota_suspension_periods_oplog
+ALTER TABLE ONLY public.quota_suspension_periods_oplog
     ADD CONSTRAINT quota_suspension_periods_pkey PRIMARY KEY (oid);
 
 
@@ -7881,7 +7931,7 @@ ALTER TABLE ONLY quota_suspension_periods_oplog
 -- Name: quota_unblocking_events_oplog quota_unblocking_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY quota_unblocking_events_oplog
+ALTER TABLE ONLY public.quota_unblocking_events_oplog
     ADD CONSTRAINT quota_unblocking_events_pkey PRIMARY KEY (oid);
 
 
@@ -7889,7 +7939,7 @@ ALTER TABLE ONLY quota_unblocking_events_oplog
 -- Name: quota_unsuspension_events_oplog quota_unsuspension_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY quota_unsuspension_events_oplog
+ALTER TABLE ONLY public.quota_unsuspension_events_oplog
     ADD CONSTRAINT quota_unsuspension_events_pkey PRIMARY KEY (oid);
 
 
@@ -7897,7 +7947,7 @@ ALTER TABLE ONLY quota_unsuspension_events_oplog
 -- Name: regulation_group_descriptions_oplog regulation_group_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY regulation_group_descriptions_oplog
+ALTER TABLE ONLY public.regulation_group_descriptions_oplog
     ADD CONSTRAINT regulation_group_descriptions_pkey PRIMARY KEY (oid);
 
 
@@ -7905,7 +7955,7 @@ ALTER TABLE ONLY regulation_group_descriptions_oplog
 -- Name: regulation_groups_oplog regulation_groups_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY regulation_groups_oplog
+ALTER TABLE ONLY public.regulation_groups_oplog
     ADD CONSTRAINT regulation_groups_pkey PRIMARY KEY (oid);
 
 
@@ -7913,7 +7963,7 @@ ALTER TABLE ONLY regulation_groups_oplog
 -- Name: regulation_replacements_oplog regulation_replacements_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY regulation_replacements_oplog
+ALTER TABLE ONLY public.regulation_replacements_oplog
     ADD CONSTRAINT regulation_replacements_pkey PRIMARY KEY (oid);
 
 
@@ -7921,7 +7971,7 @@ ALTER TABLE ONLY regulation_replacements_oplog
 -- Name: regulation_role_type_descriptions_oplog regulation_role_type_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY regulation_role_type_descriptions_oplog
+ALTER TABLE ONLY public.regulation_role_type_descriptions_oplog
     ADD CONSTRAINT regulation_role_type_descriptions_pkey PRIMARY KEY (oid);
 
 
@@ -7929,7 +7979,7 @@ ALTER TABLE ONLY regulation_role_type_descriptions_oplog
 -- Name: regulation_role_types_oplog regulation_role_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY regulation_role_types_oplog
+ALTER TABLE ONLY public.regulation_role_types_oplog
     ADD CONSTRAINT regulation_role_types_pkey PRIMARY KEY (oid);
 
 
@@ -7937,7 +7987,7 @@ ALTER TABLE ONLY regulation_role_types_oplog
 -- Name: rollbacks rollbacks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY rollbacks
+ALTER TABLE ONLY public.rollbacks
     ADD CONSTRAINT rollbacks_pkey PRIMARY KEY (id);
 
 
@@ -7945,7 +7995,7 @@ ALTER TABLE ONLY rollbacks
 -- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY schema_migrations
+ALTER TABLE ONLY public.schema_migrations
     ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (filename);
 
 
@@ -7953,7 +8003,7 @@ ALTER TABLE ONLY schema_migrations
 -- Name: search_references search_references_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY search_references
+ALTER TABLE ONLY public.search_references
     ADD CONSTRAINT search_references_pkey PRIMARY KEY (id);
 
 
@@ -7961,7 +8011,7 @@ ALTER TABLE ONLY search_references
 -- Name: section_notes section_notes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY section_notes
+ALTER TABLE ONLY public.section_notes
     ADD CONSTRAINT section_notes_pkey PRIMARY KEY (id);
 
 
@@ -7969,7 +8019,7 @@ ALTER TABLE ONLY section_notes
 -- Name: sections sections_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY sections
+ALTER TABLE ONLY public.sections
     ADD CONSTRAINT sections_pkey PRIMARY KEY (id);
 
 
@@ -7977,7 +8027,7 @@ ALTER TABLE ONLY sections
 -- Name: tariff_update_conformance_errors tariff_update_conformance_errors_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY tariff_update_conformance_errors
+ALTER TABLE ONLY public.tariff_update_conformance_errors
     ADD CONSTRAINT tariff_update_conformance_errors_pkey PRIMARY KEY (id);
 
 
@@ -7985,7 +8035,7 @@ ALTER TABLE ONLY tariff_update_conformance_errors
 -- Name: tariff_updates tariff_updates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY tariff_updates
+ALTER TABLE ONLY public.tariff_updates
     ADD CONSTRAINT tariff_updates_pkey PRIMARY KEY (filename);
 
 
@@ -7993,7 +8043,7 @@ ALTER TABLE ONLY tariff_updates
 -- Name: transmission_comments_oplog transmission_comments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY transmission_comments_oplog
+ALTER TABLE ONLY public.transmission_comments_oplog
     ADD CONSTRAINT transmission_comments_pkey PRIMARY KEY (oid);
 
 
@@ -8001,7 +8051,7 @@ ALTER TABLE ONLY transmission_comments_oplog
 -- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY users
+ALTER TABLE ONLY public.users
     ADD CONSTRAINT users_pkey PRIMARY KEY (id);
 
 
@@ -8009,2016 +8059,2024 @@ ALTER TABLE ONLY users
 -- Name: abrogation_regulation_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX abrogation_regulation_id ON measure_partial_temporary_stops_oplog USING btree (abrogation_regulation_id);
+CREATE INDEX abrogation_regulation_id ON public.measure_partial_temporary_stops_oplog USING btree (abrogation_regulation_id);
 
 
 --
 -- Name: acdo_addcoddesopl_nalodeonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX acdo_addcoddesopl_nalodeonslog_operation_date ON additional_code_descriptions_oplog USING btree (operation_date);
+CREATE INDEX acdo_addcoddesopl_nalodeonslog_operation_date ON public.additional_code_descriptions_oplog USING btree (operation_date);
 
 
 --
 -- Name: acdpo_addcoddesperopl_nalodeionodslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX acdpo_addcoddesperopl_nalodeionodslog_operation_date ON additional_code_description_periods_oplog USING btree (operation_date);
+CREATE INDEX acdpo_addcoddesperopl_nalodeionodslog_operation_date ON public.additional_code_description_periods_oplog USING btree (operation_date);
 
 
 --
 -- Name: aco_addcodopl_naldeslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX aco_addcodopl_naldeslog_operation_date ON additional_codes_oplog USING btree (operation_date);
+CREATE INDEX aco_addcodopl_naldeslog_operation_date ON public.additional_codes_oplog USING btree (operation_date);
 
 
 --
 -- Name: actdo_addcodtypdesopl_nalodeypeonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX actdo_addcodtypdesopl_nalodeypeonslog_operation_date ON additional_code_type_descriptions_oplog USING btree (operation_date);
+CREATE INDEX actdo_addcodtypdesopl_nalodeypeonslog_operation_date ON public.additional_code_type_descriptions_oplog USING btree (operation_date);
 
 
 --
 -- Name: actmto_addcodtypmeatypopl_nalodeypeurepeslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX actmto_addcodtypmeatypopl_nalodeypeurepeslog_operation_date ON additional_code_type_measure_types_oplog USING btree (operation_date);
+CREATE INDEX actmto_addcodtypmeatypopl_nalodeypeurepeslog_operation_date ON public.additional_code_type_measure_types_oplog USING btree (operation_date);
 
 
 --
 -- Name: acto_addcodtypopl_nalodepeslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX acto_addcodtypopl_nalodepeslog_operation_date ON additional_code_types_oplog USING btree (operation_date);
+CREATE INDEX acto_addcodtypopl_nalodepeslog_operation_date ON public.additional_code_types_oplog USING btree (operation_date);
 
 
 --
 -- Name: adco_desc_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX adco_desc_pk ON additional_code_descriptions_oplog USING btree (additional_code_description_period_sid, additional_code_type_id, additional_code_sid);
+CREATE INDEX adco_desc_pk ON public.additional_code_descriptions_oplog USING btree (additional_code_description_period_sid, additional_code_type_id, additional_code_sid);
 
 
 --
 -- Name: adco_periods_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX adco_periods_pk ON additional_code_description_periods_oplog USING btree (additional_code_description_period_sid, additional_code_sid, additional_code_type_id);
+CREATE INDEX adco_periods_pk ON public.additional_code_description_periods_oplog USING btree (additional_code_description_period_sid, additional_code_sid, additional_code_type_id);
 
 
 --
 -- Name: adco_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX adco_pk ON additional_codes_oplog USING btree (additional_code_sid);
+CREATE INDEX adco_pk ON public.additional_codes_oplog USING btree (additional_code_sid);
 
 
 --
 -- Name: adco_type_desc_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX adco_type_desc_pk ON additional_code_type_descriptions_oplog USING btree (additional_code_type_id);
+CREATE INDEX adco_type_desc_pk ON public.additional_code_type_descriptions_oplog USING btree (additional_code_type_id);
 
 
 --
 -- Name: adco_type_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX adco_type_id ON additional_codes_oplog USING btree (additional_code_type_id);
+CREATE INDEX adco_type_id ON public.additional_codes_oplog USING btree (additional_code_type_id);
 
 
 --
 -- Name: adco_type_measure_type_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX adco_type_measure_type_pk ON additional_code_type_measure_types_oplog USING btree (measure_type_id, additional_code_type_id);
+CREATE INDEX adco_type_measure_type_pk ON public.additional_code_type_measure_types_oplog USING btree (measure_type_id, additional_code_type_id);
 
 
 --
 -- Name: adco_types_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX adco_types_pk ON additional_code_types_oplog USING btree (additional_code_type_id);
+CREATE INDEX adco_types_pk ON public.additional_code_types_oplog USING btree (additional_code_type_id);
 
 
 --
 -- Name: additional_code_type; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX additional_code_type ON footnote_association_additional_codes_oplog USING btree (additional_code_type_id);
+CREATE INDEX additional_code_type ON public.footnote_association_additional_codes_oplog USING btree (additional_code_type_id);
 
 
 --
 -- Name: antidumping_regulation; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX antidumping_regulation ON base_regulations_oplog USING btree (antidumping_regulation_role, related_antidumping_regulation_id);
+CREATE INDEX antidumping_regulation ON public.base_regulations_oplog USING btree (antidumping_regulation_role, related_antidumping_regulation_id);
 
 
 --
 -- Name: base_regulation; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX base_regulation ON modification_regulations_oplog USING btree (base_regulation_id, base_regulation_role);
+CREATE INDEX base_regulation ON public.modification_regulations_oplog USING btree (base_regulation_id, base_regulation_role);
 
 
 --
 -- Name: base_regulations_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX base_regulations_pk ON base_regulations_oplog USING btree (base_regulation_id, base_regulation_role);
+CREATE INDEX base_regulations_pk ON public.base_regulations_oplog USING btree (base_regulation_id, base_regulation_role);
 
 
 --
 -- Name: bro_basregopl_aseonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX bro_basregopl_aseonslog_operation_date ON base_regulations_oplog USING btree (operation_date);
+CREATE INDEX bro_basregopl_aseonslog_operation_date ON public.base_regulations_oplog USING btree (operation_date);
 
 
 --
 -- Name: caro_comabrregopl_eteiononslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX caro_comabrregopl_eteiononslog_operation_date ON complete_abrogation_regulations_oplog USING btree (operation_date);
+CREATE INDEX caro_comabrregopl_eteiononslog_operation_date ON public.complete_abrogation_regulations_oplog USING btree (operation_date);
 
 
 --
 -- Name: cdo_cerdesopl_ateonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX cdo_cerdesopl_ateonslog_operation_date ON certificate_descriptions_oplog USING btree (operation_date);
+CREATE INDEX cdo_cerdesopl_ateonslog_operation_date ON public.certificate_descriptions_oplog USING btree (operation_date);
 
 
 --
 -- Name: cdpo_cerdesperopl_ateionodslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX cdpo_cerdesperopl_ateionodslog_operation_date ON certificate_description_periods_oplog USING btree (operation_date);
+CREATE INDEX cdpo_cerdesperopl_ateionodslog_operation_date ON public.certificate_description_periods_oplog USING btree (operation_date);
 
 
 --
 -- Name: cert_desc_certificate; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX cert_desc_certificate ON certificate_descriptions_oplog USING btree (certificate_code, certificate_type_code);
+CREATE INDEX cert_desc_certificate ON public.certificate_descriptions_oplog USING btree (certificate_code, certificate_type_code);
 
 
 --
 -- Name: cert_desc_period_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX cert_desc_period_pk ON certificate_description_periods_oplog USING btree (certificate_description_period_sid);
+CREATE INDEX cert_desc_period_pk ON public.certificate_description_periods_oplog USING btree (certificate_description_period_sid);
 
 
 --
 -- Name: cert_desc_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX cert_desc_pk ON certificate_descriptions_oplog USING btree (certificate_description_period_sid);
+CREATE INDEX cert_desc_pk ON public.certificate_descriptions_oplog USING btree (certificate_description_period_sid);
 
 
 --
 -- Name: cert_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX cert_pk ON certificates_oplog USING btree (certificate_code, certificate_type_code, validity_start_date);
+CREATE INDEX cert_pk ON public.certificates_oplog USING btree (certificate_code, certificate_type_code, validity_start_date);
 
 
 --
 -- Name: cert_type_code_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX cert_type_code_pk ON certificate_type_descriptions_oplog USING btree (certificate_type_code);
+CREATE INDEX cert_type_code_pk ON public.certificate_type_descriptions_oplog USING btree (certificate_type_code);
 
 
 --
 -- Name: cert_types_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX cert_types_pk ON certificate_types_oplog USING btree (certificate_type_code, validity_start_date);
+CREATE INDEX cert_types_pk ON public.certificate_types_oplog USING btree (certificate_type_code, validity_start_date);
 
 
 --
 -- Name: certificate; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX certificate ON certificate_description_periods_oplog USING btree (certificate_code, certificate_type_code);
+CREATE INDEX certificate ON public.certificate_description_periods_oplog USING btree (certificate_code, certificate_type_code);
 
 
 --
 -- Name: chapter_notes_chapter_id_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX chapter_notes_chapter_id_index ON chapter_notes USING btree (chapter_id);
+CREATE INDEX chapter_notes_chapter_id_index ON public.chapter_notes USING btree (chapter_id);
 
 
 --
 -- Name: chapter_notes_section_id_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX chapter_notes_section_id_index ON chapter_notes USING btree (section_id);
+CREATE INDEX chapter_notes_section_id_index ON public.chapter_notes USING btree (section_id);
 
 
 --
 -- Name: chief_country_cd_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX chief_country_cd_pk ON chief_country_code USING btree (chief_country_cd);
+CREATE INDEX chief_country_cd_pk ON public.chief_country_code USING btree (chief_country_cd);
 
 
 --
 -- Name: chief_country_grp_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX chief_country_grp_pk ON chief_country_group USING btree (chief_country_grp);
+CREATE INDEX chief_country_grp_pk ON public.chief_country_group USING btree (chief_country_grp);
 
 
 --
 -- Name: chief_mfcm_msrgp_code_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX chief_mfcm_msrgp_code_index ON chief_mfcm USING btree (msrgp_code);
+CREATE INDEX chief_mfcm_msrgp_code_index ON public.chief_mfcm USING btree (msrgp_code);
 
 
 --
 -- Name: cmdty_code_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX cmdty_code_index ON chief_comm USING btree (cmdty_code);
+CREATE INDEX cmdty_code_index ON public.chief_comm USING btree (cmdty_code);
 
 
 --
 -- Name: cmpl_abrg_reg_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX cmpl_abrg_reg_pk ON complete_abrogation_regulations_oplog USING btree (complete_abrogation_regulation_id, complete_abrogation_regulation_role);
+CREATE INDEX cmpl_abrg_reg_pk ON public.complete_abrogation_regulations_oplog USING btree (complete_abrogation_regulation_id, complete_abrogation_regulation_role);
 
 
 --
 -- Name: co_ceropl_teslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX co_ceropl_teslog_operation_date ON certificates_oplog USING btree (operation_date);
+CREATE INDEX co_ceropl_teslog_operation_date ON public.certificates_oplog USING btree (operation_date);
 
 
 --
 -- Name: code_type_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX code_type_id ON additional_code_description_periods_oplog USING btree (additional_code_type_id);
+CREATE INDEX code_type_id ON public.additional_code_description_periods_oplog USING btree (additional_code_type_id);
 
 
 --
 -- Name: complete_abrogation_regulation; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX complete_abrogation_regulation ON base_regulations_oplog USING btree (complete_abrogation_regulation_role, complete_abrogation_regulation_id);
+CREATE INDEX complete_abrogation_regulation ON public.base_regulations_oplog USING btree (complete_abrogation_regulation_role, complete_abrogation_regulation_id);
 
 
 --
 -- Name: condition_measurement_unit_qualifier_code; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX condition_measurement_unit_qualifier_code ON measure_conditions_oplog USING btree (condition_measurement_unit_qualifier_code);
+CREATE INDEX condition_measurement_unit_qualifier_code ON public.measure_conditions_oplog USING btree (condition_measurement_unit_qualifier_code);
 
 
 --
 -- Name: ctdo_certypdesopl_ateypeonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ctdo_certypdesopl_ateypeonslog_operation_date ON certificate_type_descriptions_oplog USING btree (operation_date);
+CREATE INDEX ctdo_certypdesopl_ateypeonslog_operation_date ON public.certificate_type_descriptions_oplog USING btree (operation_date);
 
 
 --
 -- Name: cto_certypopl_atepeslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX cto_certypopl_atepeslog_operation_date ON certificate_types_oplog USING btree (operation_date);
+CREATE INDEX cto_certypopl_atepeslog_operation_date ON public.certificate_types_oplog USING btree (operation_date);
 
 
 --
 -- Name: data_migrations_filename_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX data_migrations_filename_index ON data_migrations USING btree (filename);
+CREATE INDEX data_migrations_filename_index ON public.data_migrations USING btree (filename);
 
 
 --
 -- Name: dedo_dutexpdesopl_utyiononslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX dedo_dutexpdesopl_utyiononslog_operation_date ON duty_expression_descriptions_oplog USING btree (operation_date);
+CREATE INDEX dedo_dutexpdesopl_utyiononslog_operation_date ON public.duty_expression_descriptions_oplog USING btree (operation_date);
 
 
 --
 -- Name: deo_dutexpopl_utyonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX deo_dutexpopl_utyonslog_operation_date ON duty_expressions_oplog USING btree (operation_date);
+CREATE INDEX deo_dutexpopl_utyonslog_operation_date ON public.duty_expressions_oplog USING btree (operation_date);
 
 
 --
 -- Name: description_period_sid; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX description_period_sid ON additional_code_description_periods_oplog USING btree (additional_code_description_period_sid);
+CREATE INDEX description_period_sid ON public.additional_code_description_periods_oplog USING btree (additional_code_description_period_sid);
 
 
 --
 -- Name: duty_exp_desc_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX duty_exp_desc_pk ON duty_expression_descriptions_oplog USING btree (duty_expression_id);
+CREATE INDEX duty_exp_desc_pk ON public.duty_expression_descriptions_oplog USING btree (duty_expression_id);
 
 
 --
 -- Name: duty_exp_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX duty_exp_pk ON duty_expressions_oplog USING btree (duty_expression_id, validity_start_date);
+CREATE INDEX duty_exp_pk ON public.duty_expressions_oplog USING btree (duty_expression_id, validity_start_date);
 
 
 --
 -- Name: earo_expabrregopl_citiononslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX earo_expabrregopl_citiononslog_operation_date ON explicit_abrogation_regulations_oplog USING btree (operation_date);
+CREATE INDEX earo_expabrregopl_citiononslog_operation_date ON public.explicit_abrogation_regulations_oplog USING btree (operation_date);
 
 
 --
 -- Name: erndo_exprefnomdesopl_ortundureonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX erndo_exprefnomdesopl_ortundureonslog_operation_date ON export_refund_nomenclature_descriptions_oplog USING btree (operation_date);
+CREATE INDEX erndo_exprefnomdesopl_ortundureonslog_operation_date ON public.export_refund_nomenclature_descriptions_oplog USING btree (operation_date);
 
 
 --
 -- Name: erndpo_exprefnomdesperopl_ortundureionodslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX erndpo_exprefnomdesperopl_ortundureionodslog_operation_date ON export_refund_nomenclature_description_periods_oplog USING btree (operation_date);
+CREATE INDEX erndpo_exprefnomdesperopl_ortundureionodslog_operation_date ON public.export_refund_nomenclature_description_periods_oplog USING btree (operation_date);
 
 
 --
 -- Name: ernio_exprefnomindopl_ortundurentslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ernio_exprefnomindopl_ortundurentslog_operation_date ON export_refund_nomenclature_indents_oplog USING btree (operation_date);
+CREATE INDEX ernio_exprefnomindopl_ortundurentslog_operation_date ON public.export_refund_nomenclature_indents_oplog USING btree (operation_date);
 
 
 --
 -- Name: erno_exprefnomopl_ortundreslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX erno_exprefnomopl_ortundreslog_operation_date ON export_refund_nomenclatures_oplog USING btree (operation_date);
+CREATE INDEX erno_exprefnomopl_ortundreslog_operation_date ON public.export_refund_nomenclatures_oplog USING btree (operation_date);
 
 
 --
 -- Name: exp_abrg_reg_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX exp_abrg_reg_pk ON explicit_abrogation_regulations_oplog USING btree (explicit_abrogation_regulation_id, explicit_abrogation_regulation_role);
+CREATE INDEX exp_abrg_reg_pk ON public.explicit_abrogation_regulations_oplog USING btree (explicit_abrogation_regulation_id, explicit_abrogation_regulation_role);
 
 
 --
 -- Name: exp_rfnd_desc_period_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX exp_rfnd_desc_period_pk ON export_refund_nomenclature_description_periods_oplog USING btree (export_refund_nomenclature_sid, export_refund_nomenclature_description_period_sid);
+CREATE INDEX exp_rfnd_desc_period_pk ON public.export_refund_nomenclature_description_periods_oplog USING btree (export_refund_nomenclature_sid, export_refund_nomenclature_description_period_sid);
 
 
 --
 -- Name: exp_rfnd_desc_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX exp_rfnd_desc_pk ON export_refund_nomenclature_descriptions_oplog USING btree (export_refund_nomenclature_description_period_sid);
+CREATE INDEX exp_rfnd_desc_pk ON public.export_refund_nomenclature_descriptions_oplog USING btree (export_refund_nomenclature_description_period_sid);
 
 
 --
 -- Name: exp_rfnd_indent_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX exp_rfnd_indent_pk ON export_refund_nomenclature_indents_oplog USING btree (export_refund_nomenclature_indents_sid);
+CREATE INDEX exp_rfnd_indent_pk ON public.export_refund_nomenclature_indents_oplog USING btree (export_refund_nomenclature_indents_sid);
 
 
 --
 -- Name: exp_rfnd_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX exp_rfnd_pk ON export_refund_nomenclatures_oplog USING btree (export_refund_nomenclature_sid);
+CREATE INDEX exp_rfnd_pk ON public.export_refund_nomenclatures_oplog USING btree (export_refund_nomenclature_sid);
 
 
 --
 -- Name: explicit_abrogation_regulation; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX explicit_abrogation_regulation ON base_regulations_oplog USING btree (explicit_abrogation_regulation_role, explicit_abrogation_regulation_id);
+CREATE INDEX explicit_abrogation_regulation ON public.base_regulations_oplog USING btree (explicit_abrogation_regulation_role, explicit_abrogation_regulation_id);
 
 
 --
 -- Name: export_refund_nomenclature; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX export_refund_nomenclature ON export_refund_nomenclature_descriptions_oplog USING btree (export_refund_nomenclature_sid);
+CREATE INDEX export_refund_nomenclature ON public.export_refund_nomenclature_descriptions_oplog USING btree (export_refund_nomenclature_sid);
 
 
 --
 -- Name: faaco_fooassaddcodopl_oteionnaldeslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX faaco_fooassaddcodopl_oteionnaldeslog_operation_date ON footnote_association_additional_codes_oplog USING btree (operation_date);
+CREATE INDEX faaco_fooassaddcodopl_oteionnaldeslog_operation_date ON public.footnote_association_additional_codes_oplog USING btree (operation_date);
 
 
 --
 -- Name: faeo_fooassernopl_oteionrnslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX faeo_fooassernopl_oteionrnslog_operation_date ON footnote_association_erns_oplog USING btree (operation_date);
+CREATE INDEX faeo_fooassernopl_oteionrnslog_operation_date ON public.footnote_association_erns_oplog USING btree (operation_date);
 
 
 --
 -- Name: fagno_fooassgoonomopl_oteionodsreslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX fagno_fooassgoonomopl_oteionodsreslog_operation_date ON footnote_association_goods_nomenclatures_oplog USING btree (operation_date);
+CREATE INDEX fagno_fooassgoonomopl_oteionodsreslog_operation_date ON public.footnote_association_goods_nomenclatures_oplog USING btree (operation_date);
 
 
 --
 -- Name: famho_fooassmeuheaopl_oteioningngslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX famho_fooassmeuheaopl_oteioningngslog_operation_date ON footnote_association_meursing_headings_oplog USING btree (operation_date);
+CREATE INDEX famho_fooassmeuheaopl_oteioningngslog_operation_date ON public.footnote_association_meursing_headings_oplog USING btree (operation_date);
 
 
 --
 -- Name: famo_fooassmeaopl_oteionreslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX famo_fooassmeaopl_oteionreslog_operation_date ON footnote_association_measures_oplog USING btree (operation_date);
+CREATE INDEX famo_fooassmeaopl_oteionreslog_operation_date ON public.footnote_association_measures_oplog USING btree (operation_date);
 
 
 --
 -- Name: fdo_foodesopl_oteonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX fdo_foodesopl_oteonslog_operation_date ON footnote_descriptions_oplog USING btree (operation_date);
+CREATE INDEX fdo_foodesopl_oteonslog_operation_date ON public.footnote_descriptions_oplog USING btree (operation_date);
 
 
 --
 -- Name: fdpo_foodesperopl_oteionodslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX fdpo_foodesperopl_oteionodslog_operation_date ON footnote_description_periods_oplog USING btree (operation_date);
+CREATE INDEX fdpo_foodesperopl_oteionodslog_operation_date ON public.footnote_description_periods_oplog USING btree (operation_date);
 
 
 --
 -- Name: fo_fooopl_teslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX fo_fooopl_teslog_operation_date ON footnotes_oplog USING btree (operation_date);
+CREATE INDEX fo_fooopl_teslog_operation_date ON public.footnotes_oplog USING btree (operation_date);
 
 
 --
 -- Name: footnote_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX footnote_id ON footnote_association_measures_oplog USING btree (footnote_id);
+CREATE INDEX footnote_id ON public.footnote_association_measures_oplog USING btree (footnote_id);
 
 
 --
 -- Name: frao_ftsregactopl_ftsiononslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX frao_ftsregactopl_ftsiononslog_operation_date ON fts_regulation_actions_oplog USING btree (operation_date);
+CREATE INDEX frao_ftsregactopl_ftsiononslog_operation_date ON public.fts_regulation_actions_oplog USING btree (operation_date);
 
 
 --
 -- Name: ftdo_footypdesopl_oteypeonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ftdo_footypdesopl_oteypeonslog_operation_date ON footnote_type_descriptions_oplog USING btree (operation_date);
+CREATE INDEX ftdo_footypdesopl_oteypeonslog_operation_date ON public.footnote_type_descriptions_oplog USING btree (operation_date);
 
 
 --
 -- Name: ftn_assoc_adco_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ftn_assoc_adco_pk ON footnote_association_additional_codes_oplog USING btree (footnote_id, footnote_type_id, additional_code_sid);
+CREATE INDEX ftn_assoc_adco_pk ON public.footnote_association_additional_codes_oplog USING btree (footnote_id, footnote_type_id, additional_code_sid);
 
 
 --
 -- Name: ftn_assoc_ern_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ftn_assoc_ern_pk ON footnote_association_erns_oplog USING btree (export_refund_nomenclature_sid, footnote_id, footnote_type, validity_start_date);
+CREATE INDEX ftn_assoc_ern_pk ON public.footnote_association_erns_oplog USING btree (export_refund_nomenclature_sid, footnote_id, footnote_type, validity_start_date);
 
 
 --
 -- Name: ftn_assoc_gono_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ftn_assoc_gono_pk ON footnote_association_goods_nomenclatures_oplog USING btree (footnote_id, footnote_type, goods_nomenclature_sid, validity_start_date);
+CREATE INDEX ftn_assoc_gono_pk ON public.footnote_association_goods_nomenclatures_oplog USING btree (footnote_id, footnote_type, goods_nomenclature_sid, validity_start_date);
 
 
 --
 -- Name: ftn_assoc_meurs_head_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ftn_assoc_meurs_head_pk ON footnote_association_meursing_headings_oplog USING btree (footnote_id, meursing_table_plan_id);
+CREATE INDEX ftn_assoc_meurs_head_pk ON public.footnote_association_meursing_headings_oplog USING btree (footnote_id, meursing_table_plan_id);
 
 
 --
 -- Name: ftn_desc; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ftn_desc ON footnote_descriptions_oplog USING btree (footnote_id, footnote_type_id, footnote_description_period_sid);
+CREATE INDEX ftn_desc ON public.footnote_descriptions_oplog USING btree (footnote_id, footnote_type_id, footnote_description_period_sid);
 
 
 --
 -- Name: ftn_desc_period; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ftn_desc_period ON footnote_description_periods_oplog USING btree (footnote_id, footnote_type_id, footnote_description_period_sid);
+CREATE INDEX ftn_desc_period ON public.footnote_description_periods_oplog USING btree (footnote_id, footnote_type_id, footnote_description_period_sid);
 
 
 --
 -- Name: ftn_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ftn_pk ON footnotes_oplog USING btree (footnote_id, footnote_type_id);
+CREATE INDEX ftn_pk ON public.footnotes_oplog USING btree (footnote_id, footnote_type_id);
 
 
 --
 -- Name: ftn_type_desc_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ftn_type_desc_pk ON footnote_type_descriptions_oplog USING btree (footnote_type_id);
+CREATE INDEX ftn_type_desc_pk ON public.footnote_type_descriptions_oplog USING btree (footnote_type_id);
 
 
 --
 -- Name: ftn_types_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ftn_types_pk ON footnote_types_oplog USING btree (footnote_type_id);
+CREATE INDEX ftn_types_pk ON public.footnote_types_oplog USING btree (footnote_type_id);
 
 
 --
 -- Name: fto_footypopl_otepeslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX fto_footypopl_otepeslog_operation_date ON footnote_types_oplog USING btree (operation_date);
+CREATE INDEX fto_footypopl_otepeslog_operation_date ON public.footnote_types_oplog USING btree (operation_date);
 
 
 --
 -- Name: fts_reg_act_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX fts_reg_act_pk ON fts_regulation_actions_oplog USING btree (fts_regulation_id, fts_regulation_role, stopped_regulation_id, stopped_regulation_role);
+CREATE INDEX fts_reg_act_pk ON public.fts_regulation_actions_oplog USING btree (fts_regulation_id, fts_regulation_role, stopped_regulation_id, stopped_regulation_role);
 
 
 --
 -- Name: ftsro_fultemstoregopl_ullarytoponslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ftsro_fultemstoregopl_ullarytoponslog_operation_date ON full_temporary_stop_regulations_oplog USING btree (operation_date);
+CREATE INDEX ftsro_fultemstoregopl_ullarytoponslog_operation_date ON public.full_temporary_stop_regulations_oplog USING btree (operation_date);
 
 
 --
 -- Name: full_temp_explicit_abrogation_regulation; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX full_temp_explicit_abrogation_regulation ON full_temporary_stop_regulations_oplog USING btree (explicit_abrogation_regulation_role, explicit_abrogation_regulation_id);
+CREATE INDEX full_temp_explicit_abrogation_regulation ON public.full_temporary_stop_regulations_oplog USING btree (explicit_abrogation_regulation_role, explicit_abrogation_regulation_id);
 
 
 --
 -- Name: full_temp_stop_reg_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX full_temp_stop_reg_pk ON full_temporary_stop_regulations_oplog USING btree (full_temporary_stop_regulation_id, full_temporary_stop_regulation_role);
+CREATE INDEX full_temp_stop_reg_pk ON public.full_temporary_stop_regulations_oplog USING btree (full_temporary_stop_regulation_id, full_temporary_stop_regulation_role);
 
 
 --
 -- Name: gado_geoaredesopl_calreaonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX gado_geoaredesopl_calreaonslog_operation_date ON geographical_area_descriptions_oplog USING btree (operation_date);
+CREATE INDEX gado_geoaredesopl_calreaonslog_operation_date ON public.geographical_area_descriptions_oplog USING btree (operation_date);
 
 
 --
 -- Name: gadpo_geoaredesperopl_calreaionodslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX gadpo_geoaredesperopl_calreaionodslog_operation_date ON geographical_area_description_periods_oplog USING btree (operation_date);
+CREATE INDEX gadpo_geoaredesperopl_calreaionodslog_operation_date ON public.geographical_area_description_periods_oplog USING btree (operation_date);
 
 
 --
 -- Name: gamo_geoarememopl_calreaipslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX gamo_geoarememopl_calreaipslog_operation_date ON geographical_area_memberships_oplog USING btree (operation_date);
+CREATE INDEX gamo_geoarememopl_calreaipslog_operation_date ON public.geographical_area_memberships_oplog USING btree (operation_date);
 
 
 --
 -- Name: gao_geoareopl_caleaslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX gao_geoareopl_caleaslog_operation_date ON geographical_areas_oplog USING btree (operation_date);
+CREATE INDEX gao_geoareopl_caleaslog_operation_date ON public.geographical_areas_oplog USING btree (operation_date);
 
 
 --
 -- Name: geo_area_member_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX geo_area_member_pk ON geographical_area_memberships_oplog USING btree (geographical_area_sid, geographical_area_group_sid, validity_start_date);
+CREATE INDEX geo_area_member_pk ON public.geographical_area_memberships_oplog USING btree (geographical_area_sid, geographical_area_group_sid, validity_start_date);
 
 
 --
 -- Name: geog_area_desc_period_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX geog_area_desc_period_pk ON geographical_area_description_periods_oplog USING btree (geographical_area_description_period_sid, geographical_area_sid);
+CREATE INDEX geog_area_desc_period_pk ON public.geographical_area_description_periods_oplog USING btree (geographical_area_description_period_sid, geographical_area_sid);
 
 
 --
 -- Name: geog_area_desc_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX geog_area_desc_pk ON geographical_area_descriptions_oplog USING btree (geographical_area_description_period_sid, geographical_area_sid);
+CREATE INDEX geog_area_desc_pk ON public.geographical_area_descriptions_oplog USING btree (geographical_area_description_period_sid, geographical_area_sid);
 
 
 --
 -- Name: geog_area_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX geog_area_pk ON geographical_areas_oplog USING btree (geographical_area_id);
+CREATE INDEX geog_area_pk ON public.geographical_areas_oplog USING btree (geographical_area_id);
 
 
 --
 -- Name: gndo_goonomdesopl_odsureonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX gndo_goonomdesopl_odsureonslog_operation_date ON goods_nomenclature_descriptions_oplog USING btree (operation_date);
+CREATE INDEX gndo_goonomdesopl_odsureonslog_operation_date ON public.goods_nomenclature_descriptions_oplog USING btree (operation_date);
 
 
 --
 -- Name: gndpo_goonomdesperopl_odsureionodslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX gndpo_goonomdesperopl_odsureionodslog_operation_date ON goods_nomenclature_description_periods_oplog USING btree (operation_date);
+CREATE INDEX gndpo_goonomdesperopl_odsureionodslog_operation_date ON public.goods_nomenclature_description_periods_oplog USING btree (operation_date);
 
 
 --
 -- Name: gngdo_goonomgrodesopl_odsureouponslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX gngdo_goonomgrodesopl_odsureouponslog_operation_date ON goods_nomenclature_group_descriptions_oplog USING btree (operation_date);
+CREATE INDEX gngdo_goonomgrodesopl_odsureouponslog_operation_date ON public.goods_nomenclature_group_descriptions_oplog USING btree (operation_date);
 
 
 --
 -- Name: gngo_goonomgroopl_odsureupslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX gngo_goonomgroopl_odsureupslog_operation_date ON goods_nomenclature_groups_oplog USING btree (operation_date);
+CREATE INDEX gngo_goonomgroopl_odsureupslog_operation_date ON public.goods_nomenclature_groups_oplog USING btree (operation_date);
 
 
 --
 -- Name: gnio_goonomindopl_odsurentslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX gnio_goonomindopl_odsurentslog_operation_date ON goods_nomenclature_indents_oplog USING btree (operation_date);
+CREATE INDEX gnio_goonomindopl_odsurentslog_operation_date ON public.goods_nomenclature_indents_oplog USING btree (operation_date);
 
 
 --
 -- Name: gno_goonomopl_odsreslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX gno_goonomopl_odsreslog_operation_date ON goods_nomenclatures_oplog USING btree (operation_date);
+CREATE INDEX gno_goonomopl_odsreslog_operation_date ON public.goods_nomenclatures_oplog USING btree (operation_date);
 
 
 --
 -- Name: gnoo_goonomoriopl_odsureinslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX gnoo_goonomoriopl_odsureinslog_operation_date ON goods_nomenclature_origins_oplog USING btree (operation_date);
+CREATE INDEX gnoo_goonomoriopl_odsureinslog_operation_date ON public.goods_nomenclature_origins_oplog USING btree (operation_date);
 
 
 --
 -- Name: gnso_goonomsucopl_odsureorslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX gnso_goonomsucopl_odsureorslog_operation_date ON goods_nomenclature_successors_oplog USING btree (operation_date);
+CREATE INDEX gnso_goonomsucopl_odsureorslog_operation_date ON public.goods_nomenclature_successors_oplog USING btree (operation_date);
 
 
 --
 -- Name: gono_desc_periods_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX gono_desc_periods_pk ON goods_nomenclature_description_periods_oplog USING btree (goods_nomenclature_sid, validity_start_date, validity_end_date);
+CREATE INDEX gono_desc_periods_pk ON public.goods_nomenclature_description_periods_oplog USING btree (goods_nomenclature_sid, validity_start_date, validity_end_date);
 
 
 --
 -- Name: gono_desc_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX gono_desc_pk ON goods_nomenclature_descriptions_oplog USING btree (goods_nomenclature_sid, goods_nomenclature_description_period_sid);
+CREATE INDEX gono_desc_pk ON public.goods_nomenclature_descriptions_oplog USING btree (goods_nomenclature_sid, goods_nomenclature_description_period_sid);
 
 
 --
 -- Name: gono_desc_primary_key; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX gono_desc_primary_key ON goods_nomenclature_description_periods_oplog USING btree (goods_nomenclature_description_period_sid);
+CREATE INDEX gono_desc_primary_key ON public.goods_nomenclature_description_periods_oplog USING btree (goods_nomenclature_description_period_sid);
 
 
 --
 -- Name: gono_grp_desc_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX gono_grp_desc_pk ON goods_nomenclature_group_descriptions_oplog USING btree (goods_nomenclature_group_id, goods_nomenclature_group_type);
+CREATE INDEX gono_grp_desc_pk ON public.goods_nomenclature_group_descriptions_oplog USING btree (goods_nomenclature_group_id, goods_nomenclature_group_type);
 
 
 --
 -- Name: gono_grp_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX gono_grp_pk ON goods_nomenclature_groups_oplog USING btree (goods_nomenclature_group_id, goods_nomenclature_group_type);
+CREATE INDEX gono_grp_pk ON public.goods_nomenclature_groups_oplog USING btree (goods_nomenclature_group_id, goods_nomenclature_group_type);
 
 
 --
 -- Name: gono_indent_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX gono_indent_pk ON goods_nomenclature_indents_oplog USING btree (goods_nomenclature_indent_sid);
+CREATE INDEX gono_indent_pk ON public.goods_nomenclature_indents_oplog USING btree (goods_nomenclature_indent_sid);
 
 
 --
 -- Name: gono_origin_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX gono_origin_pk ON goods_nomenclature_origins_oplog USING btree (goods_nomenclature_sid, derived_goods_nomenclature_item_id, derived_productline_suffix, goods_nomenclature_item_id, productline_suffix);
+CREATE INDEX gono_origin_pk ON public.goods_nomenclature_origins_oplog USING btree (goods_nomenclature_sid, derived_goods_nomenclature_item_id, derived_productline_suffix, goods_nomenclature_item_id, productline_suffix);
 
 
 --
 -- Name: gono_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX gono_pk ON goods_nomenclatures_oplog USING btree (goods_nomenclature_sid);
+CREATE INDEX gono_pk ON public.goods_nomenclatures_oplog USING btree (goods_nomenclature_sid);
 
 
 --
 -- Name: gono_succ_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX gono_succ_pk ON goods_nomenclature_successors_oplog USING btree (goods_nomenclature_sid, absorbed_goods_nomenclature_item_id, absorbed_productline_suffix, goods_nomenclature_item_id, productline_suffix);
+CREATE INDEX gono_succ_pk ON public.goods_nomenclature_successors_oplog USING btree (goods_nomenclature_sid, absorbed_goods_nomenclature_item_id, absorbed_productline_suffix, goods_nomenclature_item_id, productline_suffix);
 
 
 --
 -- Name: goods_nomenclature_sid; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX goods_nomenclature_sid ON goods_nomenclature_indents_oplog USING btree (goods_nomenclature_sid);
+CREATE INDEX goods_nomenclature_sid ON public.goods_nomenclature_indents_oplog USING btree (goods_nomenclature_sid);
 
 
 --
 -- Name: goods_nomenclature_validity_dates; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX goods_nomenclature_validity_dates ON goods_nomenclature_indents_oplog USING btree (validity_start_date, validity_end_date);
+CREATE INDEX goods_nomenclature_validity_dates ON public.goods_nomenclature_indents_oplog USING btree (validity_start_date, validity_end_date);
 
 
 --
 -- Name: index_additional_code_type_descriptions_on_language_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_additional_code_type_descriptions_on_language_id ON additional_code_type_descriptions_oplog USING btree (language_id);
+CREATE INDEX index_additional_code_type_descriptions_on_language_id ON public.additional_code_type_descriptions_oplog USING btree (language_id);
 
 
 --
 -- Name: index_additional_code_types_on_meursing_table_plan_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_additional_code_types_on_meursing_table_plan_id ON additional_code_types_oplog USING btree (meursing_table_plan_id);
+CREATE INDEX index_additional_code_types_on_meursing_table_plan_id ON public.additional_code_types_oplog USING btree (meursing_table_plan_id);
 
 
 --
 -- Name: index_base_regulations_on_regulation_group_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_base_regulations_on_regulation_group_id ON base_regulations_oplog USING btree (regulation_group_id);
+CREATE INDEX index_base_regulations_on_regulation_group_id ON public.base_regulations_oplog USING btree (regulation_group_id);
 
 
 --
 -- Name: index_certificate_descriptions_on_language_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_certificate_descriptions_on_language_id ON certificate_descriptions_oplog USING btree (language_id);
+CREATE INDEX index_certificate_descriptions_on_language_id ON public.certificate_descriptions_oplog USING btree (language_id);
 
 
 --
 -- Name: index_certificate_type_descriptions_on_language_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_certificate_type_descriptions_on_language_id ON certificate_type_descriptions_oplog USING btree (language_id);
+CREATE INDEX index_certificate_type_descriptions_on_language_id ON public.certificate_type_descriptions_oplog USING btree (language_id);
 
 
 --
 -- Name: index_chapters_sections_on_goods_nomenclature_sid_and_section_i; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_chapters_sections_on_goods_nomenclature_sid_and_section_i ON chapters_sections USING btree (goods_nomenclature_sid, section_id);
+CREATE INDEX index_chapters_sections_on_goods_nomenclature_sid_and_section_i ON public.chapters_sections USING btree (goods_nomenclature_sid, section_id);
 
 
 --
 -- Name: index_chief_tame; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_chief_tame ON chief_tame USING btree (msrgp_code, msr_type, tty_code, tar_msr_no, fe_tsmp);
+CREATE INDEX index_chief_tame ON public.chief_tame USING btree (msrgp_code, msr_type, tty_code, tar_msr_no, fe_tsmp);
 
 
 --
 -- Name: index_chief_tamf; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_chief_tamf ON chief_tamf USING btree (fe_tsmp, msrgp_code, msr_type, tty_code, tar_msr_no, amend_indicator);
+CREATE INDEX index_chief_tamf ON public.chief_tamf USING btree (fe_tsmp, msrgp_code, msr_type, tty_code, tar_msr_no, amend_indicator);
 
 
 --
 -- Name: index_duty_expression_descriptions_on_language_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_duty_expression_descriptions_on_language_id ON duty_expression_descriptions_oplog USING btree (language_id);
+CREATE INDEX index_duty_expression_descriptions_on_language_id ON public.duty_expression_descriptions_oplog USING btree (language_id);
 
 
 --
 -- Name: index_export_refund_nomenclature_descriptions_on_language_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_export_refund_nomenclature_descriptions_on_language_id ON export_refund_nomenclature_descriptions_oplog USING btree (language_id);
+CREATE INDEX index_export_refund_nomenclature_descriptions_on_language_id ON public.export_refund_nomenclature_descriptions_oplog USING btree (language_id);
 
 
 --
 -- Name: index_export_refund_nomenclatures_on_goods_nomenclature_sid; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_export_refund_nomenclatures_on_goods_nomenclature_sid ON export_refund_nomenclatures_oplog USING btree (goods_nomenclature_sid);
+CREATE INDEX index_export_refund_nomenclatures_on_goods_nomenclature_sid ON public.export_refund_nomenclatures_oplog USING btree (goods_nomenclature_sid);
 
 
 --
 -- Name: index_footnote_descriptions_on_language_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_footnote_descriptions_on_language_id ON footnote_descriptions_oplog USING btree (language_id);
+CREATE INDEX index_footnote_descriptions_on_language_id ON public.footnote_descriptions_oplog USING btree (language_id);
 
 
 --
 -- Name: index_footnote_type_descriptions_on_language_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_footnote_type_descriptions_on_language_id ON footnote_type_descriptions_oplog USING btree (language_id);
+CREATE INDEX index_footnote_type_descriptions_on_language_id ON public.footnote_type_descriptions_oplog USING btree (language_id);
 
 
 --
 -- Name: index_geographical_area_descriptions_on_language_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_geographical_area_descriptions_on_language_id ON geographical_area_descriptions_oplog USING btree (language_id);
+CREATE INDEX index_geographical_area_descriptions_on_language_id ON public.geographical_area_descriptions_oplog USING btree (language_id);
 
 
 --
 -- Name: index_geographical_areas_on_parent_geographical_area_group_sid; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_geographical_areas_on_parent_geographical_area_group_sid ON geographical_areas_oplog USING btree (parent_geographical_area_group_sid);
+CREATE INDEX index_geographical_areas_on_parent_geographical_area_group_sid ON public.geographical_areas_oplog USING btree (parent_geographical_area_group_sid);
 
 
 --
 -- Name: index_goods_nomenclature_descriptions_on_language_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_goods_nomenclature_descriptions_on_language_id ON goods_nomenclature_descriptions_oplog USING btree (language_id);
+CREATE INDEX index_goods_nomenclature_descriptions_on_language_id ON public.goods_nomenclature_descriptions_oplog USING btree (language_id);
 
 
 --
 -- Name: index_goods_nomenclature_group_descriptions_on_language_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_goods_nomenclature_group_descriptions_on_language_id ON goods_nomenclature_group_descriptions_oplog USING btree (language_id);
+CREATE INDEX index_goods_nomenclature_group_descriptions_on_language_id ON public.goods_nomenclature_group_descriptions_oplog USING btree (language_id);
 
 
 --
 -- Name: index_measure_components_on_measurement_unit_code; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_measure_components_on_measurement_unit_code ON measure_components_oplog USING btree (measurement_unit_code);
+CREATE INDEX index_measure_components_on_measurement_unit_code ON public.measure_components_oplog USING btree (measurement_unit_code);
 
 
 --
 -- Name: index_measure_components_on_measurement_unit_qualifier_code; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_measure_components_on_measurement_unit_qualifier_code ON measure_components_oplog USING btree (measurement_unit_qualifier_code);
+CREATE INDEX index_measure_components_on_measurement_unit_qualifier_code ON public.measure_components_oplog USING btree (measurement_unit_qualifier_code);
 
 
 --
 -- Name: index_measure_components_on_monetary_unit_code; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_measure_components_on_monetary_unit_code ON measure_components_oplog USING btree (monetary_unit_code);
+CREATE INDEX index_measure_components_on_monetary_unit_code ON public.measure_components_oplog USING btree (monetary_unit_code);
 
 
 --
 -- Name: index_measure_condition_components_on_duty_expression_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_measure_condition_components_on_duty_expression_id ON measure_condition_components_oplog USING btree (duty_expression_id);
+CREATE INDEX index_measure_condition_components_on_duty_expression_id ON public.measure_condition_components_oplog USING btree (duty_expression_id);
 
 
 --
 -- Name: index_measure_condition_components_on_measurement_unit_code; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_measure_condition_components_on_measurement_unit_code ON measure_condition_components_oplog USING btree (measurement_unit_code);
+CREATE INDEX index_measure_condition_components_on_measurement_unit_code ON public.measure_condition_components_oplog USING btree (measurement_unit_code);
 
 
 --
 -- Name: index_measure_condition_components_on_monetary_unit_code; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_measure_condition_components_on_monetary_unit_code ON measure_condition_components_oplog USING btree (monetary_unit_code);
+CREATE INDEX index_measure_condition_components_on_monetary_unit_code ON public.measure_condition_components_oplog USING btree (monetary_unit_code);
 
 
 --
 -- Name: index_measure_conditions_on_action_code; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_measure_conditions_on_action_code ON measure_conditions_oplog USING btree (action_code);
+CREATE INDEX index_measure_conditions_on_action_code ON public.measure_conditions_oplog USING btree (action_code);
 
 
 --
 -- Name: index_measure_conditions_on_condition_measurement_unit_code; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_measure_conditions_on_condition_measurement_unit_code ON measure_conditions_oplog USING btree (condition_measurement_unit_code);
+CREATE INDEX index_measure_conditions_on_condition_measurement_unit_code ON public.measure_conditions_oplog USING btree (condition_measurement_unit_code);
 
 
 --
 -- Name: index_measure_conditions_on_condition_monetary_unit_code; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_measure_conditions_on_condition_monetary_unit_code ON measure_conditions_oplog USING btree (condition_monetary_unit_code);
+CREATE INDEX index_measure_conditions_on_condition_monetary_unit_code ON public.measure_conditions_oplog USING btree (condition_monetary_unit_code);
 
 
 --
 -- Name: index_measure_conditions_on_measure_sid; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_measure_conditions_on_measure_sid ON measure_conditions_oplog USING btree (measure_sid);
+CREATE INDEX index_measure_conditions_on_measure_sid ON public.measure_conditions_oplog USING btree (measure_sid);
 
 
 --
 -- Name: index_measure_type_descriptions_on_language_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_measure_type_descriptions_on_language_id ON measure_type_descriptions_oplog USING btree (language_id);
+CREATE INDEX index_measure_type_descriptions_on_language_id ON public.measure_type_descriptions_oplog USING btree (language_id);
 
 
 --
 -- Name: index_measure_type_series_descriptions_on_language_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_measure_type_series_descriptions_on_language_id ON measure_type_series_descriptions_oplog USING btree (language_id);
+CREATE INDEX index_measure_type_series_descriptions_on_language_id ON public.measure_type_series_descriptions_oplog USING btree (language_id);
 
 
 --
 -- Name: index_measure_types_on_measure_type_series_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_measure_types_on_measure_type_series_id ON measure_types_oplog USING btree (measure_type_series_id);
+CREATE INDEX index_measure_types_on_measure_type_series_id ON public.measure_types_oplog USING btree (measure_type_series_id);
 
 
 --
 -- Name: index_measurement_unit_descriptions_on_language_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_measurement_unit_descriptions_on_language_id ON measurement_unit_descriptions_oplog USING btree (language_id);
+CREATE INDEX index_measurement_unit_descriptions_on_language_id ON public.measurement_unit_descriptions_oplog USING btree (language_id);
 
 
 --
 -- Name: index_measures_on_additional_code_sid; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_measures_on_additional_code_sid ON measures_oplog USING btree (additional_code_sid);
+CREATE INDEX index_measures_on_additional_code_sid ON public.measures_oplog USING btree (additional_code_sid);
 
 
 --
 -- Name: index_measures_on_geographical_area_sid; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_measures_on_geographical_area_sid ON measures_oplog USING btree (geographical_area_sid);
+CREATE INDEX index_measures_on_geographical_area_sid ON public.measures_oplog USING btree (geographical_area_sid);
 
 
 --
 -- Name: index_measures_on_goods_nomenclature_sid; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_measures_on_goods_nomenclature_sid ON measures_oplog USING btree (goods_nomenclature_sid);
+CREATE INDEX index_measures_on_goods_nomenclature_sid ON public.measures_oplog USING btree (goods_nomenclature_sid);
 
 
 --
 -- Name: index_measures_on_measure_type; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_measures_on_measure_type ON measures_oplog USING btree (measure_type_id);
+CREATE INDEX index_measures_on_measure_type ON public.measures_oplog USING btree (measure_type_id);
 
 
 --
 -- Name: index_monetary_unit_descriptions_on_language_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_monetary_unit_descriptions_on_language_id ON monetary_unit_descriptions_oplog USING btree (language_id);
+CREATE INDEX index_monetary_unit_descriptions_on_language_id ON public.monetary_unit_descriptions_oplog USING btree (language_id);
 
 
 --
 -- Name: index_quota_definitions_on_measurement_unit_code; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_quota_definitions_on_measurement_unit_code ON quota_definitions_oplog USING btree (measurement_unit_code);
+CREATE INDEX index_quota_definitions_on_measurement_unit_code ON public.quota_definitions_oplog USING btree (measurement_unit_code);
 
 
 --
 -- Name: index_quota_definitions_on_measurement_unit_qualifier_code; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_quota_definitions_on_measurement_unit_qualifier_code ON quota_definitions_oplog USING btree (measurement_unit_qualifier_code);
+CREATE INDEX index_quota_definitions_on_measurement_unit_qualifier_code ON public.quota_definitions_oplog USING btree (measurement_unit_qualifier_code);
 
 
 --
 -- Name: index_quota_definitions_on_monetary_unit_code; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_quota_definitions_on_monetary_unit_code ON quota_definitions_oplog USING btree (monetary_unit_code);
+CREATE INDEX index_quota_definitions_on_monetary_unit_code ON public.quota_definitions_oplog USING btree (monetary_unit_code);
 
 
 --
 -- Name: index_quota_definitions_on_quota_order_number_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_quota_definitions_on_quota_order_number_id ON quota_definitions_oplog USING btree (quota_order_number_id);
+CREATE INDEX index_quota_definitions_on_quota_order_number_id ON public.quota_definitions_oplog USING btree (quota_order_number_id);
 
 
 --
 -- Name: index_quota_order_number_origins_on_geographical_area_sid; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_quota_order_number_origins_on_geographical_area_sid ON quota_order_number_origins_oplog USING btree (geographical_area_sid);
+CREATE INDEX index_quota_order_number_origins_on_geographical_area_sid ON public.quota_order_number_origins_oplog USING btree (geographical_area_sid);
 
 
 --
 -- Name: index_quota_suspension_periods_on_quota_definition_sid; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_quota_suspension_periods_on_quota_definition_sid ON quota_suspension_periods_oplog USING btree (quota_definition_sid);
+CREATE INDEX index_quota_suspension_periods_on_quota_definition_sid ON public.quota_suspension_periods_oplog USING btree (quota_definition_sid);
 
 
 --
 -- Name: index_regulation_group_descriptions_on_language_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_regulation_group_descriptions_on_language_id ON regulation_group_descriptions_oplog USING btree (language_id);
+CREATE INDEX index_regulation_group_descriptions_on_language_id ON public.regulation_group_descriptions_oplog USING btree (language_id);
 
 
 --
 -- Name: index_regulation_role_type_descriptions_on_language_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_regulation_role_type_descriptions_on_language_id ON regulation_role_type_descriptions_oplog USING btree (language_id);
+CREATE INDEX index_regulation_role_type_descriptions_on_language_id ON public.regulation_role_type_descriptions_oplog USING btree (language_id);
 
 
 --
 -- Name: item_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX item_id ON goods_nomenclatures_oplog USING btree (goods_nomenclature_item_id, producline_suffix);
+CREATE INDEX item_id ON public.goods_nomenclatures_oplog USING btree (goods_nomenclature_item_id, producline_suffix);
 
 
 --
 -- Name: justification_regulation; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX justification_regulation ON measures_oplog USING btree (justification_regulation_role, justification_regulation_id);
+CREATE INDEX justification_regulation ON public.measures_oplog USING btree (justification_regulation_role, justification_regulation_id);
 
 
 --
 -- Name: lang_desc_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX lang_desc_pk ON language_descriptions_oplog USING btree (language_id, language_code_id);
+CREATE INDEX lang_desc_pk ON public.language_descriptions_oplog USING btree (language_id, language_code_id);
 
 
 --
 -- Name: language_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX language_id ON additional_code_descriptions_oplog USING btree (language_id);
+CREATE INDEX language_id ON public.additional_code_descriptions_oplog USING btree (language_id);
 
 
 --
 -- Name: ldo_landesopl_ageonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ldo_landesopl_ageonslog_operation_date ON language_descriptions_oplog USING btree (operation_date);
+CREATE INDEX ldo_landesopl_ageonslog_operation_date ON public.language_descriptions_oplog USING btree (operation_date);
 
 
 --
 -- Name: lo_lanopl_geslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX lo_lanopl_geslog_operation_date ON languages_oplog USING btree (operation_date);
+CREATE INDEX lo_lanopl_geslog_operation_date ON public.languages_oplog USING btree (operation_date);
 
 
 --
 -- Name: maco_meuaddcodopl_ingnaldeslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX maco_meuaddcodopl_ingnaldeslog_operation_date ON meursing_additional_codes_oplog USING btree (operation_date);
+CREATE INDEX maco_meuaddcodopl_ingnaldeslog_operation_date ON public.meursing_additional_codes_oplog USING btree (operation_date);
 
 
 --
 -- Name: mado_meaactdesopl_ureiononslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mado_meaactdesopl_ureiononslog_operation_date ON measure_action_descriptions_oplog USING btree (operation_date);
+CREATE INDEX mado_meaactdesopl_ureiononslog_operation_date ON public.measure_action_descriptions_oplog USING btree (operation_date);
 
 
 --
 -- Name: mao_meaactopl_ureonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mao_meaactopl_ureonslog_operation_date ON measure_actions_oplog USING btree (operation_date);
+CREATE INDEX mao_meaactopl_ureonslog_operation_date ON public.measure_actions_oplog USING btree (operation_date);
 
 
 --
 -- Name: mccdo_meaconcoddesopl_ureionodeonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mccdo_meaconcoddesopl_ureionodeonslog_operation_date ON measure_condition_code_descriptions_oplog USING btree (operation_date);
+CREATE INDEX mccdo_meaconcoddesopl_ureionodeonslog_operation_date ON public.measure_condition_code_descriptions_oplog USING btree (operation_date);
 
 
 --
 -- Name: mcco_meaconcodopl_ureiondeslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mcco_meaconcodopl_ureiondeslog_operation_date ON measure_condition_codes_oplog USING btree (operation_date);
+CREATE INDEX mcco_meaconcodopl_ureiondeslog_operation_date ON public.measure_condition_codes_oplog USING btree (operation_date);
 
 
 --
 -- Name: mcco_meaconcomopl_ureionntslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mcco_meaconcomopl_ureionntslog_operation_date ON measure_condition_components_oplog USING btree (operation_date);
+CREATE INDEX mcco_meaconcomopl_ureionntslog_operation_date ON public.measure_condition_components_oplog USING btree (operation_date);
 
 
 --
 -- Name: mco_meacomopl_urentslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mco_meacomopl_urentslog_operation_date ON measure_components_oplog USING btree (operation_date);
+CREATE INDEX mco_meacomopl_urentslog_operation_date ON public.measure_components_oplog USING btree (operation_date);
 
 
 --
 -- Name: mco_meaconopl_ureonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mco_meaconopl_ureonslog_operation_date ON measure_conditions_oplog USING btree (operation_date);
+CREATE INDEX mco_meaconopl_ureonslog_operation_date ON public.measure_conditions_oplog USING btree (operation_date);
 
 
 --
 -- Name: meas_act_desc_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meas_act_desc_pk ON measure_action_descriptions_oplog USING btree (action_code);
+CREATE INDEX meas_act_desc_pk ON public.measure_action_descriptions_oplog USING btree (action_code);
 
 
 --
 -- Name: meas_act_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meas_act_pk ON measure_actions_oplog USING btree (action_code, validity_start_date);
+CREATE INDEX meas_act_pk ON public.measure_actions_oplog USING btree (action_code, validity_start_date);
 
 
 --
 -- Name: meas_comp_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meas_comp_pk ON measure_components_oplog USING btree (measure_sid, duty_expression_id);
+CREATE INDEX meas_comp_pk ON public.measure_components_oplog USING btree (measure_sid, duty_expression_id);
 
 
 --
 -- Name: meas_cond_cd_desc_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meas_cond_cd_desc_pk ON measure_condition_code_descriptions_oplog USING btree (condition_code);
+CREATE INDEX meas_cond_cd_desc_pk ON public.measure_condition_code_descriptions_oplog USING btree (condition_code);
 
 
 --
 -- Name: meas_cond_cd_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meas_cond_cd_pk ON measure_condition_codes_oplog USING btree (condition_code, validity_start_date);
+CREATE INDEX meas_cond_cd_pk ON public.measure_condition_codes_oplog USING btree (condition_code, validity_start_date);
 
 
 --
 -- Name: meas_cond_certificate; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meas_cond_certificate ON measure_conditions_oplog USING btree (certificate_code, certificate_type_code);
+CREATE INDEX meas_cond_certificate ON public.measure_conditions_oplog USING btree (certificate_code, certificate_type_code);
 
 
 --
 -- Name: meas_cond_comp_cd; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meas_cond_comp_cd ON measure_condition_components_oplog USING btree (measure_condition_sid, duty_expression_id);
+CREATE INDEX meas_cond_comp_cd ON public.measure_condition_components_oplog USING btree (measure_condition_sid, duty_expression_id);
 
 
 --
 -- Name: meas_cond_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meas_cond_pk ON measure_conditions_oplog USING btree (measure_condition_sid);
+CREATE INDEX meas_cond_pk ON public.measure_conditions_oplog USING btree (measure_condition_sid);
 
 
 --
 -- Name: meas_excl_geog_area_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meas_excl_geog_area_pk ON measure_excluded_geographical_areas_oplog USING btree (geographical_area_sid);
+CREATE INDEX meas_excl_geog_area_pk ON public.measure_excluded_geographical_areas_oplog USING btree (geographical_area_sid);
 
 
 --
 -- Name: meas_excl_geog_primary_key; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meas_excl_geog_primary_key ON measure_excluded_geographical_areas_oplog USING btree (measure_sid, excluded_geographical_area, geographical_area_sid);
+CREATE INDEX meas_excl_geog_primary_key ON public.measure_excluded_geographical_areas_oplog USING btree (measure_sid, excluded_geographical_area, geographical_area_sid);
 
 
 --
 -- Name: meas_part_temp_stop_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meas_part_temp_stop_pk ON measure_partial_temporary_stops_oplog USING btree (measure_sid, partial_temporary_stop_regulation_id);
+CREATE INDEX meas_part_temp_stop_pk ON public.measure_partial_temporary_stops_oplog USING btree (measure_sid, partial_temporary_stop_regulation_id);
 
 
 --
 -- Name: meas_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meas_pk ON measures_oplog USING btree (measure_sid);
+CREATE INDEX meas_pk ON public.measures_oplog USING btree (measure_sid);
 
 
 --
 -- Name: meas_type_desc_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meas_type_desc_pk ON measure_type_descriptions_oplog USING btree (measure_type_id);
+CREATE INDEX meas_type_desc_pk ON public.measure_type_descriptions_oplog USING btree (measure_type_id);
 
 
 --
 -- Name: meas_type_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meas_type_pk ON measure_types_oplog USING btree (measure_type_id, validity_start_date);
+CREATE INDEX meas_type_pk ON public.measure_types_oplog USING btree (measure_type_id, validity_start_date);
 
 
 --
 -- Name: meas_type_series_desc; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meas_type_series_desc ON measure_type_series_descriptions_oplog USING btree (measure_type_series_id);
+CREATE INDEX meas_type_series_desc ON public.measure_type_series_descriptions_oplog USING btree (measure_type_series_id);
 
 
 --
 -- Name: meas_type_series_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meas_type_series_pk ON measure_type_series_oplog USING btree (measure_type_series_id);
+CREATE INDEX meas_type_series_pk ON public.measure_type_series_oplog USING btree (measure_type_series_id);
 
 
 --
 -- Name: meas_unit_desc_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meas_unit_desc_pk ON measurement_unit_descriptions_oplog USING btree (measurement_unit_code);
+CREATE INDEX meas_unit_desc_pk ON public.measurement_unit_descriptions_oplog USING btree (measurement_unit_code);
 
 
 --
 -- Name: meas_unit_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meas_unit_pk ON measurement_units_oplog USING btree (measurement_unit_code, validity_start_date);
+CREATE INDEX meas_unit_pk ON public.measurement_units_oplog USING btree (measurement_unit_code, validity_start_date);
 
 
 --
 -- Name: meas_unit_qual_desc_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meas_unit_qual_desc_pk ON measurement_unit_qualifier_descriptions_oplog USING btree (measurement_unit_qualifier_code);
+CREATE INDEX meas_unit_qual_desc_pk ON public.measurement_unit_qualifier_descriptions_oplog USING btree (measurement_unit_qualifier_code);
 
 
 --
 -- Name: meas_unit_qual_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meas_unit_qual_pk ON measurement_unit_qualifiers_oplog USING btree (measurement_unit_qualifier_code, validity_start_date);
+CREATE INDEX meas_unit_qual_pk ON public.measurement_unit_qualifiers_oplog USING btree (measurement_unit_qualifier_code, validity_start_date);
 
 
 --
 -- Name: measrm_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX measrm_pk ON measurements_oplog USING btree (measurement_unit_code, measurement_unit_qualifier_code);
+CREATE INDEX measrm_pk ON public.measurements_oplog USING btree (measurement_unit_code, measurement_unit_qualifier_code);
 
 
 --
 -- Name: measure_generating_regulation; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX measure_generating_regulation ON measures_oplog USING btree (measure_generating_regulation_id);
+CREATE INDEX measure_generating_regulation ON public.measures_oplog USING btree (measure_generating_regulation_id);
 
 
 --
 -- Name: measure_sid; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX measure_sid ON footnote_association_measures_oplog USING btree (measure_sid);
+CREATE INDEX measure_sid ON public.footnote_association_measures_oplog USING btree (measure_sid);
 
 
 --
 -- Name: measurement_unit_code_qualifier; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX measurement_unit_code_qualifier ON measurement_unit_abbreviations USING btree (measurement_unit_code, measurement_unit_qualifier);
+CREATE INDEX measurement_unit_code_qualifier ON public.measurement_unit_abbreviations USING btree (measurement_unit_code, measurement_unit_qualifier);
 
 
 --
 -- Name: measurement_unit_qualifier_code; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX measurement_unit_qualifier_code ON measure_condition_components_oplog USING btree (measurement_unit_qualifier_code);
+CREATE INDEX measurement_unit_qualifier_code ON public.measure_condition_components_oplog USING btree (measurement_unit_qualifier_code);
 
 
 --
 -- Name: measures_export_refund_nomenclature_sid_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX measures_export_refund_nomenclature_sid_index ON measures_oplog USING btree (export_refund_nomenclature_sid);
+CREATE INDEX measures_export_refund_nomenclature_sid_index ON public.measures_oplog USING btree (export_refund_nomenclature_sid);
 
 
 --
 -- Name: measures_goods_nomenclature_item_id_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX measures_goods_nomenclature_item_id_index ON measures_oplog USING btree (goods_nomenclature_item_id);
+CREATE INDEX measures_goods_nomenclature_item_id_index ON public.measures_oplog USING btree (goods_nomenclature_item_id);
 
 
 --
 -- Name: megao_meaexcgeoareopl_urededcaleaslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX megao_meaexcgeoareopl_urededcaleaslog_operation_date ON measure_excluded_geographical_areas_oplog USING btree (operation_date);
+CREATE INDEX megao_meaexcgeoareopl_urededcaleaslog_operation_date ON public.measure_excluded_geographical_areas_oplog USING btree (operation_date);
 
 
 --
 -- Name: mepo_monexcperopl_aryngeodslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mepo_monexcperopl_aryngeodslog_operation_date ON monetary_exchange_periods_oplog USING btree (operation_date);
+CREATE INDEX mepo_monexcperopl_aryngeodslog_operation_date ON public.monetary_exchange_periods_oplog USING btree (operation_date);
 
 
 --
 -- Name: mero_monexcratopl_aryngeteslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mero_monexcratopl_aryngeteslog_operation_date ON monetary_exchange_rates_oplog USING btree (operation_date);
+CREATE INDEX mero_monexcratopl_aryngeteslog_operation_date ON public.monetary_exchange_rates_oplog USING btree (operation_date);
 
 
 --
 -- Name: meurs_adco_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meurs_adco_pk ON meursing_additional_codes_oplog USING btree (meursing_additional_code_sid);
+CREATE INDEX meurs_adco_pk ON public.meursing_additional_codes_oplog USING btree (meursing_additional_code_sid);
 
 
 --
 -- Name: meurs_head_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meurs_head_pk ON meursing_headings_oplog USING btree (meursing_table_plan_id, meursing_heading_number, row_column_code);
+CREATE INDEX meurs_head_pk ON public.meursing_headings_oplog USING btree (meursing_table_plan_id, meursing_heading_number, row_column_code);
 
 
 --
 -- Name: meurs_head_txt_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meurs_head_txt_pk ON meursing_heading_texts_oplog USING btree (meursing_table_plan_id, meursing_heading_number, row_column_code);
+CREATE INDEX meurs_head_txt_pk ON public.meursing_heading_texts_oplog USING btree (meursing_table_plan_id, meursing_heading_number, row_column_code);
 
 
 --
 -- Name: meurs_subhead_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meurs_subhead_pk ON meursing_subheadings_oplog USING btree (meursing_table_plan_id, meursing_heading_number, row_column_code, subheading_sequence_number);
+CREATE INDEX meurs_subhead_pk ON public.meursing_subheadings_oplog USING btree (meursing_table_plan_id, meursing_heading_number, row_column_code, subheading_sequence_number);
 
 
 --
 -- Name: meurs_tbl_cell_comp_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meurs_tbl_cell_comp_pk ON meursing_table_cell_components_oplog USING btree (meursing_table_plan_id, heading_number, row_column_code, meursing_additional_code_sid);
+CREATE INDEX meurs_tbl_cell_comp_pk ON public.meursing_table_cell_components_oplog USING btree (meursing_table_plan_id, heading_number, row_column_code, meursing_additional_code_sid);
 
 
 --
 -- Name: meurs_tbl_plan_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meurs_tbl_plan_pk ON meursing_table_plans_oplog USING btree (meursing_table_plan_id);
+CREATE INDEX meurs_tbl_plan_pk ON public.meursing_table_plans_oplog USING btree (meursing_table_plan_id);
 
 
 --
 -- Name: mho_meuheaopl_ingngslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mho_meuheaopl_ingngslog_operation_date ON meursing_headings_oplog USING btree (operation_date);
+CREATE INDEX mho_meuheaopl_ingngslog_operation_date ON public.meursing_headings_oplog USING btree (operation_date);
 
 
 --
 -- Name: mhto_meuheatexopl_ingingxtslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mhto_meuheatexopl_ingingxtslog_operation_date ON meursing_heading_texts_oplog USING btree (operation_date);
+CREATE INDEX mhto_meuheatexopl_ingingxtslog_operation_date ON public.meursing_heading_texts_oplog USING btree (operation_date);
 
 
 --
 -- Name: mo_meaopl_ntslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mo_meaopl_ntslog_operation_date ON measurements_oplog USING btree (operation_date);
+CREATE INDEX mo_meaopl_ntslog_operation_date ON public.measurements_oplog USING btree (operation_date);
 
 
 --
 -- Name: mo_meaopl_reslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mo_meaopl_reslog_operation_date ON measures_oplog USING btree (operation_date);
+CREATE INDEX mo_meaopl_reslog_operation_date ON public.measures_oplog USING btree (operation_date);
 
 
 --
 -- Name: mod_reg_complete_abrogation_regulation; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mod_reg_complete_abrogation_regulation ON modification_regulations_oplog USING btree (complete_abrogation_regulation_id, complete_abrogation_regulation_role);
+CREATE INDEX mod_reg_complete_abrogation_regulation ON public.modification_regulations_oplog USING btree (complete_abrogation_regulation_id, complete_abrogation_regulation_role);
 
 
 --
 -- Name: mod_reg_explicit_abrogation_regulation; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mod_reg_explicit_abrogation_regulation ON modification_regulations_oplog USING btree (explicit_abrogation_regulation_id, explicit_abrogation_regulation_role);
+CREATE INDEX mod_reg_explicit_abrogation_regulation ON public.modification_regulations_oplog USING btree (explicit_abrogation_regulation_id, explicit_abrogation_regulation_role);
 
 
 --
 -- Name: mod_reg_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mod_reg_pk ON modification_regulations_oplog USING btree (modification_regulation_id, modification_regulation_role);
+CREATE INDEX mod_reg_pk ON public.modification_regulations_oplog USING btree (modification_regulation_id, modification_regulation_role);
 
 
 --
 -- Name: mon_exch_period_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mon_exch_period_pk ON monetary_exchange_periods_oplog USING btree (monetary_exchange_period_sid, parent_monetary_unit_code);
+CREATE INDEX mon_exch_period_pk ON public.monetary_exchange_periods_oplog USING btree (monetary_exchange_period_sid, parent_monetary_unit_code);
 
 
 --
 -- Name: mon_exch_rate_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mon_exch_rate_pk ON monetary_exchange_rates_oplog USING btree (monetary_exchange_period_sid, child_monetary_unit_code);
+CREATE INDEX mon_exch_rate_pk ON public.monetary_exchange_rates_oplog USING btree (monetary_exchange_period_sid, child_monetary_unit_code);
 
 
 --
 -- Name: mon_unit_desc_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mon_unit_desc_pk ON monetary_unit_descriptions_oplog USING btree (monetary_unit_code);
+CREATE INDEX mon_unit_desc_pk ON public.monetary_unit_descriptions_oplog USING btree (monetary_unit_code);
 
 
 --
 -- Name: mon_unit_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mon_unit_pk ON monetary_units_oplog USING btree (monetary_unit_code, validity_start_date);
+CREATE INDEX mon_unit_pk ON public.monetary_units_oplog USING btree (monetary_unit_code, validity_start_date);
 
 
 --
 -- Name: mptso_meapartemstoopl_ureialaryopslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mptso_meapartemstoopl_ureialaryopslog_operation_date ON measure_partial_temporary_stops_oplog USING btree (operation_date);
+CREATE INDEX mptso_meapartemstoopl_ureialaryopslog_operation_date ON public.measure_partial_temporary_stops_oplog USING btree (operation_date);
 
 
 --
 -- Name: mro_modregopl_iononslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mro_modregopl_iononslog_operation_date ON modification_regulations_oplog USING btree (operation_date);
+CREATE INDEX mro_modregopl_iononslog_operation_date ON public.modification_regulations_oplog USING btree (operation_date);
 
 
 --
 -- Name: mso_meusubopl_ingngslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mso_meusubopl_ingngslog_operation_date ON meursing_subheadings_oplog USING btree (operation_date);
+CREATE INDEX mso_meusubopl_ingngslog_operation_date ON public.meursing_subheadings_oplog USING btree (operation_date);
 
 
 --
 -- Name: mtcco_meutabcelcomopl_ingbleellntslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mtcco_meutabcelcomopl_ingbleellntslog_operation_date ON meursing_table_cell_components_oplog USING btree (operation_date);
+CREATE INDEX mtcco_meutabcelcomopl_ingbleellntslog_operation_date ON public.meursing_table_cell_components_oplog USING btree (operation_date);
 
 
 --
 -- Name: mtdo_meatypdesopl_ureypeonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mtdo_meatypdesopl_ureypeonslog_operation_date ON measure_type_descriptions_oplog USING btree (operation_date);
+CREATE INDEX mtdo_meatypdesopl_ureypeonslog_operation_date ON public.measure_type_descriptions_oplog USING btree (operation_date);
 
 
 --
 -- Name: mto_meatypopl_urepeslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mto_meatypopl_urepeslog_operation_date ON measure_types_oplog USING btree (operation_date);
+CREATE INDEX mto_meatypopl_urepeslog_operation_date ON public.measure_types_oplog USING btree (operation_date);
 
 
 --
 -- Name: mtpo_meutabplaopl_ingbleanslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mtpo_meutabplaopl_ingbleanslog_operation_date ON meursing_table_plans_oplog USING btree (operation_date);
+CREATE INDEX mtpo_meutabplaopl_ingbleanslog_operation_date ON public.meursing_table_plans_oplog USING btree (operation_date);
 
 
 --
 -- Name: mtsdo_meatypserdesopl_ureypeiesonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mtsdo_meatypserdesopl_ureypeiesonslog_operation_date ON measure_type_series_descriptions_oplog USING btree (operation_date);
+CREATE INDEX mtsdo_meatypserdesopl_ureypeiesonslog_operation_date ON public.measure_type_series_descriptions_oplog USING btree (operation_date);
 
 
 --
 -- Name: mtso_meatypseropl_ureypeieslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mtso_meatypseropl_ureypeieslog_operation_date ON measure_type_series_oplog USING btree (operation_date);
+CREATE INDEX mtso_meatypseropl_ureypeieslog_operation_date ON public.measure_type_series_oplog USING btree (operation_date);
 
 
 --
 -- Name: mudo_meaunidesopl_entnitonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mudo_meaunidesopl_entnitonslog_operation_date ON measurement_unit_descriptions_oplog USING btree (operation_date);
+CREATE INDEX mudo_meaunidesopl_entnitonslog_operation_date ON public.measurement_unit_descriptions_oplog USING btree (operation_date);
 
 
 --
 -- Name: mudo_monunidesopl_arynitonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mudo_monunidesopl_arynitonslog_operation_date ON monetary_unit_descriptions_oplog USING btree (operation_date);
+CREATE INDEX mudo_monunidesopl_arynitonslog_operation_date ON public.monetary_unit_descriptions_oplog USING btree (operation_date);
 
 
 --
 -- Name: muo_meauniopl_entitslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX muo_meauniopl_entitslog_operation_date ON measurement_units_oplog USING btree (operation_date);
+CREATE INDEX muo_meauniopl_entitslog_operation_date ON public.measurement_units_oplog USING btree (operation_date);
 
 
 --
 -- Name: muo_monuniopl_aryitslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX muo_monuniopl_aryitslog_operation_date ON monetary_units_oplog USING btree (operation_date);
+CREATE INDEX muo_monuniopl_aryitslog_operation_date ON public.monetary_units_oplog USING btree (operation_date);
 
 
 --
 -- Name: muqdo_meauniquadesopl_entnitieronslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX muqdo_meauniquadesopl_entnitieronslog_operation_date ON measurement_unit_qualifier_descriptions_oplog USING btree (operation_date);
+CREATE INDEX muqdo_meauniquadesopl_entnitieronslog_operation_date ON public.measurement_unit_qualifier_descriptions_oplog USING btree (operation_date);
 
 
 --
 -- Name: muqo_meauniquaopl_entniterslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX muqo_meauniquaopl_entniterslog_operation_date ON measurement_unit_qualifiers_oplog USING btree (operation_date);
+CREATE INDEX muqo_meauniquaopl_entniterslog_operation_date ON public.measurement_unit_qualifiers_oplog USING btree (operation_date);
 
 
 --
 -- Name: ngmo_nomgromemopl_ureoupipslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ngmo_nomgromemopl_ureoupipslog_operation_date ON nomenclature_group_memberships_oplog USING btree (operation_date);
+CREATE INDEX ngmo_nomgromemopl_ureoupipslog_operation_date ON public.nomenclature_group_memberships_oplog USING btree (operation_date);
 
 
 --
 -- Name: nom_grp_member_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX nom_grp_member_pk ON nomenclature_group_memberships_oplog USING btree (goods_nomenclature_sid, goods_nomenclature_group_id, goods_nomenclature_group_type, goods_nomenclature_item_id, validity_start_date);
+CREATE INDEX nom_grp_member_pk ON public.nomenclature_group_memberships_oplog USING btree (goods_nomenclature_sid, goods_nomenclature_group_id, goods_nomenclature_group_type, goods_nomenclature_item_id, validity_start_date);
 
 
 --
 -- Name: period_sid; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX period_sid ON additional_code_descriptions_oplog USING btree (additional_code_description_period_sid);
+CREATE INDEX period_sid ON public.additional_code_descriptions_oplog USING btree (additional_code_description_period_sid);
 
 
 --
 -- Name: prao_proregactopl_ioniononslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX prao_proregactopl_ioniononslog_operation_date ON prorogation_regulation_actions_oplog USING btree (operation_date);
+CREATE INDEX prao_proregactopl_ioniononslog_operation_date ON public.prorogation_regulation_actions_oplog USING btree (operation_date);
 
 
 --
 -- Name: primary_key; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX primary_key ON geographical_areas_oplog USING btree (geographical_area_sid);
+CREATE INDEX primary_key ON public.geographical_areas_oplog USING btree (geographical_area_sid);
 
 
 --
 -- Name: pro_proregopl_iononslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX pro_proregopl_iononslog_operation_date ON prorogation_regulations_oplog USING btree (operation_date);
+CREATE INDEX pro_proregopl_iononslog_operation_date ON public.prorogation_regulations_oplog USING btree (operation_date);
 
 
 --
 -- Name: prorog_reg_act_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX prorog_reg_act_pk ON prorogation_regulation_actions_oplog USING btree (prorogation_regulation_id, prorogation_regulation_role, prorogated_regulation_id, prorogated_regulation_role);
+CREATE INDEX prorog_reg_act_pk ON public.prorogation_regulation_actions_oplog USING btree (prorogation_regulation_id, prorogation_regulation_role, prorogated_regulation_id, prorogated_regulation_role);
 
 
 --
 -- Name: prorog_reg_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX prorog_reg_pk ON prorogation_regulations_oplog USING btree (prorogation_regulation_id, prorogation_regulation_role);
+CREATE INDEX prorog_reg_pk ON public.prorogation_regulations_oplog USING btree (prorogation_regulation_id, prorogation_regulation_role);
 
 
 --
 -- Name: qao_quoassopl_otaonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX qao_quoassopl_otaonslog_operation_date ON quota_associations_oplog USING btree (operation_date);
+CREATE INDEX qao_quoassopl_otaonslog_operation_date ON public.quota_associations_oplog USING btree (operation_date);
 
 
 --
 -- Name: qbeo_quobaleveopl_otancentslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX qbeo_quobaleveopl_otancentslog_operation_date ON quota_balance_events_oplog USING btree (operation_date);
+CREATE INDEX qbeo_quobaleveopl_otancentslog_operation_date ON public.quota_balance_events_oplog USING btree (operation_date);
 
 
 --
 -- Name: qbpo_quobloperopl_otaingodslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX qbpo_quobloperopl_otaingodslog_operation_date ON quota_blocking_periods_oplog USING btree (operation_date);
+CREATE INDEX qbpo_quobloperopl_otaingodslog_operation_date ON public.quota_blocking_periods_oplog USING btree (operation_date);
 
 
 --
 -- Name: qceo_quocrieveopl_otacalntslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX qceo_quocrieveopl_otacalntslog_operation_date ON quota_critical_events_oplog USING btree (operation_date);
+CREATE INDEX qceo_quocrieveopl_otacalntslog_operation_date ON public.quota_critical_events_oplog USING btree (operation_date);
 
 
 --
 -- Name: qdo_quodefopl_otaonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX qdo_quodefopl_otaonslog_operation_date ON quota_definitions_oplog USING btree (operation_date);
+CREATE INDEX qdo_quodefopl_otaonslog_operation_date ON public.quota_definitions_oplog USING btree (operation_date);
 
 
 --
 -- Name: qeeo_quoexheveopl_otaionntslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX qeeo_quoexheveopl_otaionntslog_operation_date ON quota_exhaustion_events_oplog USING btree (operation_date);
+CREATE INDEX qeeo_quoexheveopl_otaionntslog_operation_date ON public.quota_exhaustion_events_oplog USING btree (operation_date);
 
 
 --
 -- Name: qono_quoordnumopl_otadererslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX qono_quoordnumopl_otadererslog_operation_date ON quota_order_numbers_oplog USING btree (operation_date);
+CREATE INDEX qono_quoordnumopl_otadererslog_operation_date ON public.quota_order_numbers_oplog USING btree (operation_date);
 
 
 --
 -- Name: qonoeo_quoordnumoriexcopl_otaderberginonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX qonoeo_quoordnumoriexcopl_otaderberginonslog_operation_date ON quota_order_number_origin_exclusions_oplog USING btree (operation_date);
+CREATE INDEX qonoeo_quoordnumoriexcopl_otaderberginonslog_operation_date ON public.quota_order_number_origin_exclusions_oplog USING btree (operation_date);
 
 
 --
 -- Name: qonoo_quoordnumoriopl_otaderberinslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX qonoo_quoordnumoriopl_otaderberinslog_operation_date ON quota_order_number_origins_oplog USING btree (operation_date);
+CREATE INDEX qonoo_quoordnumoriopl_otaderberinslog_operation_date ON public.quota_order_number_origins_oplog USING btree (operation_date);
 
 
 --
 -- Name: qreo_quoreoeveopl_otaingntslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX qreo_quoreoeveopl_otaingntslog_operation_date ON quota_reopening_events_oplog USING btree (operation_date);
+CREATE INDEX qreo_quoreoeveopl_otaingntslog_operation_date ON public.quota_reopening_events_oplog USING btree (operation_date);
 
 
 --
 -- Name: qspo_quosusperopl_otaionodslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX qspo_quosusperopl_otaionodslog_operation_date ON quota_suspension_periods_oplog USING btree (operation_date);
+CREATE INDEX qspo_quosusperopl_otaionodslog_operation_date ON public.quota_suspension_periods_oplog USING btree (operation_date);
 
 
 --
 -- Name: queo_quounbeveopl_otaingntslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX queo_quounbeveopl_otaingntslog_operation_date ON quota_unblocking_events_oplog USING btree (operation_date);
+CREATE INDEX queo_quounbeveopl_otaingntslog_operation_date ON public.quota_unblocking_events_oplog USING btree (operation_date);
 
 
 --
 -- Name: queo_quounseveopl_otaionntslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX queo_quounseveopl_otaionntslog_operation_date ON quota_unsuspension_events_oplog USING btree (operation_date);
+CREATE INDEX queo_quounseveopl_otaionntslog_operation_date ON public.quota_unsuspension_events_oplog USING btree (operation_date);
 
 
 --
 -- Name: quota_assoc_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX quota_assoc_pk ON quota_associations_oplog USING btree (main_quota_definition_sid, sub_quota_definition_sid);
+CREATE INDEX quota_assoc_pk ON public.quota_associations_oplog USING btree (main_quota_definition_sid, sub_quota_definition_sid);
 
 
 --
 -- Name: quota_balance_evt_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX quota_balance_evt_pk ON quota_balance_events_oplog USING btree (quota_definition_sid, occurrence_timestamp);
+CREATE INDEX quota_balance_evt_pk ON public.quota_balance_events_oplog USING btree (quota_definition_sid, occurrence_timestamp);
 
 
 --
 -- Name: quota_block_period_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX quota_block_period_pk ON quota_blocking_periods_oplog USING btree (quota_blocking_period_sid);
+CREATE INDEX quota_block_period_pk ON public.quota_blocking_periods_oplog USING btree (quota_blocking_period_sid);
 
 
 --
 -- Name: quota_crit_evt_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX quota_crit_evt_pk ON quota_critical_events_oplog USING btree (quota_definition_sid, occurrence_timestamp);
+CREATE INDEX quota_crit_evt_pk ON public.quota_critical_events_oplog USING btree (quota_definition_sid, occurrence_timestamp);
 
 
 --
 -- Name: quota_def_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX quota_def_pk ON quota_definitions_oplog USING btree (quota_definition_sid);
+CREATE INDEX quota_def_pk ON public.quota_definitions_oplog USING btree (quota_definition_sid);
 
 
 --
 -- Name: quota_exhaus_evt_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX quota_exhaus_evt_pk ON quota_exhaustion_events_oplog USING btree (quota_definition_sid, occurrence_timestamp);
+CREATE INDEX quota_exhaus_evt_pk ON public.quota_exhaustion_events_oplog USING btree (quota_definition_sid, occurrence_timestamp);
 
 
 --
 -- Name: quota_ord_num_excl_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX quota_ord_num_excl_pk ON quota_order_number_origin_exclusions_oplog USING btree (quota_order_number_origin_sid, excluded_geographical_area_sid);
+CREATE INDEX quota_ord_num_excl_pk ON public.quota_order_number_origin_exclusions_oplog USING btree (quota_order_number_origin_sid, excluded_geographical_area_sid);
 
 
 --
 -- Name: quota_ord_num_orig_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX quota_ord_num_orig_pk ON quota_order_number_origins_oplog USING btree (quota_order_number_origin_sid);
+CREATE INDEX quota_ord_num_orig_pk ON public.quota_order_number_origins_oplog USING btree (quota_order_number_origin_sid);
 
 
 --
 -- Name: quota_ord_num_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX quota_ord_num_pk ON quota_order_numbers_oplog USING btree (quota_order_number_sid);
+CREATE INDEX quota_ord_num_pk ON public.quota_order_numbers_oplog USING btree (quota_order_number_sid);
 
 
 --
 -- Name: quota_reopen_evt_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX quota_reopen_evt_pk ON quota_reopening_events_oplog USING btree (quota_definition_sid, occurrence_timestamp);
+CREATE INDEX quota_reopen_evt_pk ON public.quota_reopening_events_oplog USING btree (quota_definition_sid, occurrence_timestamp);
 
 
 --
 -- Name: quota_susp_period_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX quota_susp_period_pk ON quota_suspension_periods_oplog USING btree (quota_suspension_period_sid);
+CREATE INDEX quota_susp_period_pk ON public.quota_suspension_periods_oplog USING btree (quota_suspension_period_sid);
 
 
 --
 -- Name: quota_unblock_evt_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX quota_unblock_evt_pk ON quota_unblocking_events_oplog USING btree (quota_definition_sid, occurrence_timestamp);
+CREATE INDEX quota_unblock_evt_pk ON public.quota_unblocking_events_oplog USING btree (quota_definition_sid, occurrence_timestamp);
 
 
 --
 -- Name: quota_unsusp_evt_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX quota_unsusp_evt_pk ON quota_unsuspension_events_oplog USING btree (quota_definition_sid, occurrence_timestamp);
+CREATE INDEX quota_unsusp_evt_pk ON public.quota_unsuspension_events_oplog USING btree (quota_definition_sid, occurrence_timestamp);
 
 
 --
 -- Name: reg_grp_desc_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX reg_grp_desc_pk ON regulation_group_descriptions_oplog USING btree (regulation_group_id);
+CREATE INDEX reg_grp_desc_pk ON public.regulation_group_descriptions_oplog USING btree (regulation_group_id);
 
 
 --
 -- Name: reg_grp_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX reg_grp_pk ON regulation_groups_oplog USING btree (regulation_group_id);
+CREATE INDEX reg_grp_pk ON public.regulation_groups_oplog USING btree (regulation_group_id);
 
 
 --
 -- Name: reg_role_type_desc_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX reg_role_type_desc_pk ON regulation_role_type_descriptions_oplog USING btree (regulation_role_type_id);
+CREATE INDEX reg_role_type_desc_pk ON public.regulation_role_type_descriptions_oplog USING btree (regulation_role_type_id);
 
 
 --
 -- Name: reg_role_type_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX reg_role_type_pk ON regulation_role_types_oplog USING btree (regulation_role_type_id);
+CREATE INDEX reg_role_type_pk ON public.regulation_role_types_oplog USING btree (regulation_role_type_id);
 
 
 --
 -- Name: rgdo_reggrodesopl_ionouponslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX rgdo_reggrodesopl_ionouponslog_operation_date ON regulation_group_descriptions_oplog USING btree (operation_date);
+CREATE INDEX rgdo_reggrodesopl_ionouponslog_operation_date ON public.regulation_group_descriptions_oplog USING btree (operation_date);
 
 
 --
 -- Name: rgo_reggroopl_ionupslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX rgo_reggroopl_ionupslog_operation_date ON regulation_groups_oplog USING btree (operation_date);
+CREATE INDEX rgo_reggroopl_ionupslog_operation_date ON public.regulation_groups_oplog USING btree (operation_date);
 
 
 --
 -- Name: rr_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX rr_pk ON regulation_replacements_oplog USING btree (replaced_regulation_role, replaced_regulation_id);
+CREATE INDEX rr_pk ON public.regulation_replacements_oplog USING btree (replaced_regulation_role, replaced_regulation_id);
 
 
 --
 -- Name: rro_regrepopl_ionntslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX rro_regrepopl_ionntslog_operation_date ON regulation_replacements_oplog USING btree (operation_date);
+CREATE INDEX rro_regrepopl_ionntslog_operation_date ON public.regulation_replacements_oplog USING btree (operation_date);
 
 
 --
 -- Name: rrtdo_regroltypdesopl_ionoleypeonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX rrtdo_regroltypdesopl_ionoleypeonslog_operation_date ON regulation_role_type_descriptions_oplog USING btree (operation_date);
+CREATE INDEX rrtdo_regroltypdesopl_ionoleypeonslog_operation_date ON public.regulation_role_type_descriptions_oplog USING btree (operation_date);
 
 
 --
 -- Name: rrto_regroltypopl_ionolepeslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX rrto_regroltypopl_ionolepeslog_operation_date ON regulation_role_types_oplog USING btree (operation_date);
+CREATE INDEX rrto_regroltypopl_ionolepeslog_operation_date ON public.regulation_role_types_oplog USING btree (operation_date);
 
 
 --
 -- Name: search_references_referenced_id_referenced_class_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX search_references_referenced_id_referenced_class_index ON search_references USING btree (referenced_id, referenced_class);
+CREATE INDEX search_references_referenced_id_referenced_class_index ON public.search_references USING btree (referenced_id, referenced_class);
 
 
 --
 -- Name: section_notes_section_id_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX section_notes_section_id_index ON section_notes USING btree (section_id);
+CREATE INDEX section_notes_section_id_index ON public.section_notes USING btree (section_id);
 
 
 --
 -- Name: sid; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX sid ON additional_code_descriptions_oplog USING btree (additional_code_sid);
+CREATE INDEX sid ON public.additional_code_descriptions_oplog USING btree (additional_code_sid);
 
 
 --
 -- Name: tariff_update_conformance_errors_tariff_update_filename_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX tariff_update_conformance_errors_tariff_update_filename_index ON tariff_update_conformance_errors USING btree (tariff_update_filename);
+CREATE INDEX tariff_update_conformance_errors_tariff_update_filename_index ON public.tariff_update_conformance_errors USING btree (tariff_update_filename);
 
 
 --
 -- Name: tbl_code_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX tbl_code_index ON chief_tbl9 USING btree (tbl_code);
+CREATE INDEX tbl_code_index ON public.chief_tbl9 USING btree (tbl_code);
 
 
 --
 -- Name: tbl_type_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX tbl_type_index ON chief_tbl9 USING btree (tbl_type);
+CREATE INDEX tbl_type_index ON public.chief_tbl9 USING btree (tbl_type);
 
 
 --
 -- Name: tco_tracomopl_ionntslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX tco_tracomopl_ionntslog_operation_date ON transmission_comments_oplog USING btree (operation_date);
+CREATE INDEX tco_tracomopl_ionntslog_operation_date ON public.transmission_comments_oplog USING btree (operation_date);
 
 
 --
 -- Name: trans_comm_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX trans_comm_pk ON transmission_comments_oplog USING btree (comment_sid, language_id);
+CREATE INDEX trans_comm_pk ON public.transmission_comments_oplog USING btree (comment_sid, language_id);
 
 
 --
 -- Name: type_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX type_id ON additional_code_descriptions_oplog USING btree (additional_code_type_id);
+CREATE INDEX type_id ON public.additional_code_descriptions_oplog USING btree (additional_code_type_id);
 
 
 --
 -- Name: uoq_code_cdu2_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX uoq_code_cdu2_index ON chief_comm USING btree (uoq_code_cdu2);
+CREATE INDEX uoq_code_cdu2_index ON public.chief_comm USING btree (uoq_code_cdu2);
 
 
 --
 -- Name: uoq_code_cdu3_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX uoq_code_cdu3_index ON chief_comm USING btree (uoq_code_cdu3);
+CREATE INDEX uoq_code_cdu3_index ON public.chief_comm USING btree (uoq_code_cdu3);
 
 
 --
 -- Name: user_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX user_id ON rollbacks USING btree (user_id);
+CREATE INDEX user_id ON public.rollbacks USING btree (user_id);
+
+
+--
+-- Name: reassign_owned; Type: EVENT TRIGGER; Schema: -; Owner: -
+--
+
+CREATE EVENT TRIGGER reassign_owned ON ddl_command_end
+   EXECUTE PROCEDURE public.reassign_owned();
 
 
 --
@@ -10101,3 +10159,4 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20161209195324_alter_footn
 INSERT INTO "schema_migrations" ("filename") VALUES ('20170117212158_create_audits.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20170331125740_create_data_migrations.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20171228082821_create_publication_sigles.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180724155759_fix_footnote_id_characters_limit_in_associations.rb');


### PR DESCRIPTION
Footnote, FootnoteDescription, FootnoteDescriptionPeriod
in current db having:

```
footnote_id character varying(5)
```

but in FootnoteAssociationMeasure

```
footnote_id character varying(3)
```

This is wrong and break saving of FootnoteAssociationMeasure
if footnote_id is longer than 3 symbols

This migration fixes this issue.