### PR TITLE
Presence errors

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -3,6 +3,7 @@ TARIFF_SYNC_PASSWORD=password
 TARIFF_SYNC_HOST=http://example.com
 TARIFF_SYNC_EMAIL=user@example.com
 TARIFF_MEASURES_LOGGER=0
+TARIFF_IGNORE_PRESENCE_ERRORS=0
 TARIFF_FROM_EMAIL=no-reply@example.com
 AWS_ACCESS_KEY_ID=xxxxxxxxxxxxxxxxxxxx
 AWS_SECRET_ACCESS_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/app/controllers/api/v1/updates_controller.rb
+++ b/app/controllers/api/v1/updates_controller.rb
@@ -15,7 +15,9 @@ module Api
       private
 
       def collection
-        @collection ||= TariffSynchronizer::BaseUpdate.descending.paginate(current_page, per_page)
+        @collection ||= TariffSynchronizer::BaseUpdate.eager(:conformance_errors, :presence_errors)
+                                                      .descending
+                                                      .paginate(current_page, per_page)
       end
 
       def per_page

--- a/app/views/api/v1/updates/index.json.rabl
+++ b/app/views/api/v1/updates/index.json.rabl
@@ -7,6 +7,10 @@ child @collection => :updates do
   child :conformance_errors => :conformance_errors do
     attributes :model_name, :model_primary_key, :model_values, :model_conformance_errors
   end
+
+  child :presence_errors => :presence_errors do
+    attributes :model_name, :details
+  end
 end
 
 extends "api/v1/shared/pagination"

--- a/app/views/tariff_synchronizer/mailer/applied.html.erb
+++ b/app/views/tariff_synchronizer/mailer/applied.html.erb
@@ -57,3 +57,31 @@
     <strong>No conformance errors found.</strong>
   </p>
 <% end %>
+
+<% if @presence_errors.to_a.any? %>
+  <table>
+    <thead>
+    <tr>
+      <th>Model</th>
+      <th>Details</th>
+    </tr>
+    </thead>
+    <tbody>
+    <% @presence_errors.each do |record| %>
+      <tr>
+        <td>
+          <strong><%= record.model_name %></strong>
+        </td>
+
+        <td>
+          <%= record.details.inspect %>
+        </td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <p>
+    <strong>No presence errors found.</strong>
+  </p>
+<% end %>

--- a/db/migrate/20180730143329_add_tariff_update_destroy_errors.rb
+++ b/db/migrate/20180730143329_add_tariff_update_destroy_errors.rb
@@ -1,0 +1,12 @@
+Sequel.migration do
+  change do
+    create_table :tariff_update_destroy_errors do
+      primary_key :id
+      String :tariff_update_filename, null: false
+      String :model_name, null: false
+      jsonb :attributes
+
+      index :tariff_update_filename
+    end
+  end
+end

--- a/db/migrate/20180730143329_add_tariff_update_presence_errors.rb
+++ b/db/migrate/20180730143329_add_tariff_update_presence_errors.rb
@@ -1,10 +1,10 @@
 Sequel.migration do
   change do
-    create_table :tariff_update_destroy_errors do
+    create_table :tariff_update_presence_errors do
       primary_key :id
       String :tariff_update_filename, null: false
       String :model_name, null: false
-      jsonb :attributes
+      jsonb :details
 
       index :tariff_update_filename
     end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -6259,7 +6259,7 @@ ALTER SEQUENCE public.tariff_update_conformance_errors_id_seq OWNED BY public.ta
 -- Name: tariff_update_presence_errors; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE tariff_update_presence_errors (
+CREATE TABLE public.tariff_update_presence_errors (
     id integer NOT NULL,
     tariff_update_filename text NOT NULL,
     model_name text NOT NULL,
@@ -6271,7 +6271,7 @@ CREATE TABLE tariff_update_presence_errors (
 -- Name: tariff_update_presence_errors_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE tariff_update_presence_errors_id_seq
+CREATE SEQUENCE public.tariff_update_presence_errors_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -6283,7 +6283,7 @@ CREATE SEQUENCE tariff_update_presence_errors_id_seq
 -- Name: tariff_update_presence_errors_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE tariff_update_presence_errors_id_seq OWNED BY tariff_update_presence_errors.id;
+ALTER SEQUENCE public.tariff_update_presence_errors_id_seq OWNED BY tariff_update_presence_errors.id;
 
 
 --
@@ -7164,7 +7164,7 @@ ALTER TABLE ONLY public.tariff_update_conformance_errors ALTER COLUMN id SET DEF
 -- Name: tariff_update_presence_errors id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY tariff_update_presence_errors ALTER COLUMN id SET DEFAULT nextval('tariff_update_presence_errors_id_seq'::regclass);
+ALTER TABLE ONLY public.tariff_update_presence_errors ALTER COLUMN id SET DEFAULT nextval('tariff_update_presence_errors_id_seq'::regclass);
 
 
 --
@@ -8073,7 +8073,7 @@ ALTER TABLE ONLY public.tariff_update_conformance_errors
 -- Name: tariff_update_presence_errors tariff_update_presence_errors_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY tariff_update_presence_errors
+ALTER TABLE ONLY public.tariff_update_presence_errors
     ADD CONSTRAINT tariff_update_presence_errors_pkey PRIMARY KEY (id);
 
 
@@ -10065,7 +10065,7 @@ CREATE INDEX tariff_update_conformance_errors_tariff_update_filename_index ON pu
 -- Name: tariff_update_presence_errors_tariff_update_filename_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX tariff_update_presence_errors_tariff_update_filename_index ON tariff_update_presence_errors USING btree (tariff_update_filename);
+CREATE INDEX tariff_update_presence_errors_tariff_update_filename_index ON public.tariff_update_presence_errors USING btree (tariff_update_filename);
 
 
 --

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -6256,22 +6256,22 @@ ALTER SEQUENCE public.tariff_update_conformance_errors_id_seq OWNED BY public.ta
 
 
 --
--- Name: tariff_update_destroy_errors; Type: TABLE; Schema: public; Owner: -
+-- Name: tariff_update_presence_errors; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE tariff_update_destroy_errors (
+CREATE TABLE tariff_update_presence_errors (
     id integer NOT NULL,
     tariff_update_filename text NOT NULL,
     model_name text NOT NULL,
-    attributes jsonb
+    details jsonb
 );
 
 
 --
--- Name: tariff_update_destroy_errors_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: tariff_update_presence_errors_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE tariff_update_destroy_errors_id_seq
+CREATE SEQUENCE tariff_update_presence_errors_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -6280,10 +6280,10 @@ CREATE SEQUENCE tariff_update_destroy_errors_id_seq
 
 
 --
--- Name: tariff_update_destroy_errors_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+-- Name: tariff_update_presence_errors_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE tariff_update_destroy_errors_id_seq OWNED BY tariff_update_destroy_errors.id;
+ALTER SEQUENCE tariff_update_presence_errors_id_seq OWNED BY tariff_update_presence_errors.id;
 
 
 --
@@ -7161,10 +7161,10 @@ ALTER TABLE ONLY public.tariff_update_conformance_errors ALTER COLUMN id SET DEF
 
 
 --
--- Name: tariff_update_destroy_errors id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: tariff_update_presence_errors id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY tariff_update_destroy_errors ALTER COLUMN id SET DEFAULT nextval('tariff_update_destroy_errors_id_seq'::regclass);
+ALTER TABLE ONLY tariff_update_presence_errors ALTER COLUMN id SET DEFAULT nextval('tariff_update_presence_errors_id_seq'::regclass);
 
 
 --
@@ -8070,11 +8070,11 @@ ALTER TABLE ONLY public.tariff_update_conformance_errors
 
 
 --
--- Name: tariff_update_destroy_errors tariff_update_destroy_errors_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: tariff_update_presence_errors tariff_update_presence_errors_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY tariff_update_destroy_errors
-    ADD CONSTRAINT tariff_update_destroy_errors_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY tariff_update_presence_errors
+    ADD CONSTRAINT tariff_update_presence_errors_pkey PRIMARY KEY (id);
 
 
 --
@@ -10062,10 +10062,10 @@ CREATE INDEX tariff_update_conformance_errors_tariff_update_filename_index ON pu
 
 
 --
--- Name: tariff_update_destroy_errors_tariff_update_filename_index; Type: INDEX; Schema: public; Owner: -
+-- Name: tariff_update_presence_errors_tariff_update_filename_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX tariff_update_destroy_errors_tariff_update_filename_index ON tariff_update_destroy_errors USING btree (tariff_update_filename);
+CREATE INDEX tariff_update_presence_errors_tariff_update_filename_index ON tariff_update_presence_errors USING btree (tariff_update_filename);
 
 
 --
@@ -10213,4 +10213,4 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20170117212158_create_audi
 INSERT INTO "schema_migrations" ("filename") VALUES ('20170331125740_create_data_migrations.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20171228082821_create_publication_sigles.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20180724155759_fix_footnote_id_characters_limit_in_associations.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180730143329_add_tariff_update_destroy_errors.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180730143329_add_tariff_update_presence_errors.rb');

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -6256,6 +6256,37 @@ ALTER SEQUENCE public.tariff_update_conformance_errors_id_seq OWNED BY public.ta
 
 
 --
+-- Name: tariff_update_destroy_errors; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE tariff_update_destroy_errors (
+    id integer NOT NULL,
+    tariff_update_filename text NOT NULL,
+    model_name text NOT NULL,
+    attributes jsonb
+);
+
+
+--
+-- Name: tariff_update_destroy_errors_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE tariff_update_destroy_errors_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: tariff_update_destroy_errors_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE tariff_update_destroy_errors_id_seq OWNED BY tariff_update_destroy_errors.id;
+
+
+--
 -- Name: tariff_updates; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -7127,6 +7158,13 @@ ALTER TABLE ONLY public.sections ALTER COLUMN id SET DEFAULT nextval('public.sec
 --
 
 ALTER TABLE ONLY public.tariff_update_conformance_errors ALTER COLUMN id SET DEFAULT nextval('public.tariff_update_conformance_errors_id_seq'::regclass);
+
+
+--
+-- Name: tariff_update_destroy_errors id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY tariff_update_destroy_errors ALTER COLUMN id SET DEFAULT nextval('tariff_update_destroy_errors_id_seq'::regclass);
 
 
 --
@@ -8029,6 +8067,14 @@ ALTER TABLE ONLY public.sections
 
 ALTER TABLE ONLY public.tariff_update_conformance_errors
     ADD CONSTRAINT tariff_update_conformance_errors_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: tariff_update_destroy_errors tariff_update_destroy_errors_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY tariff_update_destroy_errors
+    ADD CONSTRAINT tariff_update_destroy_errors_pkey PRIMARY KEY (id);
 
 
 --
@@ -10016,6 +10062,13 @@ CREATE INDEX tariff_update_conformance_errors_tariff_update_filename_index ON pu
 
 
 --
+-- Name: tariff_update_destroy_errors_tariff_update_filename_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX tariff_update_destroy_errors_tariff_update_filename_index ON tariff_update_destroy_errors USING btree (tariff_update_filename);
+
+
+--
 -- Name: tbl_code_index; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -10160,3 +10213,4 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20170117212158_create_audi
 INSERT INTO "schema_migrations" ("filename") VALUES ('20170331125740_create_data_migrations.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20171228082821_create_publication_sigles.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20180724155759_fix_footnote_id_characters_limit_in_associations.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180730143329_add_tariff_update_destroy_errors.rb');

--- a/lib/taric_importer/record_processor/create_operation.rb
+++ b/lib/taric_importer/record_processor/create_operation.rb
@@ -8,6 +8,12 @@ class TaricImporter
       def to_oplog_operation
         :create
       end
+
+      private
+
+      def get_model_record
+        klass.new
+      end
     end
   end
 end

--- a/lib/taric_importer/record_processor/destroy_operation.rb
+++ b/lib/taric_importer/record_processor/destroy_operation.rb
@@ -3,39 +3,17 @@ class TaricImporter
     class DestroyOperation < Operation
       def call
         model = get_model_record
-        return unless model
-        model.set(attributes.except(*primary_key).symbolize_keys)
-        model.destroy
+        if model
+          model.set(attributes.except(*primary_key).symbolize_keys)
+          model.destroy
+        else
+          log_presence_error
+        end
         model
       end
 
       def to_oplog_operation
         :destroy
-      end
-
-      private
-
-      # Sometimes destroy operations go in wrong order (not chronologically, e.g. 'destroy' operation goes before 'create').
-      # We decided to have ability to not break import process:
-      #   set env TARIFF_IGNORE_PRESENCE_ON_DESTROY=1 to ignore Sequel::RecordNotFound on destroy
-      def get_model_record
-        filters = attributes.slice(*primary_key).symbolize_keys
-        if ignore_presence_on_destroy?
-          model = klass.filter(filters).first
-          log_destroy_error unless model
-        else
-          model = klass.filter(filters).take
-        end
-        model
-      end
-
-      def log_destroy_error
-        attrs = record.attributes.merge(transaction_id: record.transaction_id, operation_date: @operation_date)
-        instrument("destroy_error.taric_importer", klass: klass.to_s, attributes: attrs)
-      end
-
-      def ignore_presence_on_destroy?
-        TariffSynchronizer.ignore_presence_on_destroy
       end
     end
   end

--- a/lib/taric_importer/record_processor/destroy_operation.rb
+++ b/lib/taric_importer/record_processor/destroy_operation.rb
@@ -2,7 +2,8 @@ class TaricImporter
   class RecordProcessor
     class DestroyOperation < Operation
       def call
-        model = klass.filter(attributes.slice(*primary_key).symbolize_keys).take
+        model = get_model_record
+        return unless model
         model.set(attributes.except(*primary_key).symbolize_keys)
         model.destroy
         model
@@ -10,6 +11,31 @@ class TaricImporter
 
       def to_oplog_operation
         :destroy
+      end
+
+      private
+
+      # Sometimes destroy operations go in wrong order (not chronologically, e.g. 'destroy' operation goes before 'create').
+      # We decided to have ability to not break import process:
+      #   set env TARIFF_IGNORE_PRESENCE_ON_DESTROY=1 to ignore Sequel::RecordNotFound on destroy
+      def get_model_record
+        filters = attributes.slice(*primary_key).symbolize_keys
+        if ignore_presence_on_destroy?
+          model = klass.filter(filters).first
+          log_destroy_error unless model
+        else
+          model = klass.filter(filters).take
+        end
+        model
+      end
+
+      def log_destroy_error
+        attrs = record.attributes.merge(transaction_id: record.transaction_id, operation_date: @operation_date)
+        instrument("destroy_error.taric_importer", klass: klass.to_s, attributes: attrs)
+      end
+
+      def ignore_presence_on_destroy?
+        TariffSynchronizer.ignore_presence_on_destroy
       end
     end
   end

--- a/lib/taric_importer/record_processor/operation.rb
+++ b/lib/taric_importer/record_processor/operation.rb
@@ -15,8 +15,8 @@ class TaricImporter
       # for Oplog
       def attributes
         record.attributes.merge(
-          'operation' => to_oplog_operation,
-          'operation_date' => @operation_date
+          "operation" => to_oplog_operation,
+          "operation_date" => @operation_date
         )
       end
 
@@ -26,6 +26,35 @@ class TaricImporter
 
       def to_oplog_operation
         raise NotImplementedError.new
+      end
+
+      private
+
+      def ignore_presence_errors?
+        TariffSynchronizer.ignore_presence_errors
+      end
+
+      # Sometimes update operations go in wrong order (not chronologically, e.g. 'update' operation goes before 'create').
+      # We decided to have ability to not break import process:
+      #   set env TARIFF_IGNORE_PRESENCE_ERRORS=1 to ignore Sequel::RecordNotFound on update
+      # We also decided to create new record if it does not exist
+      def get_model_record
+        filters = attributes.slice(*primary_key).symbolize_keys
+        if ignore_presence_errors?
+          model = klass.filter(filters).first
+        else
+          model = klass.filter(filters).take
+        end
+        model
+      end
+
+      def log_presence_error
+        details = record.attributes.merge(
+          transaction_id: record.transaction_id,
+          operation_date: @operation_date,
+          operation: to_oplog_operation
+        )
+        instrument("presence_error.taric_importer", klass: klass.to_s, details: details)
       end
     end
   end

--- a/lib/taric_importer/record_processor/operation.rb
+++ b/lib/taric_importer/record_processor/operation.rb
@@ -4,6 +4,7 @@ class TaricImporter
       attr_reader :record
 
       delegate :primary_key, :klass, to: :record
+      delegate :instrument, to: ActiveSupport::Notifications
 
       def initialize(record, operation_date)
         @record = record

--- a/lib/taric_importer/record_processor/record.rb
+++ b/lib/taric_importer/record_processor/record.rb
@@ -31,7 +31,7 @@ class TaricImporter
       attr_accessor :transaction_id
 
       def initialize(record_hash)
-        self.transaction_id = record_hash['transaction_id']
+        self.transaction_id = record_hash["transaction_id"]
         self.klass = fast_classify(record_hash.keys.last).constantize
         self.primary_key = [klass.primary_key].flatten.map(&:to_s)
         self.attributes = record_hash.values.last

--- a/lib/taric_importer/record_processor/update_operation.rb
+++ b/lib/taric_importer/record_processor/update_operation.rb
@@ -2,8 +2,13 @@ class TaricImporter
   class RecordProcessor
     class UpdateOperation < Operation
       def call
-        model = klass.filter(attributes.slice(*primary_key).symbolize_keys).take
-        model.update(attributes.except(*primary_key).symbolize_keys)
+        model = get_model_record
+        if model
+          model.update(attributes.except(*primary_key).symbolize_keys)
+        else
+          log_presence_error
+          model = TaricImporter::RecordProcessor::CreateOperation.new(record, @operation_date).call
+        end
         model
       end
 

--- a/lib/taric_importer/transaction.rb
+++ b/lib/taric_importer/transaction.rb
@@ -19,6 +19,7 @@ class TaricImporter
     end
 
     def validate
+      return unless @record
       unless @record.conformant_for?(@record.operation)
         instrument("conformance_error.taric_importer", record: @record)
       end
@@ -27,7 +28,7 @@ class TaricImporter
     private
 
     def verify_transaction
-      if @transaction['transaction_id'].blank?
+      if @transaction["transaction_id"].blank?
         raise ArgumentError.new("TARIC transaction does not have required attributes")
       end
     end

--- a/lib/tariff_synchronizer.rb
+++ b/lib/tariff_synchronizer.rb
@@ -39,8 +39,11 @@ module TariffSynchronizer
   mattr_accessor :measures_logger_enabled
   self.measures_logger_enabled = (ENV["TARIFF_MEASURES_LOGGER"].to_i == 1)
 
-  mattr_accessor :ignore_presence_on_destroy
-  self.ignore_presence_on_destroy = (ENV["TARIFF_IGNORE_PRESENCE_ON_DESTROY"].to_i == 1)
+  # 1 - do not raise an exception when record does not exist on DESTROY operation
+  #   - do not raise an exception when record does not exist on UPDATE operation
+  #   - created new record when record does not exist on UPDATE operation
+  mattr_accessor :ignore_presence_errors
+  self.ignore_presence_errors = (ENV["TARIFF_IGNORE_PRESENCE_ERRORS"].to_i == 1)
 
   mattr_accessor :username
   self.username = ENV["TARIFF_SYNC_USERNAME"]
@@ -174,6 +177,8 @@ module TariffSynchronizer
 
               chief_update.mark_as_pending
               chief_update.clear_applied_at
+
+              chief_update.remove_all_presence_errors
 
               # need to delete measure logs
               ChiefTransformer::MeasuresLogger.delete_logs(chief_update.filename)

--- a/lib/tariff_synchronizer.rb
+++ b/lib/tariff_synchronizer.rb
@@ -39,6 +39,9 @@ module TariffSynchronizer
   mattr_accessor :measures_logger_enabled
   self.measures_logger_enabled = (ENV["TARIFF_MEASURES_LOGGER"].to_i == 1)
 
+  mattr_accessor :ignore_presence_on_destroy
+  self.ignore_presence_on_destroy = (ENV["TARIFF_IGNORE_PRESENCE_ON_DESTROY"].to_i == 1)
+
   mattr_accessor :username
   self.username = ENV["TARIFF_SYNC_USERNAME"]
 

--- a/lib/tariff_synchronizer/base_update.rb
+++ b/lib/tariff_synchronizer/base_update.rb
@@ -5,6 +5,7 @@ module TariffSynchronizer
     one_to_many :conformance_errors, class: TariffUpdateConformanceError, key: :tariff_update_filename
     one_to_many :presence_errors, class: TariffUpdatePresenceError, key: :tariff_update_filename
 
+    plugin :eager_each
     plugin :timestamps
     plugin :single_table_inheritance, :update_type
     plugin :validation_class_methods

--- a/lib/tariff_synchronizer/base_update.rb
+++ b/lib/tariff_synchronizer/base_update.rb
@@ -3,6 +3,7 @@ module TariffSynchronizer
     delegate :instrument, to: ActiveSupport::Notifications
 
     one_to_many :conformance_errors, class: TariffUpdateConformanceError, key: :tariff_update_filename
+    one_to_many :presence_errors, class: TariffUpdatePresenceError, key: :tariff_update_filename
 
     plugin :timestamps
     plugin :single_table_inheritance, :update_type

--- a/lib/tariff_synchronizer/base_update_importer.rb
+++ b/lib/tariff_synchronizer/base_update_importer.rb
@@ -13,7 +13,7 @@ module TariffSynchronizer
       return unless @base_update.pending?
       track_latest_sql_queries
       keep_record_of_conformance_errors
-      keep_record_of_destroy_errors
+      keep_record_of_presence_errors
 
       Sequel::Model.db.transaction(reraise: true) do
         # If a error is raised during import, mark the update as failed
@@ -28,7 +28,7 @@ module TariffSynchronizer
     ensure
       ActiveSupport::Notifications.unsubscribe(@sql_subscriber)
       ActiveSupport::Notifications.unsubscribe(@conformance_errors_subscriber)
-      ActiveSupport::Notifications.unsubscribe(@destroy_errors_subscriber)
+      ActiveSupport::Notifications.unsubscribe(@presence_errors_subscriber)
     end
 
     private
@@ -64,15 +64,15 @@ module TariffSynchronizer
       end
     end
 
-    def keep_record_of_destroy_errors
-      @destroy_errors_subscriber = ActiveSupport::Notifications.subscribe(/destroy_error/) do |*args|
+    def keep_record_of_presence_errors
+      @presence_errors_subscriber = ActiveSupport::Notifications.subscribe(/presence_error/) do |*args|
         event = ActiveSupport::Notifications::Event.new(*args)
         klass = event.payload[:klass]
-        attributes = event.payload[:attributes]
-        TariffSynchronizer::TariffUpdateDestroyError.create(
+        details = event.payload[:details]
+        TariffSynchronizer::TariffUpdatePresenceError.create(
           base_update: @base_update,
           model_name: klass,
-          attributes: attributes.to_json
+          details: details.to_json
         )
       end
     end

--- a/lib/tariff_synchronizer/mailer.rb
+++ b/lib/tariff_synchronizer/mailer.rb
@@ -57,6 +57,10 @@ module TariffSynchronizer
     def applied(update_names, conformance_errors = [])
       @update_names = update_names
       @conformance_errors = conformance_errors
+      # if 'presence errors' are ignored during tariff update then we can display them in email body
+      if TariffSynchronizer.ignore_presence_errors
+        @presence_errors = TariffSynchronizer::TariffUpdatePresenceError.where(tariff_update_filename: update_names)
+      end
 
       mail subject: "#{subject_prefix(:info)} Tariff updates applied"
     end

--- a/lib/tariff_synchronizer/tariff_update_destroy_error.rb
+++ b/lib/tariff_synchronizer/tariff_update_destroy_error.rb
@@ -1,0 +1,6 @@
+module TariffSynchronizer
+  class TariffUpdateDestroyError < Sequel::Model
+    many_to_one :base_update, key: :tariff_update_filename, class: BaseUpdate
+
+  end
+end

--- a/lib/tariff_synchronizer/tariff_update_presence_error.rb
+++ b/lib/tariff_synchronizer/tariff_update_presence_error.rb
@@ -1,6 +1,5 @@
 module TariffSynchronizer
-  class TariffUpdateDestroyError < Sequel::Model
+  class TariffUpdatePresenceError < Sequel::Model
     many_to_one :base_update, key: :tariff_update_filename, class: BaseUpdate
-
   end
 end

--- a/spec/unit/taric_importer/record_processor/destroy_operation_spec.rb
+++ b/spec/unit/taric_importer/record_processor/destroy_operation_spec.rb
@@ -1,13 +1,20 @@
 require 'rails_helper'
 
 describe TaricImporter::RecordProcessor::DestroyOperation do
-  describe '#to_oplog_operation' do
-    let(:empty_operation) {
-      TaricImporter::RecordProcessor::DestroyOperation.new(nil, nil)
-    }
+  let(:empty_operation) {
+    TaricImporter::RecordProcessor::DestroyOperation.new(nil, nil)
+  }
 
+  describe '#to_oplog_operation' do
     it 'identifies as destroy operation' do
       expect(empty_operation.to_oplog_operation).to eq :destroy
+    end
+  end
+
+  describe '#ignore_presence_on_destroy?' do
+    it 'returns true if presence ignored' do
+      allow(TariffSynchronizer).to receive(:ignore_presence_on_destroy).and_return(true)
+      expect(empty_operation.send(:ignore_presence_on_destroy?)).to be_truthy
     end
   end
 end

--- a/spec/unit/taric_importer/record_processor/destroy_operation_spec.rb
+++ b/spec/unit/taric_importer/record_processor/destroy_operation_spec.rb
@@ -5,16 +5,145 @@ describe TaricImporter::RecordProcessor::DestroyOperation do
     TaricImporter::RecordProcessor::DestroyOperation.new(nil, nil)
   }
 
+  let(:record_hash) {
+    {'transaction_id'=>'31946',
+     'record_code'=>'130',
+     'subrecord_code'=>'05',
+     'record_sequence_number'=>'1',
+     'update_type'=>'2',
+     'language_description'=>
+         {'language_code_id'=>'FR',
+          'language_id'=>'EN',
+          'description'=>'French'}}
+  }
+
+  let(:record) {
+    TaricImporter::RecordProcessor::Record.new(record_hash)
+  }
+
+  let(:operation) {
+    TaricImporter::RecordProcessor::DestroyOperation.new(record, Date.today)
+  }
+
   describe '#to_oplog_operation' do
     it 'identifies as destroy operation' do
       expect(empty_operation.to_oplog_operation).to eq :destroy
     end
   end
 
-  describe '#ignore_presence_on_destroy?' do
+  describe '#ignore_presence_errors?' do
     it 'returns true if presence ignored' do
-      allow(TariffSynchronizer).to receive(:ignore_presence_on_destroy).and_return(true)
-      expect(empty_operation.send(:ignore_presence_on_destroy?)).to be_truthy
+      allow(TariffSynchronizer).to receive(:ignore_presence_errors).and_return(true)
+      expect(empty_operation.send(:ignore_presence_errors?)).to be_truthy
+    end
+  end
+
+  describe '#get_model_record' do
+    context 'with ignoring presence on destroy' do
+      before do
+        allow(TariffSynchronizer).to receive(:ignore_presence_errors).and_return(true)
+      end
+
+      it 'gets model record' do
+        expect(LanguageDescription).to receive_message_chain(:filter, :first)
+        operation.send(:get_model_record)
+      end
+
+
+      context 'when record is NOT found' do
+        it 'returns nil' do
+          record = operation.send(:get_model_record)
+          expect(record).to be_nil
+        end
+      end
+
+      context 'when record is found' do
+        before do
+          LanguageDescription.unrestrict_primary_key
+          LanguageDescription.create('language_code_id'=>'FR',
+                                     'language_id'=>'EN',
+                                     'description'=>'French')
+        end
+
+        it 'returns a model record' do
+          record = operation.send(:get_model_record)
+          expect(record.language_code_id).to eq('FR')
+          expect(record).to be_a(LanguageDescription)
+        end
+      end
+    end
+
+    context 'with NOT ignoring presence on destroy' do
+      before do
+        allow(TariffSynchronizer).to receive(:ignore_presence_errors).and_return(false)
+      end
+
+      it 'gets model record' do
+        expect(LanguageDescription).to receive_message_chain(:filter, :take)
+        operation.send(:get_model_record)
+      end
+
+      context 'when record is NOT found' do
+        it 'returns a model record' do
+          expect { operation.send(:get_model_record) }.to raise_exception(Sequel::RecordNotFound)
+        end
+      end
+
+      context 'when record is found' do
+        before do
+          LanguageDescription.unrestrict_primary_key
+          LanguageDescription.create('language_code_id'=>'FR',
+                                     'language_id'=>'EN',
+                                     'description'=>'French')
+        end
+
+        it 'returns a model record' do
+          record = operation.send(:get_model_record)
+          expect(record.language_code_id).to eq('FR')
+          expect(record).to be_a(LanguageDescription)
+        end
+      end
+    end
+  end
+
+  describe '#call' do
+    context 'if record is found' do
+      before do
+        LanguageDescription.unrestrict_primary_key
+        LanguageDescription.create('language_code_id'=>'FR',
+                                   'language_id'=>'EN',
+                                   'description'=>'French')
+      end
+
+      it 'destroys the record ' do
+        expect { operation.call }.to change(LanguageDescription, :count).from(1).to(0)
+      end
+
+      it 'returns the model record' do
+        record = operation.call
+        expect(record).to be_a(LanguageDescription)
+        expect(record.language_code_id).to eq('FR')
+      end
+
+      it 'does not send presence error events' do
+        expect(operation).to_not receive(:log_presence_error)
+        operation.call
+      end
+    end
+
+    context 'if record is not found' do
+      before do
+        allow(TariffSynchronizer).to receive(:ignore_presence_errors).and_return(true)
+      end
+
+      it 'sends presence error events' do
+        expect(operation).to receive(:log_presence_error)
+        operation.call
+      end
+
+      it 'returns nil' do
+        expect(operation.call).to be_nil
+      end
     end
   end
 end

--- a/spec/unit/tariff_synchronizer/base_update_importer_spec.rb
+++ b/spec/unit/tariff_synchronizer/base_update_importer_spec.rb
@@ -37,7 +37,7 @@ describe TariffSynchronizer::BaseUpdateImporter do
       allow(taric_update).to receive(:import!).and_return(true)
       expect(ActiveSupport::Notifications).to receive(:subscribe).with(/sql\.sequel/)
       expect(ActiveSupport::Notifications).to receive(:subscribe).with(/conformance_error/)
-      expect(ActiveSupport::Notifications).to receive(:subscribe).with(/destroy_error/)
+      expect(ActiveSupport::Notifications).to receive(:subscribe).with(/presence_error/)
       base_update_importer.apply
     end
 

--- a/spec/unit/tariff_synchronizer/base_update_importer_spec.rb
+++ b/spec/unit/tariff_synchronizer/base_update_importer_spec.rb
@@ -33,6 +33,14 @@ describe TariffSynchronizer::BaseUpdateImporter do
       expect(taric_update.exception_queries).to include("(Sequel::Postgres::Database) ROLLBACK")
     end
 
+    it "subscribes to all events" do
+      allow(taric_update).to receive(:import!).and_return(true)
+      expect(ActiveSupport::Notifications).to receive(:subscribe).with(/sql\.sequel/)
+      expect(ActiveSupport::Notifications).to receive(:subscribe).with(/conformance_error/)
+      expect(ActiveSupport::Notifications).to receive(:subscribe).with(/destroy_error/)
+      base_update_importer.apply
+    end
+
     it "logs error message and sends an email" do
       tariff_synchronizer_logger_listener
 


### PR DESCRIPTION
Presence errors logger for TARIC update and destroy operations. Can be enabled and disabled via `TARIFF_IGNORE_PRESENCE_ERRORS` env variable (=1 is enabled). Eager loading errors for updates.