### PR TITLE
Data migrations for 2103909080 et. al.

### DIFF
--- a/db/data_migrations/20201008154641_end_measure_for_2103909080.rb
+++ b/db/data_migrations/20201008154641_end_measure_for_2103909080.rb
@@ -1,0 +1,23 @@
+TradeTariffBackend::DataMigrator.migration do
+  name 'Delete 425 measure for commodity 2103909080.'
+
+  MEASURE_TYPE = 'DBE'
+  COMMODITY = '2103909080'
+  VALIDITY_END_DATE: '2020-02-29 00:00:00'
+
+  up do
+    applicable { true }
+
+    apply do
+      if measure = Measure::Operation.where(
+          measure_type_id: MEASURE_TYPE, 
+          goods_nomenclature_item_id: COMMODITY
+        )
+        measure.validity_end_date = VALIDITY_END_DATE
+        measure.save!
+      end
+    end
+  end
+
+  down { }
+end

--- a/db/data_migrations/20201008154641_end_measure_for_2103909080.rb
+++ b/db/data_migrations/20201008154641_end_measure_for_2103909080.rb
@@ -32,7 +32,6 @@ TradeTariffBackend::DataMigrator.migration do
         )
         measures.each do |measure|
           measure.validity_end_date = nil
-          # only update the measures where the validity_end_date is nil, otherwise, assume there's a date there for a reason
           measure.save
         end
       end

--- a/db/data_migrations/20201008154641_end_measure_for_2103909080.rb
+++ b/db/data_migrations/20201008154641_end_measure_for_2103909080.rb
@@ -8,15 +8,13 @@ TradeTariffBackend::DataMigrator.migration do
     applicable { true }
 
     apply do
-      if measures = Measure::Operation.where(
-          measure_type_id: MEASURE_TYPE, 
-          goods_nomenclature_item_id: COMMODITY
-        )
-        measures.each do |measure|
-          measure.validity_end_date = measure.validity_end_date || '2020-02-29 00:00:00'
-          # only update the measures where the validity_end_date is nil, otherwise, assume there's a date there for a reason
-          measure.save
-        end
+      Measure::Operation.where(
+        measure_type_id: MEASURE_TYPE, 
+        goods_nomenclature_item_id: COMMODITY
+      ).each do |measure|
+        measure.validity_end_date = measure.validity_end_date || '2020-02-29 00:00:00'
+        # only update the measures where the validity_end_date is nil, otherwise, assume there's a date there for a reason
+        measure.save
       end
     end
   end

--- a/db/data_migrations/20201008154641_end_measure_for_2103909080.rb
+++ b/db/data_migrations/20201008154641_end_measure_for_2103909080.rb
@@ -23,15 +23,13 @@ TradeTariffBackend::DataMigrator.migration do
     applicable { true }
 
     apply do
-      if measures = Measure::Operation.where(
-          measure_type_id: MEASURE_TYPE, 
-          goods_nomenclature_item_id: COMMODITY,
-          validity_end_date: '2020-02-29 00:00:00'
-        )
-        measures.each do |measure|
-          measure.validity_end_date = nil
-          measure.save
-        end
+      Measure::Operation.where(
+        measure_type_id: MEASURE_TYPE, 
+        goods_nomenclature_item_id: COMMODITY,
+        validity_end_date: '2020-02-29 00:00:00'
+      ).each do |measure|
+        measure.validity_end_date = nil
+        measure.save
       end
     end
   end

--- a/db/data_migrations/20201008154642_add_footnote_to_210390908189.rb
+++ b/db/data_migrations/20201008154642_add_footnote_to_210390908189.rb
@@ -5,7 +5,7 @@ TradeTariffBackend::DataMigrator.migration do
     applicable { true }
     apply {
 
-      footnote = Footnote.where(footnote_id: "425", footnote_type_id: "01").first
+      footnote = Footnote.where(footnote_id: "853", footnote_type_id: "05").first
 
       codes = %w[2103909081 2103909089]
 

--- a/db/data_migrations/20201008154642_add_footnote_to_210390908189.rb
+++ b/db/data_migrations/20201008154642_add_footnote_to_210390908189.rb
@@ -1,0 +1,43 @@
+TradeTariffBackend::DataMigrator.migration do
+  name "Assign footnote to commodities"
+
+  up do
+    applicable { true }
+    apply {
+
+      footnote = Footnote.where(footnote_id: "425", footnote_type_id: "01").first
+
+      codes = %w[2103909081 2103909089]
+
+      codes.each do |code|
+        Sequel::Model.db.fetch("SELECT goods_nomenclature_item_id FROM measures_oplog
+                                WHERE goods_nomenclature_item_id LIKE '#{code}%'
+                                GROUP BY goods_nomenclature_item_id").all do |measure|
+          puts "Running code #{code} and Measure with gono_item_id #{measure[:goods_nomenclature_item_id]}"
+          goods_nomenclature = GoodsNomenclature.where(goods_nomenclature_item_id: measure[:goods_nomenclature_item_id]).first
+
+          if goods_nomenclature.nil?
+            puts "GoodsNomenclature #{measure.inspect} does not exist"
+            next
+          end
+          if goods_nomenclature.footnotes_dataset.where(footnotes__footnote_id: footnote.footnote_id,
+                                                        footnotes__footnote_type_id: footnote.footnote_type_id).empty?
+            puts "Creating association for Footnote #{footnote.inspect} and GoodsNomenclature #{goods_nomenclature.inspect}"
+            FootnoteAssociationGoodsNomenclature.associate_footnote_with_goods_nomenclature(goods_nomenclature, footnote)
+          else
+            puts "Footnote is already associated with GoodsNomenclature #{measure.inspect}"
+          end
+        end
+      end
+    }
+  end
+
+  down do
+    applicable {
+      false
+    }
+    apply {
+      # noop
+    }
+  end
+end


### PR DESCRIPTION
Issue with Excise tax type 425 on 2103909080 and 2103909081 and 2103909089

Matt suggested “need to write a data migration to remove/end date the excise measure and then add a footnote”
- end excise on 2103909080 (set validity_end_date to '2020-02-29 00:00:00')
- associate the footnote from 2103909080 (above) to commodities 2103909081 and 2103909089 via `FootnoteAssociationGoodsNomenclature.associate_footnote_with_goods_nomenclature`

Implements task: https://trello.com/c/RMxeSUut/956-issue-with-excise-tax-type-425-on-21039090-80