### PR TITLE
Update autoscaling policy

### DIFF
--- a/config/autoscaling/development-policy.json
+++ b/config/autoscaling/development-policy.json
@@ -4,18 +4,18 @@
   "scaling_rules": [
     {
       "metric_type": "throughput",
-      "breach_duration_secs": 60,
-      "threshold": 10,
+      "breach_duration_secs": 120,
+      "threshold": 5,
       "operator": "<",
-      "cool_down_secs": 60,
+      "cool_down_secs": 120,
       "adjustment": "-1"
     },
     {
       "metric_type": "throughput",
-      "breach_duration_secs": 60,
-      "threshold": 10,
+      "breach_duration_secs": 120,
+      "threshold": 5,
       "operator": ">=",
-      "cool_down_secs": 60,
+      "cool_down_secs": 120,
       "adjustment": "+1"
     },
     {

--- a/config/autoscaling/production-policy.json
+++ b/config/autoscaling/production-policy.json
@@ -1,53 +1,53 @@
 {
   "instance_min_count": 3,
-  "instance_max_count": 10,
+  "instance_max_count": 12,
   "scaling_rules": [
     {
       "metric_type": "throughput",
-      "breach_duration_secs": 60,
-      "threshold": 5,
+      "breach_duration_secs": 30,
+      "threshold": 4,
       "operator": "<",
       "cool_down_secs": 60,
       "adjustment": "-1"
     },
     {
       "metric_type": "throughput",
-      "breach_duration_secs": 60,
-      "threshold": 5,
+      "breach_duration_secs": 30,
+      "threshold": 4,
       "operator": ">=",
-      "cool_down_secs": 120,
+      "cool_down_secs": 60,
       "adjustment": "+1"
     },
     {
       "metric_type": "memoryutil",
-      "breach_duration_secs": 120,
-      "threshold": 50,
+      "breach_duration_secs": 30,
+      "threshold": 40,
       "operator": "<",
-      "cool_down_secs": 120,
+      "cool_down_secs": 60,
       "adjustment": "-1"
     },
     {
       "metric_type": "memoryutil",
-      "breach_duration_secs": 120,
-      "threshold": 50,
+      "breach_duration_secs": 30,
+      "threshold": 40,
       "operator": ">=",
-      "cool_down_secs": 120,
+      "cool_down_secs": 60,
       "adjustment": "+1"
     },
     {
       "metric_type": "cpu",
-      "breach_duration_secs": 120,
-      "threshold": 60,
+      "breach_duration_secs": 30,
+      "threshold": 50,
       "operator": "<",
-      "cool_down_secs": 120,
+      "cool_down_secs": 60,
       "adjustment": "-1"
     },
     {
       "metric_type": "cpu",
-      "breach_duration_secs": 120,
-      "threshold": 60,
+      "breach_duration_secs": 30,
+      "threshold": 50,
       "operator": ">=",
-      "cool_down_secs": 120,
+      "cool_down_secs": 60,
       "adjustment": "+1"
     }
   ]

--- a/config/autoscaling/staging-policy.json
+++ b/config/autoscaling/staging-policy.json
@@ -4,18 +4,18 @@
   "scaling_rules": [
     {
       "metric_type": "throughput",
-      "breach_duration_secs": 60,
-      "threshold": 10,
+      "breach_duration_secs": 120,
+      "threshold": 5,
       "operator": "<",
-      "cool_down_secs": 60,
+      "cool_down_secs": 120,
       "adjustment": "-1"
     },
     {
       "metric_type": "throughput",
-      "breach_duration_secs": 60,
-      "threshold": 10,
+      "breach_duration_secs": 120,
+      "threshold": 5,
       "operator": ">=",
-      "cool_down_secs": 60,
+      "cool_down_secs": 120,
       "adjustment": "+1"
     },
     {


### PR DESCRIPTION
- increase instance_max_count for production to 12
- lower threshold
- reduce breach_duration_secs to 30 sec
- reduce cool_down_secs to 60 sec
- lower memoryutil