### PR TITLE
Using `insert` instead of `save` in cds mapper

### DIFF
--- a/lib/cds_importer/entity_mapper.rb
+++ b/lib/cds_importer/entity_mapper.rb
@@ -33,8 +33,17 @@ class CdsImporter
     private
 
     def save_record!(record)
-      record.filename = @filename
-      record.save(validate: false, transaction: false)
+      values = record.values.except(:oid)
+
+      values.merge!(filename: @filename)
+
+      operation_klass = record.class.operation_klass
+
+      if operation_klass.columns.include?(:created_at)
+        values.merge!(created_at: operation_klass.dataset.current_datetime)
+      end
+
+      operation_klass.insert(values)
     end
 
     def save_record(record)

--- a/lib/sequel/plugins/oplog.rb
+++ b/lib/sequel/plugins/oplog.rb
@@ -82,13 +82,23 @@ module Sequel
         def _destroy_delete
           self.operation = :destroy
 
-          operation_klass.insert(self.values.except(:oid))
+          values = self.values.except(:oid)
+          if operation_klass.columns.include?(:created_at)
+            values.merge!(created_at: operation_klass.dataset.current_datetime)
+          end
+
+          operation_klass.insert(values)
         end
 
         def _update_columns(_columns)
           self.operation = :update
 
-          operation_klass.insert(self.values.except(:oid))
+          values = self.values.except(:oid)
+          if operation_klass.columns.include?(:created_at)
+            values.merge!(created_at: operation_klass.dataset.current_datetime)
+          end
+
+          operation_klass.insert(values)
         end
       end
 


### PR DESCRIPTION
We need to use insert because save, delete and update operations are overridden in oplog plugin for TARIC import.
Save create_at for update and delete operations

Asana: https://app.asana.com/0/1199164317302737/1199098423901967/f