### PR TITLE
Regulation info separator fix

### DIFF
--- a/app/serializers/api/v2/measures/measure_legal_act_serializer.rb
+++ b/app/serializers/api/v2/measures/measure_legal_act_serializer.rb
@@ -9,7 +9,11 @@ module Api
         set_id :regulation_id
 
         attributes :validity_start_date, :validity_end_date, :officialjournal_number,
-                   :officialjournal_page, :information_text
+                   :officialjournal_page
+
+        attribute :information_text do |regulation|
+          regulation&.information_text&.gsub(0xA0.chr('UTF-8'), '|')
+        end
 
         attribute :published_date do |regulation|
           regulation.try(:published_date)


### PR DESCRIPTION
[asana card](https://app.asana.com/0/1199164317302737/1198719959859936/f)
* added nbsp replacement with vertical pipe for a regulation information text field.